### PR TITLE
Fixed buttons and tabs for legacy tavler

### DIFF
--- a/src/containers/Admin/LogoTab/index.tsx
+++ b/src/containers/Admin/LogoTab/index.tsx
@@ -3,11 +3,14 @@ import { Heading2, Paragraph } from '@entur/typography'
 import LoginModal from '../LoginModal'
 import { useFirebaseAuthentication } from '../../../auth'
 import { User } from 'firebase/app'
+import { getDocumentId } from '../../../utils'
 
 const LogoTab = ({ tabIndex, setTabIndex }: Props): JSX.Element => {
     const [open, setOpen] = useState<boolean>(false)
     const user = useFirebaseAuthentication()
     const [isLoggedIn, setIsLoggedIn] = useState<boolean>()
+
+    const documentId = getDocumentId()
 
     useEffect((): void => {
         if (tabIndex === 1 && user && user.isAnonymous) {
@@ -24,6 +27,18 @@ const LogoTab = ({ tabIndex, setTabIndex }: Props): JSX.Element => {
             setOpen(false)
             setTabIndex()
         }
+    }
+
+    if (!documentId) {
+        return (
+            <div>
+                <Heading2>Last opp logo</Heading2>
+                <Paragraph>
+                    Vi har oppgradert tavla. Ønsker du tilgang på denne
+                    funksjonaliteten må du lage en ny tavle.
+                </Paragraph>
+            </div>
+        )
     }
 
     return (

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -96,7 +96,7 @@ function BottomMenu({ className, history }: Props): JSX.Element {
         [history, documentId],
     )
 
-    const lockingButton = settings.owners.length === 0 && (
+    const lockingButton = settings.owners.length === 0 && documentId && (
         <MenuButton
             title="Lås tavle"
             icon={<OpenedLockIcon size={21} />}
@@ -111,7 +111,8 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     )
 
     const logoutButton =
-        user && !user.isAnonymous ? (
+        documentId &&
+        (user && !user.isAnonymous ? (
             <MenuButton
                 title="Logg ut"
                 icon={<LogOutIcon size={21} />}
@@ -130,7 +131,7 @@ function BottomMenu({ className, history }: Props): JSX.Element {
                 icon={<UserIcon size={21} />}
                 callback={(): void => setLoginModalOpen(true)}
             />
-        )
+        ))
 
     const editButton = (settings.owners.length === 0 ||
         (user && settings.owners.includes(user.uid))) && (

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -112,6 +112,7 @@ export function useSettings(): [Settings, SettingsSetters] {
 
         setSettings({
             ...restoreFromUrl(),
+            owners: [],
             coordinates: {
                 latitude: Number(positionArray[0]),
                 longitude: Number(positionArray[1]),


### PR DESCRIPTION
Legacy tavler cannot see lock and log in buttons on menu, and is notified to upgrade to new tavle on the logo page in admin