### PR TITLE
Fix tile gradient rendering on safari

### DIFF
--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -31,7 +31,7 @@
         width: 100%;
         height: 50px;
         bottom: 0;
-        background: linear-gradient(0deg, rgba($colors-blues-blue10, 1) 0%, rgba($colors-blues-blue10, 0.7) 50%, transparent 100%);
+        background: linear-gradient(0deg, rgba($colors-blues-blue10, 1) 0%, rgba($colors-blues-blue10, 0.7) 50%, rgba($colors-blues-blue10, 0) 100%);
         z-index: 1;
     }
 


### PR DESCRIPTION
Fixes atb-as/tavla#24 

Liten bug når gradienten rendres fra blå til transparent i Safari. 

![Screenshot 2020-06-24 at 15 11 03](https://user-images.githubusercontent.com/1774972/85562608-eed56480-b62c-11ea-9de4-c5befec3fb87.png)
