### PR TITLE
Listen for changes to settings in Firebase

### DIFF
--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -7,15 +7,11 @@ import { Settings } from '../settings/index'
 const SETTINGS_COLLECTION = 'settings'
 type DocumentReference = firestore.DocumentReference
 
-export const getSettings = async (
-    id: string,
-): Promise<Settings | undefined> => {
-    const document = await firebase
+export const getSettings = (id: string): DocumentReference => {
+    return firebase
         .firestore()
         .collection(SETTINGS_COLLECTION)
         .doc(id)
-        .get()
-    return document.data() as Settings | undefined
 }
 
 export const updateSettingField = async (

--- a/src/settings/FirestoreStorage.ts
+++ b/src/settings/FirestoreStorage.ts
@@ -1,4 +1,4 @@
-import { updateSettingField, getSettings } from '../services/firebase'
+import { updateSettingField } from '../services/firebase'
 import { Settings } from '../settings/index'
 
 export type FieldValue =
@@ -10,10 +10,6 @@ export type FieldValue =
 
 export function persist(docId: string, settings: Settings): void {
     updateSettingField(docId, settings)
-}
-
-export function restore(id?: string): Promise<Settings | undefined> {
-    return getSettings(id)
 }
 
 export function changePath(): void {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -9,15 +9,12 @@ import { useLocation } from 'react-router-dom'
 import { LegMode, Coordinates } from '@entur/sdk'
 
 import { useIsFirebaseInitialized } from '../firebase-init'
-import {
-    persist as persistToFirebase,
-    restore as restoreFromFirebase,
-    FieldValue,
-} from './FirestoreStorage'
+import { persist as persistToFirebase, FieldValue } from './FirestoreStorage'
 import {
     persist as persistToUrl,
     restore as restoreFromUrl,
 } from './UrlStorage'
+import { getSettings } from '../services/firebase'
 
 // Matches the ID in an URL, if it exists.
 const ID_REGEX = /\/(?:t|(?:admin))\/(\w+)(?:\/)?/
@@ -98,29 +95,32 @@ export function useSettings(): [Settings, SettingsSetters, Persistor] {
     useEffect(() => {
         if (location.pathname == '/' || !firebaseInitialized) return
 
-        async function loadSettings(): Promise<Settings> {
-            if (getDocumentId()) {
-                setSettings(await restoreFromFirebase(getDocumentId()))
-                return
-            }
+        const id = getDocumentId()
 
-            const positionArray = location.pathname
-                .split('/')[2]
-                .split('@')[1]
-                .split('-')
-                .join('.')
-                .split(/,/)
-
-            setSettings({
-                ...restoreFromUrl(),
-                coordinates: {
-                    latitude: Number(positionArray[0]),
-                    longitude: Number(positionArray[1]),
-                },
+        if (id) {
+            return getSettings(id).onSnapshot(document => {
+                if (document.exists) {
+                    setSettings(document.data() as Settings)
+                } else {
+                    window.location.pathname = '/'
+                }
             })
         }
 
-        loadSettings()
+        const positionArray = location.pathname
+            .split('/')[2]
+            .split('@')[1]
+            .split('-')
+            .join('.')
+            .split(/,/)
+
+        setSettings({
+            ...restoreFromUrl(),
+            coordinates: {
+                latitude: Number(positionArray[0]),
+                longitude: Number(positionArray[1]),
+            },
+        })
     }, [firebaseInitialized, location])
 
     const persistSettings = useCallback(() => {


### PR DESCRIPTION
Legger til støtte for automatisk synkronisering av settings fra Firebase. Det vil si at hvis noen endrer innstillingene for en ID-basert tavle, vil alle instanser av den tavla automatisk laste inn de nye innstillingene, uten refresh.

Legger også til en make-shift håndtering av ikkeeksisterende ID-er: redirecting til startsiden hvis det ikke finnes noe for den ID-en. Bedre enn det er nå, men vi må nok ta en overhaling av hvordan rutinga fungerer. 