### PR TITLE
ETU-1257: Show icons for situations and cancellations

### DIFF
--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -2,7 +2,12 @@ import React from 'react'
 import { LegMode } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 
-import { getIcon, unique, getTransportIconIdentifier } from '../../../utils'
+import {
+    getIcon,
+    unique,
+    getTransportIconIdentifier,
+    createTileSubLabel,
+} from '../../../utils'
 import { StopPlaceWithDepartures, LineData } from '../../../types'
 
 import Tile from '../components/Tile'
@@ -36,20 +41,19 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
 
     return (
         <Tile title={name} icons={headerIcons}>
-            {departures.map(
-                ({ id: departureId, route, type, subType, time }) => {
-                    const icon = getIcon(type, subType)
+            {departures.map(data => {
+                const icon = getIcon(data.type, data.subType)
+                const subLabel = createTileSubLabel(data)
 
-                    return (
-                        <TileRow
-                            key={departureId}
-                            label={route}
-                            subLabel={time}
-                            icon={icon}
-                        />
-                    )
-                },
-            )}
+                return (
+                    <TileRow
+                        key={data.id}
+                        label={data.route}
+                        subLabel={subLabel}
+                        icon={icon}
+                    />
+                )
+            })}
         </Tile>
     )
 }

--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -7,6 +7,7 @@
     color: white;
     flex: none;
     padding: 2rem;
+    overflow: auto;
 
     &__header {
         display: flex;

--- a/src/dashboards/Chrono/components/TileRow/index.tsx
+++ b/src/dashboards/Chrono/components/TileRow/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { Heading3 } from '@entur/typography'
+import { ValidationExclamationIcon, ValidationErrorIcon } from '@entur/icons'
+import { colors } from '@entur/tokens'
 
+import { TileSubLabel } from '../../../../types'
 import './styles.scss'
 
 export function TileRow({ label, icon, subLabel }: Props): JSX.Element {
@@ -8,14 +11,35 @@ export function TileRow({ label, icon, subLabel }: Props): JSX.Element {
         <div className="tilerow">
             <div className="tilerow__icon">{icon}</div>
             <Heading3 className="tilerow__label">{label}</Heading3>
-            <div className="tilerow__sublabel">{subLabel}</div>
+            <div className="tilerow__sublabel">
+                {subLabel.time}
+                <SubLabelIcon subLabel={subLabel} />
+            </div>
         </div>
     )
 }
 
+function SubLabelIcon({ subLabel }: { subLabel: TileSubLabel }): JSX.Element {
+    if (subLabel.hasCancellation)
+        return (
+            <div className="tilerow__sublabel__cancellation">
+                <ValidationErrorIcon color={colors.validation.lava} />
+            </div>
+        )
+
+    if (subLabel.hasSituation)
+        return (
+            <div className="tilerow__sublabel__situation">
+                <ValidationExclamationIcon color={colors.validation.canary} />
+            </div>
+        )
+
+    return null
+}
+
 interface Props {
     label: string
-    subLabel?: string
+    subLabel: TileSubLabel
     icon: JSX.Element
 }
 

--- a/src/dashboards/Chrono/components/TileRow/styles.scss
+++ b/src/dashboards/Chrono/components/TileRow/styles.scss
@@ -17,6 +17,8 @@
     }
 
     &__sublabel {
+        align-items: center;
+        display: flex;
         font-size: 1.25rem;
         font-weight: 400;
         margin: 0;
@@ -24,5 +26,23 @@
         margin-left: auto;
         min-width: 5rem;
         text-align: right;
+
+        &__cancellation {
+            align-items: center;
+            background-color: $colors-brand-white;
+            border-radius: 0.5rem;
+            display: flex;
+            height: 0.875rem;
+            justify-content: center;
+            margin-left: 1rem;
+            overflow: visible;
+            width: 0.875rem;
+        }
+
+        &__situation {
+            font-size: 1.125rem;
+            height: 1.25rem;
+            margin-left: 1rem;
+        }
     }
 }

