### PR TITLE
Use 'npm ci' in CircleCI, remove caching of node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,10 @@ jobs:
 
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
-
       - add_ssh_keys: *ssh-fingerprint
-
-      - run: npm install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
-
-      - run:
-          name: Lint
-          command: npm run lint
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
 
   deploy:
     docker:
@@ -40,21 +26,8 @@ jobs:
 
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
-
       - add_ssh_keys: *ssh-fingerprint
-
-      - run: npm install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
-
+      - run: npm ci
       - run:
           name: Deploy web
           command: npm run deploy --token=$FIREBASE_TOKEN --non-interactive
@@ -67,21 +40,8 @@ jobs:
 
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
-
       - add_ssh_keys: *ssh-fingerprint
-
-      - run: npm install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
-
+      - run: npm ci
       - run:
           name: Deploy web staging
           command: npm run deploy:staging --token=$FIREBASE_TOKEN --non-interactive

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@entur/loader": "^0.3.21",
     "@entur/modal": "^1.1.19",
     "@entur/sdk": "^1.6.0",
-    "@entur/tokens": "^1  .3.5",
+    "@entur/tokens": "^1.3.5",
     "@entur/travel": "^4.0.3",
     "@entur/typography": "^1.2.0",
     "connect-history-api-fallback": "^1.6.0",


### PR DESCRIPTION
Since we're now on CircleCI's newer Node image we can (hopefully) use 'npm ci'. It didn't work on Node 8 because CircleCI used an old version of npm. Caching is not necessary with 'npm ci' because it deletes node_modules anyways.