### PR TITLE
Add CODEOWNERS file for adding default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @bujordet @gurogb @draperunner @cjrorvik


### PR DESCRIPTION
1 review is required for merging into master. The users listed in CODEOWNERS will be set as reviewers by default on new pull requests.

https://help.github.com/articles/enabling-required-reviews-for-pull-requests/

https://help.github.com/articles/about-codeowners/

