### PR TITLE
Remove alphabetical sorting of bike rental stations

### DIFF
--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -23,7 +23,7 @@ async function fetchBikeRentalStations(
         .filter((id, index, ids) => ids.indexOf(id) === index)
 
     const allStations = await service.getBikeRentalStations(allStationIds)
-    return allStations.sort((a, b) => a.name.localeCompare(b.name, 'no'))
+    return allStations
 }
 
 export default function useBikeRentalStations(): Array<


### PR DESCRIPTION
Forslag om å sortere bysykler på avstand fra `position`.

Det ser ut som at Entur SDK gir stoppesteder sortert på avstand, så gitt at det er riktig observert, kan man bare fjerne sorteringsfunksjonen i `fetchBikeRentalStations`.

Fixes atb-as/tavla#21