### PR TITLE
DK-2398: Replaced transportMode=coach with transportMode='bus'

### DIFF
--- a/src/containers/departureBoard/DepartureBoard.jsx
+++ b/src/containers/departureBoard/DepartureBoard.jsx
@@ -79,9 +79,10 @@ class DepartureBoard extends React.Component {
         const minDiff = departureTime.diff(moment(), 'minutes')
 
         const route = `${line.publicCode || ''} ${destinationDisplay.frontText}`.trim()
+        const transportMode = line.transportMode === 'coach' ? 'bus' : line.transportMode
 
         return {
-            type: line.transportMode,
+            type: transportMode,
             time: this.formatDeparture(minDiff, departureTime),
             route,
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,9 +119,10 @@ export function transformDepartureToLineData(departure) {
     const { line } = serviceJourney.journeyPattern
     const departureTime = moment(expectedDepartureTime)
     const minDiff = departureTime.diff(moment(), 'minutes')
+    const transportMode = line.transportMode === 'coach' ? 'bus' : line.transportMode
 
     return {
-        type: line.transportMode,
+        type: transportMode,
         time: formatDeparture(minDiff, departureTime),
         route: line.publicCode + ' '+ destinationDisplay.frontText,
     }


### PR DESCRIPTION
We like to handle all transportMode=coach as Bus. It will always have same icons and filter.
Therefore we filter out coach from api-result and replace it with type=bus.