### PR TITLE
Activate noImplicitAny, fix errors

### DIFF
--- a/src/containers/DashboardWrapper/Footer/index.tsx
+++ b/src/containers/DashboardWrapper/Footer/index.tsx
@@ -12,7 +12,19 @@ import BackButton from '../../../components/backButton/BackButton'
 
 import './styles.scss'
 
-function RadioBox({ value, selected, onChange, children }): JSX.Element {
+interface RadioBoxProps {
+    value: string
+    selected: boolean
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+    children: JSX.Element | JSX.Element[]
+}
+
+function RadioBox({
+    value,
+    selected,
+    onChange,
+    children,
+}: RadioBoxProps): JSX.Element {
     const id = `radio-${value}`
 
     return (
@@ -66,10 +78,13 @@ function Footer({ className, history }: Props): JSX.Element {
         [history, documentId],
     )
 
-    const onChange = useCallback(event => {
-        event.preventDefault()
-        setChoice(event.target.value)
-    }, [])
+    const onChange = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement>) => {
+            event.preventDefault()
+            setChoice(event.target.value)
+        },
+        [],
+    )
 
     const submit = useCallback(
         event => {

--- a/src/containers/LandingPage/SearchPanel/index.tsx
+++ b/src/containers/LandingPage/SearchPanel/index.tsx
@@ -28,7 +28,7 @@ function mapFeaturesToItems(features: Feature[]): Item[] {
     })
 }
 
-function getErrorMessage(error): string {
+function getErrorMessage(error: PositionError): string {
     switch (error.code) {
         case error.PERMISSION_DENIED:
             return 'Du må godta bruk av posisjon i nettleseren før vi kan hente den.'
@@ -74,7 +74,7 @@ const SearchPanel = ({ handleCoordinatesSelected }: Props): JSX.Element => {
         getAddressFromPosition(position)
     }
 
-    const handleDeniedLocation = (error): void => {
+    const handleDeniedLocation = (error: PositionError): void => {
         refreshLocationPermission()
         setErrorMessage(getErrorMessage(error))
         setLocation({
@@ -103,7 +103,7 @@ const SearchPanel = ({ handleCoordinatesSelected }: Props): JSX.Element => {
         }
     }
 
-    const handleGoToBoard = (event): void => {
+    const handleGoToBoard = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
         if (chosenCoord) {
             handleCoordinatesSelected(chosenCoord)

--- a/src/dashboards/Timeline/index.tsx
+++ b/src/dashboards/Timeline/index.tsx
@@ -40,7 +40,7 @@ function groupDeparturesByMode(
             ...map,
             [departure.type]: [...(map[departure.type] || []), departure],
         }),
-        {},
+        {} as { [mode in LegMode]?: Array<LineData> },
     )
 }
 
@@ -69,7 +69,13 @@ function getLegBonePattern(
     }
 }
 
-function Tick({ minutes, mode, index }): JSX.Element {
+interface TickProps {
+    minutes: number
+    mode: LegMode
+    index: number
+}
+
+function Tick({ minutes, mode, index }: TickProps): JSX.Element {
     let label = `${minutes} min`
     let marginLeft = -30
 
@@ -102,21 +108,33 @@ function Tick({ minutes, mode, index }): JSX.Element {
     )
 }
 
+interface TimelineData {
+    stopId: string
+    name: string
+    groupedDepartures: [LegMode, LineData[]][]
+}
+
 const TimelineDashboard = ({ history }: Props): JSX.Element => {
     useCounter()
     const stopPlacesWithDepartures = useStopPlacesWithDepartures()
 
-    const data = useMemo(
+    const data: TimelineData[] = useMemo(
         () =>
             (stopPlacesWithDepartures || [])
                 .filter(({ departures }) => departures.length > 0)
-                .map(({ id, name, departures }) => ({
-                    stopId: id,
-                    name,
-                    groupedDepartures: Object.entries(
+                .map(({ id, name, departures }) => {
+                    const groupedDepartures = Object.entries(
                         groupDeparturesByMode(departures.reverse()),
-                    ).sort(([modeA], [modeB]) => orderModes(modeA, modeB)),
-                })),
+                    ).sort(([modeA], [modeB]) =>
+                        orderModes(modeA, modeB),
+                    ) as TimelineData['groupedDepartures']
+
+                    return {
+                        stopId: id,
+                        name,
+                        groupedDepartures,
+                    }
+                }),
         [stopPlacesWithDepartures],
     )
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,4 +1,4 @@
-import createEnturService from '@entur/sdk'
+import createEnturService, { LegMode, TransportSubmode } from '@entur/sdk'
 
 import { StopPlaceWithLines, Line } from './types'
 import { unique } from './utils'
@@ -13,7 +13,10 @@ export default createEnturService({
     },
 })
 
-function journeyplannerPost(query, variables): Promise<any> {
+function journeyplannerPost<T>(
+    query: string,
+    variables: Record<string, any>,
+): Promise<T> {
     return fetch(`${process.env.JOURNEYPLANNER_HOST}/graphql`, {
         method: 'POST',
         headers: {
@@ -33,11 +36,23 @@ interface EstimatedCall {
     }
     serviceJourney: {
         line: {
-            transportMode: string
-            transportSubmode: string
+            id: string
+            transportMode: LegMode
+            transportSubmode: TransportSubmode
             publicCode: string
         }
     }
+}
+
+interface StopPlaceWithEstimatedCalls {
+    id: string
+    name: string
+    description: string
+    latitude: number
+    longitude: number
+    transportMode: LegMode
+    transportSubmode: TransportSubmode
+    estimatedCalls: EstimatedCall[]
 }
 
 function getNumericPublicCode(publicCode: string): number | void {
@@ -76,10 +91,12 @@ function estimatedCallsComparator(a: EstimatedCall, b: EstimatedCall): number {
 
 export async function getStopPlacesWithLines(
     stopPlaceIds: Array<string>,
-): Promise<Array<StopPlaceWithLines>> {
+): Promise<StopPlaceWithLines[]> {
     try {
         const variables = { ids: stopPlaceIds }
-        const results = await journeyplannerPost(
+        const results = await journeyplannerPost<{
+            data: { stopPlaces: StopPlaceWithEstimatedCalls[] }
+        }>(
             `query ($ids: [String]!) {
                 stopPlaces(ids: $ids) {
                     id,
@@ -95,6 +112,7 @@ export async function getStopPlacesWithLines(
                         }
                         serviceJourney {
                             line {
+                                id
                                 transportMode,
                                 transportSubmode,
                                 publicCode
@@ -107,24 +125,26 @@ export async function getStopPlacesWithLines(
             variables,
         )
 
-        const stops = results.data.stopPlaces.map(stopPlace => {
-            const lines = stopPlace.estimatedCalls
-                .sort(estimatedCallsComparator)
-                .map(({ destinationDisplay, serviceJourney }) => ({
-                    ...serviceJourney.line,
-                    name: `${serviceJourney.line.publicCode} ${destinationDisplay.frontText}`,
-                }))
+        const stops: StopPlaceWithLines[] = results.data.stopPlaces.map(
+            stopPlace => {
+                const lines = stopPlace.estimatedCalls
+                    .sort(estimatedCallsComparator)
+                    .map(({ destinationDisplay, serviceJourney }) => ({
+                        ...serviceJourney.line,
+                        name: `${serviceJourney.line.publicCode} ${destinationDisplay.frontText}`,
+                    }))
 
-            const uniqueLines = unique(
-                lines,
-                (a: Line, b: Line) => a.name === b.name,
-            )
+                const uniqueLines = unique(
+                    lines,
+                    (a: Line, b: Line) => a.name === b.name,
+                )
 
-            return {
-                ...stopPlace,
-                lines: uniqueLines,
-            }
-        })
+                return {
+                    ...stopPlace,
+                    lines: uniqueLines,
+                }
+            },
+        )
 
         return stops
     } catch (error) {

--- a/src/settings/UrlStorage.ts
+++ b/src/settings/UrlStorage.ts
@@ -23,14 +23,17 @@ function migrateFromV0(settings: string): Settings {
         return DEFAULT_SETTINGS
     }
     const parsed = JSON.parse(atob(settings))
-    const migratedHiddenRoutes = parsed.hiddenRoutes
-        .map(idAndRouteString => idAndRouteString.split('$'))
+    const migratedHiddenRoutes: Settings['hiddenRoutes'] = parsed.hiddenRoutes
+        .map((idAndRouteString: string) => idAndRouteString.split('$'))
         .reduce(
-            (routeMap, [stopPlaceId, routeName]) => ({
+            (
+                routeMap: Settings['hiddenRoutes'],
+                [stopPlaceId, routeName]: [string, string],
+            ) => ({
                 ...routeMap,
                 [stopPlaceId]: [...(routeMap[stopPlaceId] || []), routeName],
             }),
-            {},
+            {} as Settings['hiddenRoutes'],
         )
 
     return {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -134,9 +134,9 @@ export function getIcon(
     }
 }
 
-export function groupBy<T>(
-    objectArray: Array<T>,
-    property: string,
+export function groupBy<T extends { [key: string]: any }>(
+    objectArray: T[],
+    property: keyof T,
 ): { [key: string]: Array<T> } {
     return objectArray.reduce((acc, obj) => {
         const key = obj[property]
@@ -145,7 +145,7 @@ export function groupBy<T>(
         }
         acc[key].push(obj)
         return acc
-    }, {})
+    }, {} as { [key: string]: any })
 }
 
 function formatDeparture(minDiff: number, departureTime: Date): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
         "typeRoots": ["./types", "node_modules/@types"],
+        "noImplicitAny": true,
         "downlevelIteration": true
     },
     "include": ["types", "./src/**/*"],

--- a/types/universal-ga/index.d.ts
+++ b/types/universal-ga/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'universal-ga'


### PR DESCRIPTION
Å sette `strict: true` er det samme som å aktivere følgande under-flagg. Så eg tenkte å ta eitt og eitt!

- [x] --noImplicitAny
- [ ] --noImplicitThis
- [ ] --alwaysStrict
- [ ] --strictBindCallApply
- [ ] --strictNullChecks 
- [ ] --strictFunctionTypes
- [ ] --strictPropertyInitialization
