### PR TITLE
Fjernet feilmeldingsside idet Admin laster opp og permission er `null`

### DIFF
--- a/src/logic/usePermittedTavle.tsx
+++ b/src/logic/usePermittedTavle.tsx
@@ -4,7 +4,7 @@ import { useUser } from '../auth'
 import { getSettings } from '../services/firebase'
 
 export default function usePermittedTavle(): boolean {
-    const [permitted, setPermission] = useState<boolean>(false)
+    const [permitted, setPermission] = useState<boolean>()
     const documentId = getDocumentId()
     const user = useUser()
 
@@ -19,7 +19,6 @@ export default function usePermittedTavle(): boolean {
                 )
             })
         }
-        setPermission(false)
     }, [documentId, user, setPermission])
-    return permitted ? permitted : null
+    return permitted
 }

--- a/src/routers/PrivateRoute/index.tsx
+++ b/src/routers/PrivateRoute/index.tsx
@@ -17,7 +17,7 @@ function PrivateRoute({
     if (!getDocumentId())
         return <Route path={path} exact={exact} component={component} />
 
-    if (!user) return null
+    if (!user || permitted == null) return null
 
     return permitted ? (
         <Route path={path} exact={exact} component={component} />

--- a/src/routers/PrivateRoute/index.tsx
+++ b/src/routers/PrivateRoute/index.tsx
@@ -17,7 +17,7 @@ function PrivateRoute({
     if (!getDocumentId())
         return <Route path={path} exact={exact} component={component} />
 
-    if (!user || permitted == null) return null
+    if (!user || permitted == undefined) return null
 
     return permitted ? (
         <Route path={path} exact={exact} component={component} />


### PR DESCRIPTION
Å sjekke etter lovlig tilgang til Admin burde nå være ganske usynlig.