### PR TITLE
Update resizable-handle cursor to north-south

### DIFF
--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -72,7 +72,7 @@
         width: 100%;
         height: 20px;
         bottom: 0;
-        cursor: s-resize;
+        cursor: ns-resize;
         z-index: 2;
         opacity: 0;
         transition: bottom 0.3s, opacity 0.3s;


### PR DESCRIPTION
Musepekeren til størrelsejusterings-håndtaket bør peke både opp og ned (nord og sør, ikke bare sør).