### PR TITLE
Make tile header text use all available space

### DIFF
--- a/src/components/departureTiles/styles.scss
+++ b/src/components/departureTiles/styles.scss
@@ -36,11 +36,13 @@
 }
 
 .stop-header {
+    display: flex;
+    justify-content: space-between;
     height: 90px;
     width: 334px;
 
     &--icons {
-        float: right;
+        display: flex;
         max-height: 60px;
         margin-top: 26px;
     }
@@ -49,12 +51,12 @@
         display: inline-block;
         overflow: hidden;
         height: 40px;
-        max-width: 190px;
         text-overflow: ellipsis;
         font-family: $base-font-family;
         font-size: 28px;
         font-weight: 500;
         color: $white;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
Also fix ellipsis text-overflow


![tavla-pr](https://user-images.githubusercontent.com/4339443/47266455-34c45600-d537-11e8-9170-2bd96e9a3a41.jpg)
