### PR TITLE
Limit column count if there are not enough space

### DIFF
--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -53,12 +53,29 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const localStorageLayout = getFromLocalStorage(history.location.key)
     const extraCols = anyBikeRentalStations ? 1 : 0
 
+    // Limit column count if there are not enough space
+    function limitToMax(columns: number): number {
+        return Math.min(numberOfStopPlaces + extraCols, columns)
+    }
+
     const cols = {
-        lg: numberOfStopPlaces + extraCols,
-        md: numberOfStopPlaces + extraCols,
-        sm: 1,
+        xxlg: limitToMax(6),
+        xlg: limitToMax(5),
+        lg: limitToMax(4),
+        md: limitToMax(3),
+        sm: limitToMax(2),
         xs: 1,
         xxs: 1,
+    }
+
+    const gridBreakpoints = {
+        xxlg: 2200,
+        xlg: 1600,
+        lg: 1350,
+        md: 996,
+        sm: 768,
+        xs: 480,
+        xxs: 0,
     }
 
     return (
@@ -73,6 +90,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     key={numberOfStopPlaces}
                     cols={cols}
                     layouts={localStorageLayout}
+                    breakpoints={gridBreakpoints}
                     compactType="horizontal"
                     isResizable={true}
                     onLayoutChange={(layout, layouts) => {


### PR DESCRIPTION
Forslag om å legge inn flere breakpoints slik at det ikke blir for trangt om plassen når man har mange stoppesteder på samme tavle. 

`limitToMax` returnerer hvor mange kolonner som trengs til stoppesteder, begrenset til et maks antall kolonner for bredden på skjermen.

Fant ikke en god måte å dynamisk sette antall kolonner basert på bredden på skjermen, så det ble litt hardkodet.
