### PR TITLE
Remove unused imports

### DIFF
--- a/src/containers/Admin/DashboardPickerTab/index.tsx
+++ b/src/containers/Admin/DashboardPickerTab/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback } from 'react'
 import { Heading2 } from '@entur/typography'
 
 import './styles.scss'

--- a/src/containers/Admin/EditTab/StopPlacePanel/PanelRow/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/PanelRow/index.tsx
@@ -27,7 +27,7 @@ const PanelRow = ({
 
     const header = (
         <div className="stop-place-panel__row__header">
-            <span onClick={(event) => event.stopPropagation()}>
+            <span onClick={(event): void => event.stopPropagation()}>
                 <Checkbox
                     id={id}
                     className="stop-place-panel__row__checkbox"
@@ -36,7 +36,7 @@ const PanelRow = ({
                 />
             </span>
             <span>{name}</span>
-            <span onClick={(event) => event.stopPropagation()}>
+            <span onClick={(event): void => event.stopPropagation()}>
                 {uniqueModes.map((mode) => (
                     <TravelSwitch
                         key={mode}

--- a/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
@@ -88,7 +88,7 @@ function StopPlacePanel(props: Props): JSX.Element {
                 <div className="stop-place-panel__header">
                     <div
                         className="stop-place-panel__checkall"
-                        onClick={(event) => event.stopPropagation()}
+                        onClick={(event): void => event.stopPropagation()}
                     >
                         <Checkbox
                             id="check-all-stop-places"

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -70,7 +70,7 @@ const EditTab = (): JSX.Element => {
             },
         )
 
-        return () => {
+        return (): void => {
             ignoreResponse = true
         }
     }, [nearestPlaces, nearestStopPlaceIds, newStops])
@@ -94,7 +94,7 @@ const EditTab = (): JSX.Element => {
             setStations(sortedStations)
         })
 
-        return () => {
+        return (): void => {
             ignoreResponse = true
         }
     }, [nearestPlaces, newStations])
@@ -134,7 +134,7 @@ const EditTab = (): JSX.Element => {
                     <div className="edit-tab__header">
                         <Heading2>Kollektiv</Heading2>
                         <Switch
-                            onChange={() => toggleMode('kollektiv')}
+                            onChange={(): void => toggleMode('kollektiv')}
                             checked={!hiddenModes.includes('kollektiv')}
                             size="large"
                         />
@@ -153,7 +153,7 @@ const EditTab = (): JSX.Element => {
                     <div className="edit-tab__header">
                         <Heading2>Bysykkel</Heading2>
                         <Switch
-                            onChange={() => toggleMode('bysykkel')}
+                            onChange={(): void => toggleMode('bysykkel')}
                             checked={!hiddenModes.includes('bysykkel')}
                             size="large"
                         />

--- a/src/containers/Admin/ThemeTab/index.tsx
+++ b/src/containers/Admin/ThemeTab/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { RadioGroup, Radio } from '@entur/form'
 import { Heading2, Paragraph } from '@entur/typography'
 
 import { useSettingsContext } from '../../../settings'
@@ -17,7 +16,7 @@ import { getDocumentId } from '../../../utils'
 const ThemeTab = (): JSX.Element => {
     const [radioValue, setRadioValue] = useState<Theme>(null)
     const [settings, { setTheme }] = useSettingsContext()
-    const { themeContext, setThemeContext } = useTheme()
+    const { setThemeContext } = useTheme()
     const documentId = getDocumentId()
 
     useEffect(() => {

--- a/src/containers/Admin/index.tsx
+++ b/src/containers/Admin/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Button } from '@entur/button'
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@entur/tab'
 import { ClosedLockIcon } from '@entur/icons'

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -29,7 +29,9 @@ analytics.set('anonymizeIp', true)
 analytics.set('page', window.location.pathname)
 analytics.pageview(window.location.pathname)
 
-function getDashboardComponent(dashboardKey?: string | void) {
+function getDashboardComponent(
+    dashboardKey?: string | void,
+): (props: Props) => JSX.Element {
     switch (dashboardKey) {
         case 'Timeline':
             return Timeline

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -1,17 +1,11 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
 import { useParams } from 'react-router-dom'
-import { Heading3, Paragraph } from '@entur/typography'
 import {
-    EditIcon,
     ConfigurationIcon,
-    CheckIcon,
     OpenedLockIcon,
     LogOutIcon,
     UserIcon,
 } from '@entur/icons'
-import { Modal } from '@entur/modal'
-import { Button } from '@entur/button'
-import { colors } from '@entur/tokens'
 import { useToast } from '@entur/alert'
 
 import firebase from 'firebase'

--- a/src/containers/DashboardWrapper/UpgradeTavlaBanner/index.tsx
+++ b/src/containers/DashboardWrapper/UpgradeTavlaBanner/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { NewIcon } from '@entur/icons'
 import './styles.scss'
-import { Link } from 'react-router-dom'
 import { getDocumentId } from '../../../utils'
 
 const UpgradeTavlaBanner = (): JSX.Element => {

--- a/src/containers/Error/index.tsx
+++ b/src/containers/Error/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { PrimaryButton } from '@entur/button'
 

--- a/src/containers/ThemeWrapper/ThemeContrastWrapper.tsx
+++ b/src/containers/ThemeWrapper/ThemeContrastWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { Contrast } from '@entur/layout'
 

--- a/src/containers/ThemeWrapper/ThemeProvider.tsx
+++ b/src/containers/ThemeWrapper/ThemeProvider.tsx
@@ -10,12 +10,12 @@ type ThemeContextType = {
 
 const ThemeContext = React.createContext<ThemeContextType>({
     themeContext: undefined,
-    setThemeContext: () => {
+    setThemeContext: (): void => {
         return
     },
 })
 
-const ThemeProvider: FC = (props) => {
+const ThemeProvider: FC = (props): JSX.Element => {
     const [settings] = useSettingsContext()
     const [themeContext, setThemeContext] = useState<Theme>(undefined)
 
@@ -25,9 +25,10 @@ const ThemeProvider: FC = (props) => {
         }
     }, [settings, themeContext])
 
-    const contextValue = useMemo(() => ({ themeContext, setThemeContext }), [
-        themeContext,
-    ])
+    const contextValue = useMemo(
+        (): ThemeContextType => ({ themeContext, setThemeContext }),
+        [themeContext],
+    )
     return (
         <div className={`${themeContext}-theme`}>
             <ThemeContext.Provider value={contextValue} {...props} />
@@ -35,7 +36,7 @@ const ThemeProvider: FC = (props) => {
     )
 }
 
-export const useTheme = () => {
+export const useTheme = (): ThemeContextType => {
     return React.useContext(ThemeContext)
 }
 

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { LegMode } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 
 import {

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { LegMode } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 
 import {

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -19,7 +19,7 @@ function onLayoutChange(layouts: Layouts, key: string): void {
     saveToLocalStorage(key, layouts)
 }
 
-function getDataGrid(index: number) {
+function getDataGrid(index: number): { [key: string]: number } {
     return {
         w: 1,
         maxW: 1,
@@ -76,7 +76,10 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     layouts={localStorageLayout}
                     compactType="horizontal"
                     isResizable={true}
-                    onLayoutChange={(layout: Layout[], layouts: Layouts) => {
+                    onLayoutChange={(
+                        layout: Layout[],
+                        layouts: Layouts,
+                    ): void => {
                         if (numberOfStopPlaces > 0) {
                             onLayoutChange(layouts, dashboardKey)
                         }

--- a/src/logic/useNearestPlaces.ts
+++ b/src/logic/useNearestPlaces.ts
@@ -23,7 +23,7 @@ export default function useNearestPlaces(
                 setNearestPlaces(places)
             })
 
-        return () => {
+        return (): void => {
             ignoreResponse = true
         }
     }, [distance, position])

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo } from 'react'
-import { LegMode } from '@entur/sdk'
 
 import { StopPlaceWithDepartures } from '../types'
 import {


### PR DESCRIPTION
Fikser en haug med warnings i konsollen (alle unntatt de som angår `any`-typings). Hovedsaklig imports som ikke blir brukt og manglende return types.