### PR TITLE
Use Firebase autoconfig

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,3 +1,2 @@
 JOURNEYPLANNER_HOST=https://api.entur.io/journey-planner/v2
 GEOCODER_HOST=https://api.entur.io/geocoder/v1
-FIREBASE_CONFIG='{"apiKey":"AIzaSyBcgTAiIkaWqt5U2vbdgoItYXL7ilJlVn8","authDomain":"entur-tavla.firebaseapp.com","databaseURL":"https://entur-tavla.firebaseio.com","projectId":"entur-tavla","storageBucket":"entur-tavla.appspot.com","messagingSenderId":"629581375388","appId":"1:629581375388:web:cf1e2c99354ccd1f180a59"}'

--- a/.env.staging
+++ b/.env.staging
@@ -1,3 +1,2 @@
 JOURNEYPLANNER_HOST=https://api.staging.entur.io/journey-planner/v2
 GEOCODER_HOST=https://api.staging.entur.io/geocoder/v1
-FIREBASE_CONFIG='{"apiKey":"AIzaSyAouFBEcNC7jJcEQagpekH2qK7PhJMxmjg","authDomain":"tavla-stage.firebaseapp.com","databaseURL":"https://tavla-stage.firebaseio.com","projectId":"tavla-stage","storageBucket":"tavla-stage.appspot.com","messagingSenderId":"907796975617","appId":"1:907796975617:web:0ad5a446403bf3ea2d3000"}'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .vscode/
 .idea/
 .firebase/*.cache
+.env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Create an env file for local development called `.env.local`. You can copy one o
 cp .env.staging .env.local
 ```
 
-The .env.local will not be checked in to git, so we can experience with it as we'd like.
+The .env.local will not be checked in to git, so we can experiment with it as we'd like.
 
 Follow the steps for *Hosting your own Fork with Firebase* below. When `FIREBASE_CONFIG` has been added to .env.local, you can run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,33 @@ cd tavla
 npm install
 ```
 
-Run the development server with
+Run the server with
+
+```
+npm run serve:staging
+```
+
+Your browser should automatically open the app on http://localhost:5000
+
+### Set up a better development experience
+
+`npm run serve` uses `firebase serve` under the hood. This allows the use of [SDK auto-configuration](https://firebase.google.com/docs/hosting/reserved-urls#sdk_auto-configuration). That's cool, but means we have to build the app again for every change. For local development, we would prefer to use `webpack-dev-server` with hot-reloading. In order to do that, we need to reference the Firebase config through an environment variable called `FIREBASE_CONFIG`, rather than rely on auto-configuration.
+
+Create an env file for local development called `.env.local`. You can copy one of the existing files:
+
+```
+cp .env.staging .env.local
+```
+
+The .env.local will not be checked in to git, so we can experience with it as we'd like.
+
+Follow the steps for *Hosting your own Fork with Firebase* below. When `FIREBASE_CONFIG` has been added to .env.local, you can run
 
 ```
 npm start
 ```
 
-Your browser should automatically open the app on http://localhost:9090
+to start the local development server.
 
 ## Code Quality
 
@@ -49,9 +69,19 @@ First of all you need a Firebase _project. Go to https://console.firebase.google
 
 When the project is set up, add a new Web app to your project from the Project Overview. You don't need to "Add Firebase SDK" – that's already done in this repo.
 
-### Download config
-Press the cogwheel next to "Project Settings" in the left menu and go to "Project settings". Scroll down and find the Config under "Firebase SDK snippet". Copy the config object (the part after `const firebaseConfig = `). You need to stringify this and put it in both .env.staging and .env.prod (unless you have multiple projects). To stringify it, you can open the browser console and run `JSON.stringify(<CONFIG OBJECT>)`. Set the resulting string as the value for `FIREBASE_CONFIG` in the .env files.
+### Download config for local development
+In order to ease local development and allow hot reloading and such, we need to reference the Firebase config through an environment variable called `FIREBASE_CONFIG`, rather than rely on the auto-config that Firebase provides through `firebase serve`.
 
+Press the cogwheel next to "Project Settings" in the left menu and go to "Project settings". Scroll down and find the Config under "Firebase SDK snippet". Copy the config object (the part after `const firebaseConfig = `). You need to stringify this and put it in your `.env.local` file. To stringify it, you can open the browser console and run `JSON.stringify(<CONFIG OBJECT>)`. Set the resulting string as the value for `FIREBASE_CONFIG` in the .env.local file:
+
+```diff
+# .env.local
+JOURNEYPLANNER_HOST=https://api.staging.entur.io/journey-planner/v2
+GEOCODER_HOST=https://api.staging.entur.io/geocoder/v1
++FIREBASE_CONFIG='{"apiKey":"AIz...
+```
+
+### Configure .firebaserc
 Now let's update the `.firebaserc` file. Replace the project name with your own. You might not have a staging project, so just remove that:
 ```diff
 {
@@ -62,7 +92,6 @@ Now let's update the `.firebaserc` file. Replace the project name with your own.
   }
 }
 ```
-
 
 ### Enable Authentication
 In the Firebase Console (console.firebase.google.com), go to "Authentication" and "Sign-in method". Enable "Anonymous".

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "clean": "rm -rf dist/",
     "build": "npm run clean && webpack --mode production --env prod",
     "build:staging": "npm run clean && webpack --mode production --env staging",
+    "serve": "npm run build && firebase serve",
+    "serve:staging": "npm run build:staging && firebase serve",
     "deploy": "npm run build && firebase deploy -P prod",
     "deploy:staging": "npm run build:staging && firebase deploy -P staging"
   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,16 +3,20 @@ import { useState, useEffect, useContext, createContext } from 'react'
 import firebase, { User } from 'firebase/app'
 import 'firebase/auth'
 
+import { useIsFirebaseInitialized } from './firebase-init'
+
 export function useAnonymousLogin(): User | null {
     const [user, setUser] = useState<User | null>()
+    const firebaseInitialized = useIsFirebaseInitialized()
 
     useEffect(() => {
+        if (!firebaseInitialized) return
+
         const unsubscribe = firebase.auth().onAuthStateChanged(newUser => {
+            setUser(newUser)
             if (newUser) {
-                setUser(newUser)
                 return
             }
-            setUser(null)
             firebase
                 .auth()
                 .signInAnonymously()
@@ -20,7 +24,7 @@ export function useAnonymousLogin(): User | null {
         })
 
         return unsubscribe
-    }, [])
+    }, [firebaseInitialized])
 
     return user
 }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -2,11 +2,9 @@ import React from 'react'
 import { Route, Switch, Redirect, Router } from 'react-router-dom'
 import analytics from 'universal-ga'
 
-import firebase from 'firebase/app'
-import 'firebase/auth'
-
 import { SettingsContext, useSettings } from '../settings'
 import { useAnonymousLogin, UserProvider } from '../auth'
+import initializeFirebase from '../firebase-init'
 
 import Compact from '../dashboards/Compact'
 import Chrono from '../dashboards/Chrono'
@@ -16,9 +14,7 @@ import LandingPage from './LandingPage'
 import Admin from './Admin'
 import Privacy from './Privacy'
 
-const firebaseConfig = JSON.parse(process.env.FIREBASE_CONFIG)
-
-firebase.initializeApp(firebaseConfig)
+initializeFirebase()
 
 analytics.initialize('UA-108877193-6')
 analytics.set('anonymizeIp', true)

--- a/src/firebase-init.ts
+++ b/src/firebase-init.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+import firebase from 'firebase/app'
+import 'firebase/auth'
+
+let appSingleton: undefined | firebase.app.App | Promise<firebase.app.App>
+
+/*
+ * Initializes the Firebase app. It is safe to call multiple times – only one instance will be created
+ */
+export default async function initializeFirebase(): Promise<firebase.app.App> {
+    if (appSingleton) {
+        return appSingleton
+    }
+
+    if (process.env.FIREBASE_CONFIG) {
+        appSingleton = firebase.initializeApp(
+            JSON.parse(process.env.FIREBASE_CONFIG),
+        )
+        return appSingleton
+    }
+
+    appSingleton = fetch('/__/firebase/init.json').then(async response => {
+        return firebase.initializeApp(await response.json())
+    })
+
+    return appSingleton
+}
+
+export function useIsFirebaseInitialized(): boolean {
+    const [initialized, setInitialized] = useState<boolean>(false)
+
+    useEffect(() => {
+        initializeFirebase().then(() => setInitialized(true))
+    }, [])
+
+    return initialized
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const postcssPresetEnv = require('postcss-preset-env')
 
 const OUTPUT_PATH = path.resolve(__dirname, 'dist')
 
-module.exports = (env) => {
+module.exports = env => {
     return {
         mode: 'development',
         entry: './src/main.tsx',
@@ -44,9 +44,7 @@ module.exports = (env) => {
                             loader: 'postcss-loader',
                             options: {
                                 ident: 'postcss',
-                                plugins: () => [
-                                    postcssPresetEnv(),
-                                ],
+                                plugins: () => [postcssPresetEnv()],
                             },
                         },
                     ],
@@ -60,9 +58,7 @@ module.exports = (env) => {
                             loader: 'postcss-loader',
                             options: {
                                 ident: 'postcss',
-                                plugins: () => [
-                                    postcssPresetEnv(),
-                                ],
+                                plugins: () => [postcssPresetEnv()],
                             },
                         },
                         'sass-loader',
@@ -89,7 +85,12 @@ module.exports = (env) => {
                 filename: 'index.html',
                 favicon: 'src/assets/images/logo.png',
             }),
-            new Dotenv({ path: path.join(__dirname, `.env.${typeof env === 'string' ? env : 'staging'}`) }),
+            new Dotenv({
+                path: path.join(
+                    __dirname,
+                    `.env.${typeof env === 'string' ? env : 'local'}`,
+                ),
+            }),
         ],
         watch: typeof env !== 'string',
         optimization: {


### PR DESCRIPTION
Firebase tilbyr "SDK auto-configuration": https://firebase.google.com/docs/hosting/reserved-urls#sdk_auto-configuration

Det fungerer berre lokalt når man kjører `firebase serve`. `firebase serve` er fint for å teste produksjons-bygg før deploy, men dårlig for lokal utvikling, for man får ikkje hot-reloading osv. som webpack tilbyr.

Derfor har eg lagt til bruk av `.env.local` som man må ha for å bruke `npm start` (webpack-dev-server). Man kan putte FIREBASE_CONFIG i .env.local. Då kan me bruke configen frå miljøvariabelen i staden for å bruke auto-configen. `.env.local` blir ikkje sjekka inn i git, så eg har prøvd å forklare i CONTRIBUTE.md korleis man lagar denne fila.

Ved bruk av auto-config skjer initialisering av Firebase asynkront. Det kompliserer ting litt, for me må passe på at me ikkje bruker firebase-metodar før det er initialisert. Derfor lagde eg `firebase-init.ts` som står for initialisering. Denne funkjsonen som den eksporterer kan trygt bli kalt fleire gonger, slik at man kan bruke den til å sikre seg om at Firebase er initialisert. Lagde til og med ein hook som `auth.ts` kan dra nytte av.