### PR TITLE
Kronologisk visningstype

### DIFF
--- a/src/containers/Admin/DashboardPanel/index.tsx
+++ b/src/containers/Admin/DashboardPanel/index.tsx
@@ -26,7 +26,8 @@ function DashboardPanel(): JSX.Element {
                     value={dashboard}
                     onChange={onChange}
                 >
-                    <RadioPanel variant="midnight" label="Entur" value=""/>
+                    <RadioPanel variant="midnight" label="Entur" value="" />
+                    <RadioPanel variant="midnight" label="Kronologisk" value="Chrono" />
                     <RadioPanel variant="midnight" label="Race" value="Race" />
                 </RadioGroup>
             </div>

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -7,6 +7,7 @@ import analytics from 'universal-ga'
 import { SettingsContext, useSettings } from '../settings'
 
 import Entur from '../dashboards/Entur'
+import Chrono from '../dashboards/Chrono'
 import Race from '../dashboards/Race'
 
 import LandingPage from './LandingPage'
@@ -23,6 +24,8 @@ function getDashboardComponent(dashboardKey?: string | void) {
     switch (dashboardKey) {
         case 'Race':
             return Race
+        case 'Chrono':
+            return Chrono
         default:
             return Entur
     }

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BikeRentalStation } from '@entur/sdk'
 import { Heading3 } from '@entur/typography'
+import { colors } from '@entur/tokens'
 
 import { getIcon } from '../../../utils'
 
@@ -12,14 +13,14 @@ const BikeIcon = getIcon('bicycle')
 
 const BikeTile = ({ stations }: Props): JSX.Element => {
     return (
-        <Tile title="Bysykkel" icons={[<BikeIcon height={ 32 } width={ 32 } color="#D1D4E3" />]}>
+        <Tile title="Bysykkel" icons={[<BikeIcon height={ 32 } width={ 32 } color={colors.blues.blue60} />]}>
             {
                 stations.map(({
                     name, bikesAvailable, id, spacesAvailable,
                 }) => (
                     <div key={id} className="bikerow">
                         <div className="bikerow__icon">
-                            <BikeIcon height={ 32 } width={ 32 } />
+                            <BikeIcon height={ 32 } width={ 32 } color={colors.transport.contrast.mobility} />
                         </div>
                         <div className="bikerow__texts">
                             <Heading3 className="bikerow__label">

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { BikeRentalStation } from '@entur/sdk'
+import { Heading3 } from '@entur/typography'
+
+import { getIcon } from '../../../utils'
+
+import Tile from '../components/Tile'
+
+import './styles.scss'
+
+const BikeIcon = getIcon('bicycle')
+
+const BikeTile = ({ stations }: Props): JSX.Element => {
+    return (
+        <Tile title="Bysykkel" icons={[<BikeIcon height={ 32 } width={ 32 } color="#D1D4E3" />]}>
+            {
+                stations.map(({
+                    name, bikesAvailable, id, spacesAvailable,
+                }) => (
+                    <div key={id} className="bikerow">
+                        <div className="bikerow__icon">
+                            <BikeIcon height={ 32 } width={ 32 } />
+                        </div>
+                        <div className="bikerow__texts">
+                            <Heading3 className="bikerow__label">
+                                { name }
+                            </Heading3>
+                            <div className="bikerow__sublabels">
+                                { bikesAvailable === 1 ? <span>1 sykkel</span> : <span>{`${bikesAvailable} sykler`}</span> }
+                                { spacesAvailable === 1 ? <span>1 lås</span> : <span>{`${spacesAvailable} låser`}</span> }
+                            </div>
+                        </div>
+                    </div>
+                ))
+            }
+        </Tile>
+    )
+}
+
+interface Props {
+    stations: Array<BikeRentalStation>,
+}
+
+export default BikeTile

--- a/src/dashboards/Chrono/BikeTile/styles.scss
+++ b/src/dashboards/Chrono/BikeTile/styles.scss
@@ -1,0 +1,34 @@
+@import '../../../assets/styles/import.scss';
+
+.chrono .bikerow {
+    display: flex;
+    border-bottom: 2px solid $colors-blues-blue20;
+    padding: 1rem 0;
+
+    &__label {
+        margin: 0;
+        margin-bottom: 0.5rem;
+    }
+
+    &__texts {
+        flex-direction: column;
+        flex-grow: 1;
+    }
+
+    &__icon {
+        min-width: 2rem;
+        margin-right: 1rem;
+    }
+
+    &__sublabels {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        font-size: 1.25rem;
+        justify-content: space-between;
+        max-width: 18rem;
+
+        span {
+            font-weight: 400;
+        }
+    }
+}

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -25,7 +25,7 @@ function getTransportHeaderIcons(departures: Array<LineData>, hiddenModes?: Arra
         })
 
     return transportIcons.map(({ key, Icon }) => (
-        <Icon key={ key } height={ 30 } width={ 30 } color={ colors.brand.lavender } />
+        <Icon key={ key } height={ 32 } width={ 32 } color={ colors.blues.blue60 } />
     ))
 }
 

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { LegMode } from '@entur/sdk'
+import { colors } from '@entur/tokens'
+
+import { getIcon, getIconColor, unique } from '../../../utils'
+import { StopPlaceWithDepartures, LineData } from '../../../types'
+
+import Tile from '../components/Tile'
+import TileRow from '../components/TileRow'
+
+import './styles.scss'
+
+function getTransportHeaderIcons(departures: Array<LineData>, hiddenModes?: Array<LegMode>): Array<JSX.Element> {
+    const transportModes = unique(departures
+        .map(({ type, subType }) => ({ type, subType }))
+        .filter(({ type }) => !hiddenModes || !hiddenModes.includes(type)),
+    ((a, b) => a.type === b.type && a.subType === b.subType))
+
+    const transportIcons = transportModes
+        .map(({ type, subType }) => ({ key: type + subType, Icon: getIcon(type, subType) }))
+        .filter(({ Icon }, index, icons) => {
+            // @ts-ignore
+            const iconIndex = icons.findIndex(icon => icon.Icon.name === Icon.name)
+            return iconIndex === index
+        })
+
+    return transportIcons.map(({ key, Icon }) => (
+        <Icon key={ key } height={ 30 } width={ 30 } color={ colors.brand.lavender } />
+    ))
+}
+
+const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
+    const { departures, name, id } = stopPlaceWithDepartures
+    const headerIcons = getTransportHeaderIcons(departures)
+
+    return (
+        <Tile title={name} icons={headerIcons}>
+            {
+                departures.map(({
+                    serviceJourneyId, route, type, subType, time,
+                }) => {
+                    const Icon = getIcon(type, subType)
+                    const iconColor = getIconColor(type, subType)
+
+                    return (
+                        <TileRow
+                            key={`${id}${serviceJourneyId}`}
+                            label={route}
+                            subLabel={time}
+                            icon={Icon ? <Icon height={ 32 } width={ 32 } color={ iconColor } className="route-icon" /> : null}
+                        />
+                    )
+                })
+            }
+        </Tile>
+    )
+}
+
+interface Props {
+    stopPlaceWithDepartures: StopPlaceWithDepartures,
+}
+
+export default DepartureTile

--- a/src/dashboards/Chrono/DepartureTile/styles.scss
+++ b/src/dashboards/Chrono/DepartureTile/styles.scss
@@ -1,0 +1,1 @@
+@import '../../../assets/styles/import.scss';

--- a/src/dashboards/Chrono/components/Tile/index.tsx
+++ b/src/dashboards/Chrono/components/Tile/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Heading2 } from '@entur/typography'
+
+import './styles.scss'
+
+function Tile({ title, icons, children }: Props): JSX.Element {
+    return (
+        <div className="tile">
+            <header className="tile__header">
+                <Heading2>{ title }</Heading2>
+                <div className="tile__header-icons">
+                    { icons }
+                </div>
+            </header>
+            { children }
+        </div>
+    )
+}
+
+interface Props {
+    title: string,
+    icons: JSX.Element | Array<JSX.Element>,
+    children: Array<JSX.Element>,
+}
+
+export default Tile

--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -1,0 +1,26 @@
+@import '../../../../assets/styles/import.scss';
+
+.chrono .tile {
+    height: fit-content;
+    width: 25rem;
+    background-color: $colors-blues-blue10;
+    color: $white;
+    flex: none;
+    padding: 2rem;
+
+    &__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+
+        h2 {
+            margin: 0;
+        }
+    }
+
+    &__header-icons {
+        display: flex;
+        align-items: center;
+    }
+}

--- a/src/dashboards/Chrono/components/TileRow/index.tsx
+++ b/src/dashboards/Chrono/components/TileRow/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Heading3 } from '@entur/typography'
+
+import './styles.scss'
+
+export function TileRow({ label, icon, subLabel }: Props): JSX.Element {
+    return (
+        <div className="tilerow">
+            <div className="tilerow__icon">
+                { icon }
+            </div>
+            <Heading3 className="tilerow__label">{ label }</Heading3>
+            <div className="tilerow__sublabel">
+                { subLabel }
+            </div>
+        </div>
+    )
+}
+
+interface Props {
+    label: string,
+    subLabel?: string,
+    icon: JSX.Element,
+}
+
+export default TileRow