--- a/src/dashboards/Compact/BikeTile/index.tsx
+++ b/src/dashboards/Compact/BikeTile/index.tsx
@@ -24,12 +24,18 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                     }
                     label={name}
                     subLabels={[
-                        bikesAvailable === 1
-                            ? '1 sykkel'
-                            : `${bikesAvailable} sykler`,
-                        spacesAvailable === 1
-                            ? '1 lås'
-                            : `${spacesAvailable} låser`,
+                        {
+                            time:
+                                bikesAvailable === 1
+                                    ? '1 sykkel'
+                                    : `${bikesAvailable} sykler`,
+                        },
+                        {
+                            time:
+                                spacesAvailable === 1
+                                    ? '1 lås'
+                                    : `${spacesAvailable} låser`,
+                        },
                     ]}
                 />
             ))}

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -7,6 +7,7 @@ import {
     groupBy,
     unique,
     getTransportIconIdentifier,
+    createTileSubLabel,
 } from '../../../utils'
 import { StopPlaceWithDepartures, LineData } from '../../../types'
 
@@ -53,7 +54,7 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                     <TileRow
                         key={route}
                         label={route}
-                        subLabels={routeData.map(data => data.time)}
+                        subLabels={routeData.map(createTileSubLabel)}
                         icon={icon}
                     />
                 )

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -26,7 +26,7 @@ export function TileRow({ label, icon, subLabels }: Props): JSX.Element {
 }
 
 function SubLabelIcon({ subLabel }: { subLabel: TileSubLabel }): JSX.Element {
-    if (true)
+    if (subLabel.hasCancellation)
         return (
             <div className="tilerow__sublabel__cancellation">
                 <ValidationErrorIcon color={colors.validation.lava} />

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { Heading3 } from '@entur/typography'
+import { ValidationExclamationIcon, ValidationErrorIcon } from '@entur/icons'
+import { colors } from '@entur/tokens'
 
+import { TileSubLabel } from '../../../../types'
 import './styles.scss'
 
 export function TileRow({ label, icon, subLabels }: Props): JSX.Element {
@@ -11,9 +14,10 @@ export function TileRow({ label, icon, subLabels }: Props): JSX.Element {
                 <Heading3 className="tilerow__label">{label}</Heading3>
                 <div className="tilerow__sublabels">
                     {subLabels.map((subLabel, index) => (
-                        <span className="tilerow__sublabel" key={index}>
-                            {subLabel}
-                        </span>
+                        <div className="tilerow__sublabel" key={index}>
+                            {subLabel.time}
+                            <SubLabelIcon subLabel={subLabel} />
+                        </div>
                     ))}
                 </div>
             </div>
@@ -21,9 +25,27 @@ export function TileRow({ label, icon, subLabels }: Props): JSX.Element {
     )
 }
 
+function SubLabelIcon({ subLabel }: { subLabel: TileSubLabel }): JSX.Element {
+    if (true)
+        return (
+            <div className="tilerow__sublabel__cancellation">
+                <ValidationErrorIcon color={colors.validation.lava} />
+            </div>
+        )
+
+    if (subLabel.hasSituation)
+        return (
+            <div className="tilerow__sublabel__situation">
+                <ValidationExclamationIcon color={colors.validation.canary} />
+            </div>
+        )
+
+    return null
+}
+
 interface Props {
     label: string
-    subLabels: Array<string>
+    subLabels: Array<TileSubLabel>
     icon: JSX.Element
 }
 

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -15,6 +15,11 @@
         margin-bottom: 0.5rem;
     }
 
+    &__icon-notice {
+        margin-top: 0.5rem;
+        margin-right: 0.5rem;
+    }
+
     &__icon {
         min-width: 2rem;
         margin-right: 1rem;
@@ -31,10 +36,33 @@
         grid-template-columns: repeat(3, 1fr);
         font-size: 1.25rem;
         justify-content: space-between;
-        max-width: 18rem;
+        max-width: 20rem;
+    }
 
-        span {
-            font-weight: 400;
+    &__sublabel {
+        align-items: center;
+        display: flex;
+        font-weight: 400;
+
+        &__cancellation {
+            align-items: center;
+            background-color: $colors-brand-white;
+            border-radius: 0.5rem;
+            display: flex;
+            height: 0.875rem;
+            justify-content: center;
+            margin-left: 0.375rem;
+            overflow: visible;
+            width: 0.875rem;
+        }
+
+        &__situation {
+            width: 0.9375rem;
+        }
+
+        svg {
+            margin-left: -0.125rem;
+            margin-right: -0.125rem;
         }
     }
 }

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -15,11 +15,6 @@
         margin-bottom: 0.5rem;
     }
 
-    &__icon-notice {
-        margin-top: 0.5rem;
-        margin-right: 0.5rem;
-    }
-
     &__icon {
         min-width: 2rem;
         margin-right: 1rem;
@@ -57,7 +52,9 @@
         }
 
         &__situation {
-            width: 0.9375rem;
+            font-size: 1.125rem;
+            height: 1.25rem;
+            margin-left: 0.375rem;
         }
 
         svg {

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -62,6 +62,8 @@ async function fetchStopPlaceDepartures(
             return stop
         }
 
+        console.log('departuresForThisStopPlace :', departuresForThisStopPlace)
+
         const mappedAndFilteredDepartures = departuresForThisStopPlace.departures
             .map(transformDepartureToLineData)
             .filter(

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -62,8 +62,6 @@ async function fetchStopPlaceDepartures(
             return stop
         }
 
-        console.log('departuresForThisStopPlace :', departuresForThisStopPlace)
-
         const mappedAndFilteredDepartures = departuresForThisStopPlace.departures
             .map(transformDepartureToLineData)
             .filter(

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export interface LineData {
     time: string
     route: string
     expectedDepartureTime: string
+    hasSituation?: boolean
+    hasCancellation?: boolean
 }
 
 export interface Line {
@@ -25,4 +27,10 @@ export type StopPlaceWithLines = StopPlace & { lines: Array<Line> }
 export interface NearestPlaces {
     bikeRentalStationIds: Array<string>
     stopPlaceIds: Array<string>
+}
+
+export interface TileSubLabel {
+    time: string
+    hasCancellation?: boolean
+    hasSituation?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface LineData {
     time: string
     route: string
     expectedDepartureTime: string
-    hasSituation?: boolean
+    situation?: string
     hasCancellation?: boolean
 }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -20,7 +20,7 @@ import { colors } from '@entur/tokens'
 
 import { Coordinates, Departure, LegMode, TransportSubmode } from '@entur/sdk'
 
-import { LineData } from './types'
+import { LineData, TileSubLabel } from './types'
 
 function isSubModeAirportLink(subMode?: string): boolean {
     const airportLinkTypes = ['airportLinkRail', 'airportLinkBus']
@@ -186,6 +186,8 @@ export function transformDepartureToLineData(departure: Departure): LineData {
         expectedDepartureTime,
         destinationDisplay,
         serviceJourney,
+        situations,
+        cancellation,
     } = departure
 
     const { line } = serviceJourney.journeyPattern
@@ -208,6 +210,20 @@ export function transformDepartureToLineData(departure: Departure): LineData {
         subType,
         time: formatDeparture(minDiff, departureTime),
         route,
+        hasSituation: Boolean(situations.length),
+        hasCancellation: cancellation,
+    }
+}
+
+export function createTileSubLabel({
+    hasSituation,
+    hasCancellation,
+    time,
+}: LineData): TileSubLabel {
+    return {
+        hasSituation,
+        hasCancellation,
+        time,
     }
 }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -210,18 +210,18 @@ export function transformDepartureToLineData(departure: Departure): LineData {
         subType,
         time: formatDeparture(minDiff, departureTime),
         route,
-        hasSituation: Boolean(situations.length),
+        situation: situations[0]?.summary?.[0]?.value,
         hasCancellation: cancellation,
     }
 }
 
 export function createTileSubLabel({
-    hasSituation,
+    situation,
     hasCancellation,
     time,
 }: LineData): TileSubLabel {
     return {
-        hasSituation,
+        hasSituation: Boolean(situation),
         hasCancellation,
         time,
     }


### PR DESCRIPTION
Show icons for situations and cancellations, in **compact** and **chronological** views:

**Compact:**
<img width="429" alt="Screenshot 2020-04-14 at 07 50 04" src="https://user-images.githubusercontent.com/981009/79199841-d6c7b480-7e35-11ea-85b9-0a2f3b2b6cf7.png">

**Chronological:**
<img width="388" alt="Screenshot 2020-04-14 at 08 38 55" src="https://user-images.githubusercontent.com/981009/79199877-e5ae6700-7e35-11ea-824b-286f8c6d196e.png">
