### PR TITLE
Noen grunnleggende regler for Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if false;
+      allow read, update, create: if request.auth.uid != null;
     }
   }
 }


### PR DESCRIPTION
`write` er ikke tillatt, da sletting ikke skal skje.