--- a/src/dashboards/Chrono/components/TileRow/styles.scss
+++ b/src/dashboards/Chrono/components/TileRow/styles.scss
@@ -3,8 +3,7 @@
 .chrono .tilerow {
     display: flex;
     border-bottom: 2px solid $colors-blues-blue20;
-    padding: 1rem 0;
-    align-items: center;
+    padding: 1rem 0 0.75rem 0;
 
     &__icon {
         min-width: 2rem;
@@ -13,11 +12,16 @@
 
     &__label {
         margin: 0;
+        margin-top: 0.25rem;
     }
 
     &__sublabel {
         font-size: 1.25rem;
+        font-weight: 400;
         margin: 0;
+        margin-top: 7px;
         margin-left: auto;
+        min-width: 5rem;
+        text-align: right;
     }
 }

--- a/src/dashboards/Chrono/components/TileRow/styles.scss
+++ b/src/dashboards/Chrono/components/TileRow/styles.scss
@@ -1,0 +1,23 @@
+@import '../../../../assets/styles/import.scss';
+
+.chrono .tilerow {
+    display: flex;
+    border-bottom: 2px solid $colors-blues-blue20;
+    padding: 1rem 0;
+    align-items: center;
+
+    &__icon {
+        min-width: 2rem;
+        margin-right: 1rem;
+    }
+
+    &__label {
+        margin: 0;
+    }
+
+    &__sublabel {
+        font-size: 1.25rem;
+        margin: 0;
+        margin-left: auto;
+    }
+}

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { useBikeRentalStations, useStopPlacesWithDepartures } from '../../logic'
+import DashboardWrapper from '../../containers/DashboardWrapper'
+
+import BikeTile from './BikeTile'
+import DepartureTile from './DepartureTile'
+
+import './styles.scss'
+
+const ChronoDashboard = ({ history }: Props): JSX.Element => {
+    const bikeRentalStations = useBikeRentalStations()
+    const stopPlacesWithDepartures = useStopPlacesWithDepartures()
+
+    return (
+        <DashboardWrapper
+            className="chrono"
+            history={history}
+            bikeRentalStations={bikeRentalStations}
+            stopPlacesWithDepartures={stopPlacesWithDepartures}
+        >
+            <div className="chrono__tiles">
+                {
+                    (stopPlacesWithDepartures || [])
+                        .filter(({ departures }) => departures.length > 0)
+                        .map((stop, index) => (
+                            <DepartureTile
+                                key={index}
+                                stopPlaceWithDepartures={stop}
+                            />
+                        ))
+                }
+                {
+                    bikeRentalStations && bikeRentalStations.length ? (
+                        <BikeTile stations={bikeRentalStations} />
+                    ) : null
+                }
+            </div>
+        </DashboardWrapper>
+    )
+}
+
+interface Props {
+    history: any,
+}
+
+export default ChronoDashboard

--- a/src/dashboards/Chrono/styles.scss
+++ b/src/dashboards/Chrono/styles.scss
@@ -1,0 +1,29 @@
+@import '../../assets/styles/import.scss';
+
+.chrono {
+    &__tiles {
+        display: flex;
+        flex-direction: row;
+        overflow-x: auto;
+
+        .tile {
+            margin-right: 2rem;
+            max-height: 75vh;
+            overflow-y: scroll;
+        }
+    }
+}
+
+@media (max-width: 1000px) {
+    .chrono {
+        &__tiles {
+            display: block;
+        }
+
+        .tile {
+            margin-bottom: 1rem;
+            max-height: unset;
+            width: 100%;
+        }
+    }
+}

--- a/src/dashboards/Entur/BikeTile/index.tsx
+++ b/src/dashboards/Entur/BikeTile/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { BikeRentalStation } from '@entur/sdk'
+import { colors } from '@entur/tokens'
 
 import { getIcon } from '../../../utils'
 
@@ -10,14 +11,14 @@ const BikeIcon = getIcon('bicycle')
 
 const BikeTile = ({ stations }: Props): JSX.Element => {
     return (
-        <Tile title="Bysykkel" icons={[<BikeIcon height={ 24 } width={ 24 } color="#D1D4E3" />]}>
+        <Tile title="Bysykkel" icons={[<BikeIcon height={ 32 } width={ 32 } color={colors.blues.blue60} />]}>
             {
                 stations.map(({
                     name, bikesAvailable, id, spacesAvailable,
                 }) => (
                     <TileRow
                         key={id}
-                        icon={<BikeIcon height={ 24 } width={ 24 } color="#D1D4E3" />}
+                        icon={<BikeIcon height={ 32 } width={ 32 } color={colors.transport.contrast.mobility} />}
                         label={name}
                         subLabels={[
                             bikesAvailable === 1 ? '1 sykkel' : `${bikesAvailable} sykler`,

--- a/src/dashboards/Entur/DepartureTile/index.tsx
+++ b/src/dashboards/Entur/DepartureTile/index.tsx
@@ -27,7 +27,7 @@ function getTransportHeaderIcons(departures: Array<LineData>, hiddenModes?: Arra
         })
 
     return transportIcons.map(({ key, Icon }) => (
-        <Icon key={ key } height={ 30 } width={ 30 } color={ colors.brand.lavender } />
+        <Icon key={ key } height={ 32 } width={ 32 } color={ colors.blues.blue60 } />
     ))
 }
 
@@ -52,7 +52,7 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                             key={route}
                             label={route}
                             subLabels={routeData.map(data => data.time)}
-                            icon={Icon ? <Icon height={ 24 } width={ 24 } color={ iconColor } className="route-icon" /> : null}
+                            icon={Icon ? <Icon height={ 32 } width={ 32 } color={ iconColor } className="route-icon" /> : null}
                         />
                     )
                 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export function getIconColor(type: LegMode, subType?: TransportSubmode): string 
         case 'bus':
             return colors.transport.contrast.bus
         case 'bicycle':
-            return colors.transport.contrast.bicycle
+            return colors.transport.contrast.mobility
         case 'water':
             return colors.transport.contrast.ferry
         case 'metro':


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4339443/70906704-515b0180-2007-11ea-91aa-81f62b901e0b.png)

Nytt, valgbar "Kronologisk visning", der alle enkeltavgangar får si eiga rad.