### PR TITLE
Hide overflowing departures

### DIFF
--- a/src/components/bikeTable/styles.scss
+++ b/src/components/bikeTable/styles.scss
@@ -12,10 +12,6 @@
     text-align: center;
 }
 
-.bike-tile-container {
-    justify-content: center;
-}
-
 .bike-tile-container h2 {
     font-size: 1.5rem;
     margin: 0 0 15 0;

--- a/src/components/departureTiles/styles.scss
+++ b/src/components/departureTiles/styles.scss
@@ -22,6 +22,7 @@
     width: 18%;
     padding: 1.6%;
     margin: 0.7%;
+    overflow: hidden;
     height: fit-content;
     align-self: center;
 


### PR DESCRIPTION
A quickfix improves the issue in #55 a little.

![overflow](https://user-images.githubusercontent.com/4339443/44078640-511c30e0-9fa7-11e8-99e8-504092839d35.jpg)
