### PR TITLE
Filter lines per station, not globally

### DIFF
--- a/src/components/departureTiles/DepartureTile.jsx
+++ b/src/components/departureTiles/DepartureTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {
-    getIcon, getIconColor, groupBy, isVisible, getTransportHeaderIcons,
+    getIcon, getIconColor, groupBy, isVisible, getTransportHeaderIcons, getCombinedStopPlaceAndRouteId,
 } from '../../utils'
 
 const DepartureTile = ({
@@ -32,7 +32,10 @@ const DepartureTile = ({
             <div>
                 {
                     routes
-                        .filter((route) => !hiddenRoutes.includes(route))
+                        .filter((route) => (
+                            !hiddenRoutes.includes(route)
+                            && !hiddenRoutes.some(hiddenRoute => hiddenRoute.includes(getCombinedStopPlaceAndRouteId(stopPlace.id, route)))
+                        ))
                         .map((route) => {
                             const subType = groupedDepartures[route][0].subType
                             const routeData = groupedDepartures[route].slice(0, 3)

--- a/src/containers/adminPage/SelectionPanel.jsx
+++ b/src/containers/adminPage/SelectionPanel.jsx
@@ -8,7 +8,7 @@ import {
 } from 'react-accessible-accordion'
 import { SlideSwitch, Checkbox } from '@entur/component-library'
 import SelectionPanelSearch from './searchPanels/SelectionPanelSearch.jsx'
-import { getIcon, getIconColor } from '../../utils'
+import { getIcon, getIconColor, getCombinedStopPlaceAndRouteId } from '../../utils'
 import './styles.scss'
 
 function SelectionPanel(props) {
@@ -80,7 +80,7 @@ function SelectionPanel(props) {
                                                 <table className="admin-route-table">
                                                     <tbody>
                                                         { departures.map(({ route, type }, i) => {
-                                                            const isVisible = !onCheck(route, 'routes')
+                                                            const isVisible = !onCheck(getCombinedStopPlaceAndRouteId(id, route), 'routes')
                                                             const Icon = getIcon(type)
                                                             const iconColor = getIconColor(type)
                                                             return (
@@ -97,7 +97,10 @@ function SelectionPanel(props) {
                                                                             key={i}
                                                                             id="SlideSwitch"
                                                                             className="mode-sort-slide-switch-stops"
-                                                                            onChange={() => { updateHiddenList(route, 'routes') }}
+                                                                            onChange={() => {
+                                                                                const comboId = getCombinedStopPlaceAndRouteId(id, route)
+                                                                                updateHiddenList(comboId, 'routes')
+                                                                            }}
                                                                             checked={isVisible}
                                                                         />
                                                                     </td>

--- a/src/utils.js
+++ b/src/utils.js
@@ -293,3 +293,7 @@ export function updateHiddenListAndHash(clickedId, state, hiddenType) {
             return { hiddenLists, hashedState }
     }
 }
+
+export function getCombinedStopPlaceAndRouteId(stopPlaceId, routeName) {
+    return `${stopPlaceId}$${routeName}`
+}


### PR DESCRIPTION
Still compatible with older setups.

--

Dersom man filtrerte vekk f.eks. trikk 11 Majorstuen frå Biermanns gate, ville denne forsvinne også frå Torshov, sjølv om man ville vise den der. Linjer vart filtrert globalt, mens no blir det filtrert per stasjon.
