### PR TITLE
Fix tile gradient

### DIFF
--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -93,7 +93,8 @@
         bottom: 0;
         margin: 0 40%;
         border-radius: 50vh;
-        background-color: rgba(255, 255, 255, 0.7);
+        background-color: var(--tavla-font-color);
+        opacity: 0.7;
         transition: bottom 0.3s;
     }
 

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -33,12 +33,9 @@
         width: 100%;
         height: 50px;
         bottom: 0;
-        background: linear-gradient(
-            0deg,
-            rgba(var(--tavla-box-background-color), 1) 0%,
-            rgba(var(--tavla-box-background-color), 0.7) 50%,
-            rgba(var(--tavla-box-background-color), 0) 100%
-        );
+        background-color: var(--tavla-box-background-color);
+        mask-image: linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 70%, rgba(0, 0, 0, 1) 100%);
+        -webkit-mask-image: -webkit-linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 70%, rgba(0, 0, 0, 1) 100%);
         z-index: 1;
     }
 


### PR DESCRIPTION
- Ser at gradienten på bunnen av tiles har forsvunnet fordi man ikke kan sette opacity på CSS variabler. Løste dette ved å bruke en maske istedet. Det ser ut som om det er _grei_ støtte for `-webkit-mask-image` i browsere https://caniuse.com/#search=mask-image
- Oppdaterte også fargen på `.react-resizable-handle`

Fixes atb-as/tavla#31