### PR TITLE
Outline fixes

### DIFF
--- a/src/components/LoginModal/CloseButton/styles.scss
+++ b/src/components/LoginModal/CloseButton/styles.scss
@@ -11,6 +11,7 @@
     font-size: inherit;
     font-weight: inherit;
     margin-left: auto;
+    outline: none;
 
     .icon {
         margin-right: 0.5rem;

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -72,6 +72,10 @@
     background-color: var(--tavla-background-color);
 }
 
+.eds-tab:focus {
+    box-shadow: none;
+}
+
 @media (min-width: 600px) {
     .admin {
         padding-bottom: 8rem;


### PR DESCRIPTION
Har sett et par outlines/box-shadows som ikke ser så fine ut i admin-interfacet. Forslag om å fjerne disse.

Før:
![Screenshot 2020-07-29 at 15 29 50](https://user-images.githubusercontent.com/1774972/88806319-8e4bc100-d1b0-11ea-8258-06a98d30032c.png)
![Screenshot 2020-07-29 at 15 30 13](https://user-images.githubusercontent.com/1774972/88806323-8ee45780-d1b0-11ea-90d8-aa7bc7aa76b1.png)

Etter:
![Screenshot 2020-07-29 at 15 31 53](https://user-images.githubusercontent.com/1774972/88806431-b20f0700-d1b0-11ea-9419-5d82b617cf5d.png)
![Screenshot 2020-07-29 at 15 32 02](https://user-images.githubusercontent.com/1774972/88806435-b2a79d80-d1b0-11ea-8a0c-6149112c2f89.png)
