### PR TITLE
Feat/lock tavla

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,6 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents/settings/{document} {
     allow read, create: if request.auth != null;
-    allow update: if request.auth != null && (!resource.data.keys().hasAny(['owner']) || resource.data.owner == request.auth.uid);
+    allow update: if request.auth != null && (resource.data.owner == '' || resource.data.owner == request.auth.uid);
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,6 @@ service cloud.firestore {
   match /databases/{database}/documents/settings/{document} {
     allow read;
     allow create: if request.auth != null;
-    allow update: if request.auth != null && (resource.data.owner == '' || resource.data.owner == request.auth.uid);
+    allow update: if request.auth != null && (resource.data.owners.size() == 0 || resource.data.owners.hasAny([request.auth.uid]));
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,7 @@
 rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, update, create: if request.auth.uid != null;
-    }
+  match /databases/{database}/documents/settings/{document} {
+    allow read, create: if request.auth != null;
+    allow update: if request.auth != null && (!resource.data.keys().hasAny(['owner']) || resource.data.owner == request.auth.uid);
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,8 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents/settings/{document} {
-    allow read, create: if request.auth != null;
+    allow read;
+    allow create: if request.auth != null;
     allow update: if request.auth != null && (resource.data.owner == '' || resource.data.owner == request.auth.uid);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2668,6 +2668,35 @@
         }
       }
     },
+    "@entur/alert": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/@entur/alert/-/alert-0.5.26.tgz",
+      "integrity": "sha512-8uF5onCkLLM7czFwRIxt9efVfK8Ri8jv92NYW8kPQb73tH+8RA9rJxbBs+Pdu+1JeqmTG1aeq5595roEVCPceg==",
+      "requires": {
+        "@entur/icons": "^1.8.0",
+        "@entur/utils": "^0.2.9",
+        "classnames": "^2.2.6"
+      },
+      "dependencies": {
+        "@entur/icons": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@entur/icons/-/icons-1.8.0.tgz",
+          "integrity": "sha512-u6cs6oBuE1+vVXhaTMwspPwqixqFcxYRjjFwQhyS9Sj0LJTMHnqkvspwaohOYicLckovKuRAM2b+RGDYT9pFjw==",
+          "requires": {
+            "@entur/tokens": "^1.3.6",
+            "@entur/utils": "^0.2.9"
+          }
+        },
+        "@entur/tokens": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/@entur/tokens/-/tokens-1.3.6.tgz",
+          "integrity": "sha512-7g3ilIHx6+7Kj5DaF4Wcsw9Qcrxf2DGdb5gjqQdYNzCqjnEc3omoPqrSFfB5dRUEOXThIZt8415D4lfIhbYLLQ==",
+          "requires": {
+            "hex-rgb": "^4.1.0"
+          }
+        }
+      }
+    },
     "@entur/button": {
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/@entur/button/-/button-2.2.11.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.2",
     "@entur/a11y": "^0.2.23",
+    "@entur/alert": "^0.5.26",
     "@entur/button": "^2.2.11",
     "@entur/chip": "^0.3.16",
     "@entur/dropdown": "^1.2.0",

--- a/src/assets/styles/import.scss
+++ b/src/assets/styles/import.scss
@@ -13,3 +13,4 @@
 @import '~@entur/button/dist/styles.css';
 @import '~@entur/grid/dist/styles.css';
 @import '~@entur/tooltip/dist/styles.css';
+@import '~@entur/alert/dist/styles.css';

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@ import firebase, { User } from 'firebase/app'
 import 'firebase/auth'
 
 /**
- * If user is´ undefined, we don't know yet if user is logged in.
+ * If user is undefined, we don't know yet if user is logged in.
  * If user is null, we know there's not a logged in user
  * If user is User, we have a logged-in or anonymous user.
  */

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@ import firebase, { User } from 'firebase/app'
 import 'firebase/auth'
 
 /**
- * If user is undefined, we don't know yet if user is logged in.
+ * If user is´ undefined, we don't know yet if user is logged in.
  * If user is null, we know there's not a logged in user
  * If user is User, we have a logged-in or anonymous user.
  */

--- a/src/containers/Admin/LoginModal/EmailLogin/index.tsx
+++ b/src/containers/Admin/LoginModal/EmailLogin/index.tsx
@@ -5,7 +5,7 @@ import { TextField, InputGroup } from '@entur/form'
 import { GridContainer, GridItem } from '@entur/grid'
 import { EmailIcon, ClosedLockIcon, BackArrowIcon } from '@entur/icons'
 import { PrimaryButton } from '@entur/button'
-import { Heading2, Link } from '@entur/typography'
+import { Heading3, Link } from '@entur/typography'
 
 import { useFormFields } from '../../../../utils'
 import { ModalType } from '..'
@@ -68,7 +68,7 @@ const EmailLogin = ({ setModalType }: Props): JSX.Element => {
             <div className="centered">
                 <img src={sikkerhetBom} srcSet={`${retinaSikkerhetBom} 2x`} />
             </div>
-            <Heading2 margin="none">Logg inn med e-post</Heading2>
+            <Heading3 margin="none">Logg inn med e-post</Heading3>
             <form>
                 <GridContainer spacing="medium">
                     <GridItem small={12}>

--- a/src/containers/Admin/LoginModal/EmailSent/index.tsx
+++ b/src/containers/Admin/LoginModal/EmailSent/index.tsx
@@ -2,12 +2,12 @@ import React, { Dispatch, SetStateAction } from 'react'
 
 import { GridContainer, GridItem } from '@entur/grid'
 import { PrimaryButton } from '@entur/button'
-import { Heading4, Paragraph } from '@entur/typography'
+import { Heading3, Paragraph } from '@entur/typography'
 
 import { ModalType } from '../.'
 
-import Check from '../../../../assets/images/sikkerhet_bom.png'
-import retinaCheck from '../../../../assets/images/sikkerhet_bom@2x.png'
+import Check from '../../../../assets/images/check.png'
+import retinaCheck from '../../../../assets/images/check@2x.png'
 
 export interface UserResetPassword {
     email: string
@@ -23,7 +23,7 @@ const ResetPassword = ({ setModalType }: Props): JSX.Element => {
             <div className="centered">
                 <img src={Check} srcSet={`${retinaCheck} 2x`} />
             </div>
-            <Heading4 margin="none">Sjekk e-posten din!</Heading4>
+            <Heading3 margin="none">Sjekk e-posten din!</Heading3>
             <Paragraph>
                 Hvis du har en profil hos oss, så har vi sendt deg en e-post
                 hvor du kan endre ditt passord.

--- a/src/containers/Admin/LoginModal/LoginOptions/index.tsx
+++ b/src/containers/Admin/LoginModal/LoginOptions/index.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction } from 'react'
 
-import { Heading2, Paragraph } from '@entur/typography'
+import { Heading3, Paragraph } from '@entur/typography'
 import { GridContainer, GridItem } from '@entur/grid'
 import { PrimaryButton, SecondaryButton } from '@entur/button'
 import { ModalType } from '..'
@@ -18,7 +18,7 @@ const LoginOptions = ({ setModalType }: Props): JSX.Element => {
             <div className="centered">
                 <img src={sikkerhetBom} srcSet={`${retinaSikkerhetBom} 2x`} />
             </div>
-            <Heading2 margin="bottom">Logg inn for å fortsette</Heading2>
+            <Heading3 margin="bottom">Logg inn for å fortsette</Heading3>
             <Paragraph style={{ textAlign: 'center' }}>
                 For å låse tavlas redigeringsrettigheter til en konto, må du
                 være innlogget.

--- a/src/containers/Admin/LoginModal/ResetPassword/index.tsx
+++ b/src/containers/Admin/LoginModal/ResetPassword/index.tsx
@@ -5,7 +5,7 @@ import { TextField, InputGroup } from '@entur/form'
 import { GridContainer, GridItem } from '@entur/grid'
 import { EmailIcon, BackArrowIcon } from '@entur/icons'
 import { PrimaryButton } from '@entur/button'
-import { Heading2, Paragraph } from '@entur/typography'
+import { Heading3, Paragraph } from '@entur/typography'
 
 import { useFormFields } from '../../../../utils'
 import { ModalType } from '..'
@@ -60,7 +60,7 @@ const ResetPassword = ({ setModalType }: Props): JSX.Element => {
             <div className="centered">
                 <img src={sikkerhetBom} srcSet={`${retinaSikkerhetBom} 2x`} />
             </div>
-            <Heading2 margin="none">Glemt passord</Heading2>
+            <Heading3 margin="none">Glemt passord</Heading3>
             <Paragraph>
                 Skriv inn e-postadressen som du registrerte profilen din på, så
                 sender vi deg en lenke der du kan lage et nytt passord.

--- a/src/containers/Admin/LoginModal/index.tsx
+++ b/src/containers/Admin/LoginModal/index.tsx
@@ -10,6 +10,7 @@ import EmailSent from './EmailSent'
 import './styles.scss'
 
 import { Modal } from '@entur/modal'
+import { useToast } from '@entur/alert'
 
 import { useFirebaseAuthentication } from '../../../auth'
 
@@ -29,6 +30,8 @@ const LoginModal = ({ open, onDismiss }: Props): JSX.Element => {
     const user = useFirebaseAuthentication()
 
     const isLoggedIn = user && !user.isAnonymous
+
+    const { addToast } = useToast()
 
     const [modalType, setModalType] = useState<ModalType>('LoginOptionsModal')
 
@@ -50,9 +53,14 @@ const LoginModal = ({ open, onDismiss }: Props): JSX.Element => {
     useEffect(() => {
         if (isLoggedIn && open) {
             setModalType('LoginOptionsModal')
+            addToast({
+                title: 'Logget inn',
+                content: 'Du har nå logget inn på din konto.',
+                variant: 'success',
+            })
             onDismiss()
         }
-    }, [isLoggedIn, open, onDismiss])
+    }, [isLoggedIn, open, onDismiss, addToast])
 
     const handleDismiss = (): void => {
         setModalType('LoginOptionsModal')

--- a/src/containers/Admin/LoginModal/index.tsx
+++ b/src/containers/Admin/LoginModal/index.tsx
@@ -32,10 +32,6 @@ const LoginModal = ({ open, onDismiss }: Props): JSX.Element => {
 
     const [modalType, setModalType] = useState<ModalType>('LoginOptionsModal')
 
-    const handleDismiss = (): void => {
-        setModalType('LoginOptionsModal')
-    }
-
     const displayModal = (): JSX.Element => {
         switch (modalType) {
             case 'LoginEmailModal':
@@ -53,14 +49,19 @@ const LoginModal = ({ open, onDismiss }: Props): JSX.Element => {
 
     useEffect(() => {
         if (isLoggedIn && open) {
-            handleDismiss()
+            setModalType('LoginOptionsModal')
             onDismiss()
         }
     }, [isLoggedIn, open, onDismiss])
 
+    const handleDismiss = (): void => {
+        setModalType('LoginOptionsModal')
+        onDismiss()
+    }
+
     return (
         <Modal
-            onDismiss={onDismiss}
+            onDismiss={handleDismiss}
             open={open}
             size="small"
             title=""

--- a/src/containers/Admin/LoginModal/index.tsx
+++ b/src/containers/Admin/LoginModal/index.tsx
@@ -13,6 +13,11 @@ import { Modal } from '@entur/modal'
 
 import { useFirebaseAuthentication } from '../../../auth'
 
+interface Props {
+    open: boolean
+    onDismiss: () => void
+}
+
 export type ModalType =
     | 'LoginOptionsModal'
     | 'LoginEmailModal'
@@ -20,17 +25,15 @@ export type ModalType =
     | 'ResetPasswordModal'
     | 'EmailSentModal'
 
-const LoginModal = (): JSX.Element => {
+const LoginModal = ({ open, onDismiss }: Props): JSX.Element => {
     const user = useFirebaseAuthentication()
 
     const isLoggedIn = user && !user.isAnonymous
 
     const [modalType, setModalType] = useState<ModalType>('LoginOptionsModal')
-    const [modalOpen, setModalOpen] = useState(false)
 
     const handleDismiss = (): void => {
         setModalType('LoginOptionsModal')
-        setModalOpen(false)
     }
 
     const displayModal = (): JSX.Element => {
@@ -49,27 +52,22 @@ const LoginModal = (): JSX.Element => {
     }
 
     useEffect(() => {
-        if (isLoggedIn && modalOpen) {
+        if (isLoggedIn && open) {
             handleDismiss()
+            onDismiss()
         }
-    }, [isLoggedIn, modalOpen])
+    }, [isLoggedIn, open, onDismiss])
 
-    if (modalOpen) {
-        return (
-            <Modal
-                onDismiss={handleDismiss}
-                size="small"
-                title=""
-                className="login-modal"
-            >
-                {displayModal()}
-            </Modal>
-        )
-    }
-    return isLoggedIn ? (
-        <a onClick={(): Promise<void> => firebase.auth().signOut()}>Logg ut</a>
-    ) : (
-        <a onClick={(): void => setModalOpen(true)}>Logg inn</a>
+    return (
+        <Modal
+            onDismiss={onDismiss}
+            open={open}
+            size="small"
+            title=""
+            className="login-modal"
+        >
+            {displayModal()}
+        </Modal>
     )
 }
 

--- a/src/containers/Admin/LoginModal/styles.scss
+++ b/src/containers/Admin/LoginModal/styles.scss
@@ -13,7 +13,7 @@
     }
 
     h2,
-    h4 {
+    h3 {
         text-align: center;
     }
 

--- a/src/containers/Admin/index.tsx
+++ b/src/containers/Admin/index.tsx
@@ -7,7 +7,6 @@ import StopPlacePanel from './StopPlacePanel'
 import BikePanel from './BikePanel'
 import ModePanel from './ModePanel'
 import DistanceEditor from './DistanceEditor'
-import LoginModal from './LoginModal'
 
 import { useDebounce, isLegMode, unique, getDocumentId } from '../../utils'
 
@@ -146,8 +145,6 @@ const AdminPage = ({ history }: Props): JSX.Element => {
 
     return (
         <Contrast className="admin">
-            <LockModal />
-
             <AdminHeader goBackToDashboard={goToDash} />
 
             <div className="admin__content">

--- a/src/containers/Admin/index.tsx
+++ b/src/containers/Admin/index.tsx
@@ -23,6 +23,7 @@ import StopPlaceSearch from './StopPlaceSearch'
 
 import './styles.scss'
 import AdminHeader from './AdminHeader'
+import LockModal from '../LockModal'
 
 const AdminPage = ({ history }: Props): JSX.Element => {
     const [settings, settingsSetters] = useSettingsContext()
@@ -145,6 +146,8 @@ const AdminPage = ({ history }: Props): JSX.Element => {
 
     return (
         <Contrast className="admin">
+            <LockModal />
+
             <AdminHeader goBackToDashboard={goToDash} />
 
             <div className="admin__content">

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -14,6 +14,8 @@ import LandingPage from './LandingPage'
 import Admin from './Admin'
 import Privacy from './Privacy'
 
+import { ToastProvider } from '@entur/alert'
+
 analytics.initialize('UA-108877193-6')
 analytics.set('anonymizeIp', true)
 
@@ -42,19 +44,25 @@ const Content = (): JSX.Element => {
     return (
         <UserProvider value={user}>
             <SettingsContext.Provider value={settings}>
-                <Switch>
-                    <Route exact path="/" component={LandingPage} />
-                    <Route exact path="/t/:documentId" component={Dashboard} />
-                    <Route
-                        exact
-                        path="/admin/:documentId"
-                        component={settings[0] && Admin}
-                    />
-                    <Route path="/dashboard" component={Dashboard} />
-                    <Route path="/admin" component={Admin} />
-                    <Route path="/privacy" component={Privacy} />
-                    <Redirect from="*" to="/" />
-                </Switch>
+                <ToastProvider>
+                    <Switch>
+                        <Route exact path="/" component={LandingPage} />
+                        <Route
+                            exact
+                            path="/t/:documentId"
+                            component={Dashboard}
+                        />
+                        <Route
+                            exact
+                            path="/admin/:documentId"
+                            component={settings[0] && Admin}
+                        />
+                        <Route path="/dashboard" component={Dashboard} />
+                        <Route path="/admin" component={Admin} />
+                        <Route path="/privacy" component={Privacy} />
+                        <Redirect from="*" to="/" />
+                    </Switch>
+                </ToastProvider>
             </SettingsContext.Provider>
         </UserProvider>
     )

--- a/src/containers/DashboardWrapper/BottomMenu/MenuButton/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/MenuButton/index.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 
 import './styles.scss'
 
-function MenuButton({ title, icon, callback }: Props): JSX.Element {
-    return (
+import { Tooltip } from '@entur/tooltip'
+
+function MenuButton({ title, icon, callback, tooltip }: Props): JSX.Element {
+    const button = (
         <button
             onClick={callback}
             className="bottom_menu_button hvr-float hvr-underline-from-center"
@@ -12,12 +14,23 @@ function MenuButton({ title, icon, callback }: Props): JSX.Element {
             {title}
         </button>
     )
+
+    if (tooltip) {
+        return (
+            <Tooltip content={tooltip} placement="top">
+                {button}
+            </Tooltip>
+        )
+    }
+
+    return button
 }
 
 interface Props {
     title: string
     icon: JSX.Element
     callback?: (event: React.SyntheticEvent<HTMLButtonElement>) => void
+    tooltip?: React.ReactNode
 }
 
 export default MenuButton

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -12,6 +12,7 @@ import {
 import { Modal } from '@entur/modal'
 import { Button } from '@entur/button'
 import { colors } from '@entur/tokens'
+import { useToast } from '@entur/alert'
 
 import firebase from 'firebase'
 
@@ -78,6 +79,8 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     const [choice, setChoice] = useState<string>(settings.dashboard || '')
     const [loginModalOpen, setLoginModalOpen] = useState<boolean>(false)
 
+    const { addToast } = useToast()
+
     const { documentId } = useParams()
 
     const onSettingsButtonClick = useCallback(
@@ -93,7 +96,7 @@ function BottomMenu({ className, history }: Props): JSX.Element {
         [history, documentId],
     )
 
-    const lockingButton = !settings.owner && (
+    const lockingButton = settings.owners.length === 0 && (
         <MenuButton
             title="Lås tavle"
             icon={<OpenedLockIcon size={21} />}
@@ -112,7 +115,14 @@ function BottomMenu({ className, history }: Props): JSX.Element {
             <MenuButton
                 title="Logg ut"
                 icon={<LogOutIcon size={21} />}
-                callback={(): Promise<void> => firebase.auth().signOut()}
+                callback={(): void => {
+                    addToast({
+                        title: 'Logget ut',
+                        content: 'Du er nå logget ut av din konto',
+                        variant: 'success',
+                    })
+                    firebase.auth().signOut()
+                }}
             />
         ) : (
             <MenuButton
@@ -122,8 +132,8 @@ function BottomMenu({ className, history }: Props): JSX.Element {
             />
         )
 
-    const editButton = (!settings.owner ||
-        (user && user.uid == settings.owner)) && (
+    const editButton = (settings.owners.length === 0 ||
+        (user && settings.owners.includes(user.uid))) && (
         <div>
             <MenuButton
                 title="Endre visning"

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -1,7 +1,18 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react'
+import React, {
+    useState,
+    useCallback,
+    useEffect,
+    useRef,
+    forwardRef,
+} from 'react'
 import { useParams } from 'react-router-dom'
 import { Heading3, Paragraph } from '@entur/typography'
-import { EditIcon, ConfigurationIcon, CheckIcon } from '@entur/icons'
+import {
+    EditIcon,
+    ConfigurationIcon,
+    CheckIcon,
+    OpenedLockIcon,
+} from '@entur/icons'
 import { Modal } from '@entur/modal'
 import { Button } from '@entur/button'
 import { colors } from '@entur/tokens'
@@ -14,6 +25,7 @@ import { useScrollPosition } from '@n8tb1t/use-scroll-position'
 import { useWindowWidth } from '@react-hook/window-size'
 
 import './styles.scss'
+import LockModal from '../../LockModal'
 
 interface RadioBoxProps {
     value: string
@@ -60,6 +72,7 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     const [settings, { setDashboard }] = useSettingsContext()
 
     const [modalOpen, setModalOpen] = useState<boolean>(false)
+    const [lockModalOpen, setLockModalOpen] = useState<boolean>(false)
     const [choice, setChoice] = useState<string>(settings.dashboard || '')
 
     const { documentId } = useParams()
@@ -143,6 +156,17 @@ function BottomMenu({ className, history }: Props): JSX.Element {
                     icon={<ConfigurationIcon size={21} />}
                     callback={onSettingsButtonClick}
                 />
+                <MenuButton
+                    title="Lås tavle"
+                    icon={<OpenedLockIcon size={21} />}
+                    callback={(): void => setLockModalOpen(true)}
+                    tooltip={
+                        <>
+                            Lås tavla til en konto slik <br />
+                            at bare du kan redigere den.
+                        </>
+                    }
+                />
             </div>
 
             <Modal
@@ -197,6 +221,11 @@ function BottomMenu({ className, history }: Props): JSX.Element {
                     </div>
                 </form>
             </Modal>
+
+            <LockModal
+                open={lockModalOpen}
+                onDismiss={(): void => setLockModalOpen(false)}
+            />
         </div>
     )
 }

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -7,6 +7,7 @@ import {
     CheckIcon,
     OpenedLockIcon,
     LogOutIcon,
+    UserIcon,
 } from '@entur/icons'
 import { Modal } from '@entur/modal'
 import { Button } from '@entur/button'
@@ -23,6 +24,7 @@ import { useWindowWidth } from '@react-hook/window-size'
 
 import './styles.scss'
 import LockModal from '../../LockModal'
+import LoginModal from '../../Admin/LoginModal/.'
 import { useFirebaseAuthentication } from '../../../auth'
 
 interface RadioBoxProps {
@@ -74,36 +76,9 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     const [modalOpen, setModalOpen] = useState<boolean>(false)
     const [lockModalOpen, setLockModalOpen] = useState<boolean>(false)
     const [choice, setChoice] = useState<string>(settings.dashboard || '')
+    const [loginModalOpen, setLoginModalOpen] = useState<boolean>(false)
 
     const { documentId } = useParams()
-
-    const displayLockingOrLogoutButton = (): JSX.Element | null => {
-        if (!settings.owner) {
-            return (
-                <MenuButton
-                    title="Lås tavle"
-                    icon={<OpenedLockIcon size={21} />}
-                    callback={(): void => setLockModalOpen(true)}
-                    tooltip={
-                        <>
-                            Lås tavla til en konto slik <br />
-                            at bare du kan redigere den.
-                        </>
-                    }
-                />
-            )
-        } else if (user && !user.isAnonymous) {
-            return (
-                <MenuButton
-                    title="Logg ut"
-                    icon={<LogOutIcon size={21} />}
-                    callback={(): Promise<void> => firebase.auth().signOut()}
-                />
-            )
-        } else {
-            return null
-        }
-    }
 
     const onSettingsButtonClick = useCallback(
         (event) => {
@@ -116,6 +91,51 @@ function BottomMenu({ className, history }: Props): JSX.Element {
             }
         },
         [history, documentId],
+    )
+
+    const lockingButton = !settings.owner && (
+        <MenuButton
+            title="Lås tavle"
+            icon={<OpenedLockIcon size={21} />}
+            callback={(): void => setLockModalOpen(true)}
+            tooltip={
+                <>
+                    Lås tavla til en konto slik <br />
+                    at bare du kan redigere den.
+                </>
+            }
+        />
+    )
+
+    const logoutButton =
+        user && !user.isAnonymous ? (
+            <MenuButton
+                title="Logg ut"
+                icon={<LogOutIcon size={21} />}
+                callback={(): Promise<void> => firebase.auth().signOut()}
+            />
+        ) : (
+            <MenuButton
+                title="Logg inn"
+                icon={<UserIcon size={21} />}
+                callback={(): void => setLoginModalOpen(true)}
+            />
+        )
+
+    const editButton = (!settings.owner ||
+        (user && user.uid == settings.owner)) && (
+        <div>
+            <MenuButton
+                title="Endre visning"
+                icon={<EditIcon size={21} />}
+                callback={(): void => setModalOpen(true)}
+            />
+            <MenuButton
+                title="Rediger tavla"
+                icon={<ConfigurationIcon size={21} />}
+                callback={onSettingsButtonClick}
+            />
+        </div>
     )
 
     const onChange = useCallback(
@@ -174,17 +194,9 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     return (
         <div ref={menuRef} className={`bottom-menu ${className || ''}`}>
             <div className="bottom-menu__actions">
-                <MenuButton
-                    title="Endre visning"
-                    icon={<EditIcon size={21} />}
-                    callback={(): void => setModalOpen(true)}
-                />
-                <MenuButton
-                    title="Rediger tavla"
-                    icon={<ConfigurationIcon size={21} />}
-                    callback={onSettingsButtonClick}
-                />
-                {displayLockingOrLogoutButton()}
+                {editButton}
+                {lockingButton}
+                {logoutButton}
             </div>
 
             <Modal
@@ -243,6 +255,11 @@ function BottomMenu({ className, history }: Props): JSX.Element {
             <LockModal
                 open={lockModalOpen}
                 onDismiss={(): void => setLockModalOpen(false)}
+            />
+
+            <LoginModal
+                open={loginModalOpen}
+                onDismiss={(): void => setLoginModalOpen(false)}
             />
         </div>
     )

--- a/src/containers/LockModal/index.tsx
+++ b/src/containers/LockModal/index.tsx
@@ -36,7 +36,7 @@ const LockModal = ({ open, onDismiss }: Props): JSX.Element => {
             setOwners(newOwnersList)
         }
     }, [settings.owners, user, setOwners, open])
-    
+
     if (user === undefined) {
         return null
     }

--- a/src/containers/LockModal/index.tsx
+++ b/src/containers/LockModal/index.tsx
@@ -13,27 +13,34 @@ import LoginModal from '../Admin/LoginModal'
 import { GridContainer, GridItem } from '@entur/grid'
 import { PrimaryButton } from '@entur/button'
 
-const LockModal = ({ open, onDismiss }): JSX.Element => {
+import './../Admin/LoginModal/styles.scss'
+
+interface Props {
+    open: boolean
+    onDismiss: () => void
+}
+
+const LockModal = ({ open, onDismiss }: Props): JSX.Element => {
     const user = useFirebaseAuthentication()
 
-    const [{ owner }, { setOwner }] = useSettingsContext()
+    const [settings, { setOwner }] = useSettingsContext()
 
     useEffect(() => {
-        if (user && !user.isAnonymous && owner !== user.uid) {
+        if (user && !user.isAnonymous && settings.owner !== user.uid && open) {
             setOwner(user.uid)
         }
-    }, [owner, user, setOwner])
+    }, [settings.owner, user, setOwner, open])
 
     if (user === undefined) {
         return null
     }
 
     if (!user || user.isAnonymous) {
-        return <LoginModal />
+        return <LoginModal open={open} onDismiss={onDismiss} />
     }
 
     return (
-        <Modal size="small" open={open} title="Lås tavla" onDismiss={onDismiss}>
+        <Modal size="small" open={open} title="" onDismiss={onDismiss}>
             <div className="centered">
                 <img src={Check} srcSet={`${retinaCheck} 2x`} />
             </div>

--- a/src/containers/LockModal/index.tsx
+++ b/src/containers/LockModal/index.tsx
@@ -13,7 +13,7 @@ import LoginModal from '../Admin/LoginModal'
 import { GridContainer, GridItem } from '@entur/grid'
 import { PrimaryButton } from '@entur/button'
 
-import './../Admin/LoginModal/styles.scss'
+import './styles.scss'
 
 interface Props {
     open: boolean
@@ -40,7 +40,13 @@ const LockModal = ({ open, onDismiss }: Props): JSX.Element => {
     }
 
     return (
-        <Modal size="small" open={open} title="" onDismiss={onDismiss}>
+        <Modal
+            size="small"
+            open={open}
+            title=""
+            onDismiss={onDismiss}
+            className="lock-modal"
+        >
             <div className="centered">
                 <img src={Check} srcSet={`${retinaCheck} 2x`} />
             </div>

--- a/src/containers/LockModal/index.tsx
+++ b/src/containers/LockModal/index.tsx
@@ -23,14 +23,20 @@ interface Props {
 const LockModal = ({ open, onDismiss }: Props): JSX.Element => {
     const user = useFirebaseAuthentication()
 
-    const [settings, { setOwner }] = useSettingsContext()
+    const [settings, { setOwners }] = useSettingsContext()
 
     useEffect(() => {
-        if (user && !user.isAnonymous && settings.owner !== user.uid && open) {
-            setOwner(user.uid)
+        if (
+            user &&
+            !user.isAnonymous &&
+            !settings.owners.includes(user.uid) &&
+            open
+        ) {
+            const newOwnersList = [...settings.owners, user.uid]
+            setOwners(newOwnersList)
         }
-    }, [settings.owner, user, setOwner, open])
-
+    }, [settings.owners, user, setOwners, open])
+    
     if (user === undefined) {
         return null
     }

--- a/src/containers/LockModal/index.tsx
+++ b/src/containers/LockModal/index.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from 'react'
+
+import { Modal } from '@entur/modal'
+import { Heading3, Paragraph } from '@entur/typography'
+
+import Check from '../../assets/images/check.png'
+import retinaCheck from '../../assets/images/check@2x.png'
+
+import { useFirebaseAuthentication } from '../../auth'
+import { useSettingsContext } from '../../settings'
+
+import LoginModal from '../Admin/LoginModal'
+import { GridContainer, GridItem } from '@entur/grid'
+import { PrimaryButton } from '@entur/button'
+
+const LockModal = (): JSX.Element => {
+    const user = useFirebaseAuthentication()
+
+    const [{ owner }, { setOwner }] = useSettingsContext()
+
+    useEffect(() => {
+        if (user && !user.isAnonymous && owner !== user.uid) {
+            setOwner(user.uid)
+        }
+    }, [owner, user, setOwner])
+
+    if (user === undefined) {
+        return null
+    }
+
+    if (!user || user.isAnonymous) {
+        return <LoginModal />
+    }
+
+    return (
+        <Modal
+            onDismiss={() => false}
+            size="small"
+            title=""
+            className="login-modal"
+        >
+            <div className="centered">
+                <img src={Check} srcSet={`${retinaCheck} 2x`} />
+            </div>
+            <Heading3 margin="none">Tavla er låst til din konto</Heading3>
+            <Paragraph>
+                Fra nå av kan bare du redigere denne tavla. Hvis du ikke vil ha
+                tavla lagret lenger, kan du slette den fra oversikten over dine
+                tavler.
+            </Paragraph>
+            <GridContainer spacing="medium">
+                <GridItem small={12}>
+                    <PrimaryButton
+                        width="fluid"
+                        type="submit"
+                        onClick={() => false}
+                        className="modal-submit"
+                    >
+                        Se avgangstavla
+                    </PrimaryButton>
+                </GridItem>
+            </GridContainer>
+        </Modal>
+    )
+}
+
+export default LockModal

--- a/src/containers/LockModal/index.tsx
+++ b/src/containers/LockModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 
-import { Modal } from '@entur/modal'
 import { Heading3, Paragraph } from '@entur/typography'
+import { Modal } from '@entur/modal'
 
 import Check from '../../assets/images/check.png'
 import retinaCheck from '../../assets/images/check@2x.png'
@@ -13,7 +13,7 @@ import LoginModal from '../Admin/LoginModal'
 import { GridContainer, GridItem } from '@entur/grid'
 import { PrimaryButton } from '@entur/button'
 
-const LockModal = (): JSX.Element => {
+const LockModal = ({ open, onDismiss }): JSX.Element => {
     const user = useFirebaseAuthentication()
 
     const [{ owner }, { setOwner }] = useSettingsContext()
@@ -33,12 +33,7 @@ const LockModal = (): JSX.Element => {
     }
 
     return (
-        <Modal
-            onDismiss={() => false}
-            size="small"
-            title=""
-            className="login-modal"
-        >
+        <Modal size="small" open={open} title="Lås tavla" onDismiss={onDismiss}>
             <div className="centered">
                 <img src={Check} srcSet={`${retinaCheck} 2x`} />
             </div>
@@ -53,7 +48,7 @@ const LockModal = (): JSX.Element => {
                     <PrimaryButton
                         width="fluid"
                         type="submit"
-                        onClick={() => false}
+                        onClick={onDismiss}
                         className="modal-submit"
                     >
                         Se avgangstavla

--- a/src/containers/LockModal/styles.scss
+++ b/src/containers/LockModal/styles.scss
@@ -1,0 +1,42 @@
+@import '../../assets/styles/import.scss';
+
+.lock-modal.eds-modal__content {
+    padding-top: 0.8rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    padding-bottom: 1.5rem;
+
+    p {
+        padding: 0 1rem;
+        text-align: center;
+        margin: 0;
+    }
+
+    h2,
+    h3 {
+        text-align: center;
+    }
+
+    .eds-grid__container {
+        padding: 10%;
+    }
+
+    img {
+        width: 45%;
+        margin: 0 auto;
+    }
+
+    a {
+        cursor: pointer;
+        margin-bottom: 3rem;
+    }
+
+    .modal-submit {
+        margin-top: 1rem;
+    }
+
+    .centered {
+        display: flex;
+        justify-content: center;
+    }
+}

--- a/src/settings/UrlStorage.ts
+++ b/src/settings/UrlStorage.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SETTINGS: Settings = {
     newStops: [],
     dashboard: '',
     coordinates: undefined,
+    owner: null,
 }
 
 const VERSION_PREFIX_REGEX = /^v(\d)+::/

--- a/src/settings/UrlStorage.ts
+++ b/src/settings/UrlStorage.ts
@@ -13,7 +13,7 @@ export const DEFAULT_SETTINGS: Settings = {
     newStops: [],
     dashboard: '',
     coordinates: undefined,
-    owner: null,
+    owner: '',
 }
 
 const VERSION_PREFIX_REGEX = /^v(\d)+::/

--- a/src/settings/UrlStorage.ts
+++ b/src/settings/UrlStorage.ts
@@ -13,7 +13,7 @@ export const DEFAULT_SETTINGS: Settings = {
     newStops: [],
     dashboard: '',
     coordinates: undefined,
-    owner: '',
+    owners: [],
 }
 
 const VERSION_PREFIX_REGEX = /^v(\d)+::/

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -29,7 +29,7 @@ export interface Settings {
     newStations?: string[]
     newStops?: string[]
     dashboard?: string | void
-    owner?: string
+    owners?: string[]
 }
 
 interface SettingsSetters {
@@ -41,7 +41,7 @@ interface SettingsSetters {
     setNewStations: (newStations: string[]) => void
     setNewStops: (newStops: string[]) => void
     setDashboard: (dashboard: string) => void
-    setOwner: (owner: string) => void
+    setOwners: (owners: string[]) => void
 }
 
 export const SettingsContext = createContext<
@@ -57,7 +57,7 @@ export const SettingsContext = createContext<
         setNewStations: (): void => undefined,
         setNewStops: (): void => undefined,
         setDashboard: (): void => undefined,
-        setOwner: (): void => undefined,
+        setOwners: (): void => undefined,
     },
 ])
 
@@ -171,9 +171,9 @@ export function useSettings(): [Settings, SettingsSetters] {
         [set],
     )
 
-    const setOwner = useCallback(
-        (owner: string): void => {
-            set('owner', owner)
+    const setOwners = useCallback(
+        (owners: string[]): void => {
+            set('owners', owners)
         },
         [set],
     )
@@ -187,7 +187,7 @@ export function useSettings(): [Settings, SettingsSetters] {
         setNewStations,
         setNewStops,
         setDashboard,
-        setOwner,
+        setOwners,
     }
 
     return [settings, setters]

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -29,6 +29,7 @@ export interface Settings {
     newStations?: string[]
     newStops?: string[]
     dashboard?: string | void
+    owner?: string
 }
 
 interface SettingsSetters {
@@ -40,6 +41,7 @@ interface SettingsSetters {
     setNewStations: (newStations: string[]) => void
     setNewStops: (newStops: string[]) => void
     setDashboard: (dashboard: string) => void
+    setOwner: (owner: string) => void
 }
 
 export const SettingsContext = createContext<
@@ -55,6 +57,7 @@ export const SettingsContext = createContext<
         setNewStations: (): void => undefined,
         setNewStops: (): void => undefined,
         setDashboard: (): void => undefined,
+        setOwner: (): void => undefined,
     },
 ])
 
@@ -168,6 +171,13 @@ export function useSettings(): [Settings, SettingsSetters] {
         [set],
     )
 
+    const setOwner = useCallback(
+        (owner: string): void => {
+            set('owner', owner)
+        },
+        [set],
+    )
+
     const setters = {
         setHiddenStations,
         setHiddenStops,
@@ -177,6 +187,7 @@ export function useSettings(): [Settings, SettingsSetters] {
         setNewStations,
         setNewStops,
         setDashboard,
+        setOwner,
     }
 
     return [settings, setters]


### PR DESCRIPTION
It is now possible to "lock" a tavle to a user. The locking functionality can be found in the menu. This pull-request only handles that a tavle is owned by a user, not that other users is unable to edit the tavle. It is still possible to force browse to the admin panel, and change a tavle that is locked - this feature will come in another pull request.

The menu is updated with the following buttons: "Rediger", "Endre visning", "Logg inn", "Lås tavle" and "Logg ut", they will displayed when appropriate, depending on whether the tavle is locked or not, or if the user is logged in or not. Another PR will come with menu design changes.

Also; the owner field on a tavle is a list of strings (uid), so that in the feature, it will be easy to support a scenario where a tavle can be owned by multiple users.