### PR TITLE
Update dashboard-wrapper padding on smaller screens

### DIFF
--- a/src/containers/DashboardWrapper/styles.scss
+++ b/src/containers/DashboardWrapper/styles.scss
@@ -60,6 +60,7 @@
 
 @media (max-width: 700px) {
     .dashboard-wrapper {
+        padding: 2rem 1rem;
         &__logo-wrapper p {
             margin: -0.5rem 0 0 0;
         }

--- a/src/containers/DashboardWrapper/styles.scss
+++ b/src/containers/DashboardWrapper/styles.scss
@@ -61,6 +61,7 @@
 @media (max-width: 700px) {
     .dashboard-wrapper {
         padding: 2rem 1rem;
+
         &__logo-wrapper p {
             margin: -0.5rem 0 0 0;
         }


### PR DESCRIPTION
For skjermer mindre enn 700px, bør paddingen rundt `DashboardWrapper` være mindre.

Før:
![Screenshot 2020-06-23 at 10 09 49](https://user-images.githubusercontent.com/1774972/85378241-932aae80-b53a-11ea-94a6-7b9fe15a8dea.png)

Etter:
![Screenshot 2020-06-23 at 10 10 04](https://user-images.githubusercontent.com/1774972/85378244-945bdb80-b53a-11ea-9cd8-5083809b9aa5.png)
