### PR TITLE
Remove empty columns on dashboard

### DIFF
--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -34,7 +34,14 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const dashboardKey = history.location.key
 
     const bikeRentalStations = useBikeRentalStations()
-    const stopPlacesWithDepartures = useStopPlacesWithDepartures()
+
+    let stopPlacesWithDepartures = useStopPlacesWithDepartures()
+
+    if (stopPlacesWithDepartures) {
+        stopPlacesWithDepartures = stopPlacesWithDepartures.filter(
+            ({ departures }) => departures.length > 0,
+        )
+    }
 
     const numberOfStopPlaces = stopPlacesWithDepartures
         ? stopPlacesWithDepartures.length
@@ -73,19 +80,17 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                         }
                     }}
                 >
-                    {(stopPlacesWithDepartures || [])
-                        .filter(({ departures }) => departures.length > 0)
-                        .map((stop, index) => (
-                            <div
-                                key={index.toString()}
-                                data-grid={getDataGrid(index)}
-                            >
-                                <DepartureTile
-                                    key={index}
-                                    stopPlaceWithDepartures={stop}
-                                />
-                            </div>
-                        ))}
+                    {(stopPlacesWithDepartures || []).map((stop, index) => (
+                        <div
+                            key={index.toString()}
+                            data-grid={getDataGrid(index)}
+                        >
+                            <DepartureTile
+                                key={index}
+                                stopPlaceWithDepartures={stop}
+                            />
+                        </div>
+                    ))}
                     {anyBikeRentalStations ? (
                         <div
                             key={numberOfStopPlaces.toString()}

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -37,6 +37,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
 
     let stopPlacesWithDepartures = useStopPlacesWithDepartures()
 
+    // Remove stop places without departures
     if (stopPlacesWithDepartures) {
         stopPlacesWithDepartures = stopPlacesWithDepartures.filter(
             ({ departures }) => departures.length > 0,


### PR DESCRIPTION
When there is stop places without departures in the compact dashboard, an empty column is assigned that takes up space to the right. 

![Screenshot 2020-06-18 at 08 49 54](https://user-images.githubusercontent.com/1774972/84987976-790b5d80-b141-11ea-8ee0-08511b4b734d.png)

This is fixed when empty bus stops are filtered out before `numberOfStopPlaces` is calculated.

## Steps to recreate

We used "Dronningens gate, Trondheim" as the test case, where there are two empty bus stops.

https://tavla.entur.no/dashboard/@63-431938,10-393419/