### PR TITLE
Fix alignment of back arrow on dashboard

### DIFF
--- a/src/containers/DashboardWrapper/Footer/styles.scss
+++ b/src/containers/DashboardWrapper/Footer/styles.scss
@@ -18,6 +18,11 @@
             margin-left: 0.5rem;
         }
     }
+
+    &__back-button {
+        padding: 0;
+        height: 2rem;
+    }
 }
 
 .radiobox {


### PR DESCRIPTION
Flyttet tilbakepila til venstre for å være på linje med resten av brukergrensesnittet, og gjort den samme høyde som knappene til høyre.

Før:
![Screenshot 2020-06-18 at 11 40 32](https://user-images.githubusercontent.com/67003841/85005067-97c91e80-b158-11ea-8c87-9c281fa6ab34.png)

Etter:
![Screenshot 2020-06-23 at 09 24 55](https://user-images.githubusercontent.com/1774972/85373437-89517d00-b533-11ea-9663-fbf133eefd16.png)
