### PR TITLE
Remove unnecessary scrollbars

### DIFF
--- a/src/containers/DashboardWrapper/styles.scss
+++ b/src/containers/DashboardWrapper/styles.scss
@@ -4,7 +4,7 @@
     background-color: $colors-brand-blue;
     color: white;
     padding: 2rem 4rem;
-    overflow: scroll;
+    overflow-x: auto;
     height: calc(100vh);
 
     &__no-stops {

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -4,12 +4,13 @@
     &__tiles {
         display: block;
         flex-direction: row;
-        overflow-x: auto;
+        overflow-x: visible;
 
         .tile {
             width: 100%;
             padding-top: 2rem;
             overflow-y: hidden;
+            overflow-x: hidden;
             margin-bottom: 1rem;
         }
     }


### PR DESCRIPTION
Using Safari or Chrome on macOS with scroll bars enabled ("Always" in System Preferences > General) looks like this:

Before:
![Screenshot 2020-06-24 at 15 36 20](https://user-images.githubusercontent.com/1774972/85566709-930cda80-b630-11ea-9835-576179fdbeb6.png)

After:
![Screenshot 2020-06-24 at 15 58 14](https://user-images.githubusercontent.com/1774972/85570890-0237fe00-b634-11ea-8306-669fe8e28da2.png)

Fixes atb-as/tavla#25