### PR TITLE
Remove automatic config - rely on env variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,19 +52,19 @@ We are using Firebase for hosting tavla.entur.no (Firebase Hosting) and we are u
 PS! Make sure you are following the licenses and terms for Tavla: https://github.com/entur/tavla#licenses-and-terms
 
 ### Create a project
-First of all you need a Firebase _project. Go to https://console.firebase.google.com to set up a new project.
+First of all you need a Firebase _project_. Go to https://console.firebase.google.com to set up a new project.
 
 When the project is set up, add a new Web app to your project from the Project Overview. You don't need to "Add Firebase SDK" – that's already done in this repo.
 
-### Download config for local development
-In order to ease local development and allow hot reloading and such, we need to reference the Firebase config through an environment variable called `FIREBASE_CONFIG`, rather than rely on the auto-config that Firebase provides through `firebase serve`.
+### Download config
+We need to reference the Firebase config through an environment variable called `FIREBASE_CONFIG`.
 
-Press the cogwheel next to "Project Settings" in the left menu and go to "Project settings". Scroll down and find the Config under "Firebase SDK snippet". Copy the config object (the part after `const firebaseConfig = `). You need to stringify this and put it in your `.env.staging` file. To stringify it, you can open the browser console and run `JSON.stringify(<CONFIG OBJECT>)`. Set the resulting string as the value for `FIREBASE_CONFIG` in the .env.staging file:
+Press the cogwheel next to "Project Settings" in the left menu and go to "Project settings". Scroll down and find the Config under "Firebase SDK snippet". Copy the config object (the part after `const firebaseConfig = `). You need to stringify this and put it in your `.env.staging` file. To stringify it, you can open the browser console and run `JSON.stringify(<CONFIG OBJECT>)`. Set the resulting string as the value for `FIREBASE_CONFIG` in the .env.prod file:
 
 ```diff
-# .env.staging
-JOURNEYPLANNER_HOST=https://api.staging.entur.io/journey-planner/v2
-GEOCODER_HOST=https://api.staging.entur.io/geocoder/v1
+# .env.prod
+JOURNEYPLANNER_HOST=https://api.entur.io/journey-planner/v2
+GEOCODER_HOST=https://api.entur.io/geocoder/v1
 -FIREBASE_CONFIG='{"apiKey":"AIz...
 +FIREBASE_CONFIG='{"apiKey":"<YOUR_CONFIG ... >
 ```

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,6 @@ import { useState, useEffect, useContext, createContext } from 'react'
 import firebase, { User } from 'firebase/app'
 import 'firebase/auth'
 
-import { useIsFirebaseInitialized } from './firebase-init'
 /**
  * If user is undefined, we don't know yet if user is logged in.
  * If user is null, we know there's not a logged in user
@@ -11,11 +10,8 @@ import { useIsFirebaseInitialized } from './firebase-init'
  */
 export function useAnonymousLogin(): User | null | undefined {
     const [user, setUser] = useState<User | null | undefined>()
-    const firebaseInitialized = useIsFirebaseInitialized()
 
     useEffect(() => {
-        if (!firebaseInitialized) return
-
         const unsubscribe = firebase.auth().onAuthStateChanged(newUser => {
             setUser(newUser)
             if (newUser) {
@@ -28,7 +24,7 @@ export function useAnonymousLogin(): User | null | undefined {
         })
 
         return unsubscribe
-    }, [firebaseInitialized])
+    }, [])
 
     return user
 }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -4,7 +4,7 @@ import analytics from 'universal-ga'
 
 import { SettingsContext, useSettings } from '../settings'
 import { useAnonymousLogin, UserProvider } from '../auth'
-import initializeFirebase from '../firebase-init'
+import '../firebase-init'
 
 import Compact from '../dashboards/Compact'
 import Chrono from '../dashboards/Chrono'
@@ -13,8 +13,6 @@ import Timeline from '../dashboards/Timeline'
 import LandingPage from './LandingPage'
 import Admin from './Admin'
 import Privacy from './Privacy'
-
-initializeFirebase()
 
 analytics.initialize('UA-108877193-6')
 analytics.set('anonymizeIp', true)

--- a/src/firebase-init.ts
+++ b/src/firebase-init.ts
@@ -1,37 +1,7 @@
-import { useState, useEffect } from 'react'
 import firebase from 'firebase/app'
-import 'firebase/auth'
 
-let appSingleton: undefined | firebase.app.App | Promise<firebase.app.App>
-
-/*
- * Initializes the Firebase app. It is safe to call multiple times – only one instance will be created
- */
-export default async function initializeFirebase(): Promise<firebase.app.App> {
-    if (appSingleton) {
-        return appSingleton
-    }
-
-    if (process.env.FIREBASE_CONFIG) {
-        appSingleton = firebase.initializeApp(
-            JSON.parse(process.env.FIREBASE_CONFIG),
-        )
-        return appSingleton
-    }
-
-    appSingleton = fetch('/__/firebase/init.json').then(async response => {
-        return firebase.initializeApp(await response.json())
-    })
-
-    return appSingleton
-}
-
-export function useIsFirebaseInitialized(): boolean {
-    const [initialized, setInitialized] = useState<boolean>(false)
-
-    useEffect(() => {
-        initializeFirebase().then(() => setInitialized(true))
-    }, [])
-
-    return initialized
+if (!process.env.FIREBASE_CONFIG) {
+    console.error('The environment variable FIREBASE_CONFIG is missing!')
+} else {
+    firebase.initializeApp(JSON.parse(process.env.FIREBASE_CONFIG))
 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -8,7 +8,6 @@ import {
 import { useLocation } from 'react-router-dom'
 import { LegMode, Coordinates } from '@entur/sdk'
 
-import { useIsFirebaseInitialized } from '../firebase-init'
 import { persist as persistToFirebase, FieldTypes } from './FirestoreStorage'
 import {
     persist as persistToUrl,
@@ -68,12 +67,10 @@ export function useSettingsContext(): [Settings, SettingsSetters] {
 export function useSettings(): [Settings, SettingsSetters] {
     const [settings, setSettings] = useState<Settings>()
 
-    const firebaseInitialized = useIsFirebaseInitialized()
-
     const location = useLocation()
 
     useEffect(() => {
-        if (location.pathname == '/' || !firebaseInitialized) return
+        if (location.pathname == '/') return
 
         const id = getDocumentId()
 
@@ -101,7 +98,7 @@ export function useSettings(): [Settings, SettingsSetters] {
                 longitude: Number(positionArray[1]),
             },
         })
-    }, [firebaseInitialized, location])
+    }, [location])
 
     const set = useCallback(
         <T>(key: string, value: FieldTypes): void => {


### PR DESCRIPTION
Dersom man bruker Firebase Hosting kan man droppe config og la Firebase ordne det automatisk. Men det funker ikkje så bra lokalt. No som me uansett har configen for begge miljøa i repoet, kan me like godt forenkle litt og droppe støtten for denne automatiske konfigureringa.