### PR TITLE
Fix floating buttons for Safari

### DIFF
--- a/src/containers/Admin/FloatingButtons/styles.scss
+++ b/src/containers/Admin/FloatingButtons/styles.scss
@@ -12,6 +12,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        line-height: 0.25rem;
 
         &.eds-button--variant-primary {
             background: var(--floating-button-primary-background);


### PR DESCRIPTION
Ser at teksten i `FloatingButtons` er litt dårlig alignet i Safari. Å sette en line-height fikser problemet. Har ingen god forklaring på hvorfor 0.25rem var det som passet best, men det er "midt på" i Safari, og det påvirker ikke andre nettlesere.

### Før
![Screenshot 2020-07-30 at 10 48 07](https://user-images.githubusercontent.com/1774972/88903157-8002b100-d253-11ea-96c1-359e69140455.png)

### Etter
![Screenshot 2020-07-30 at 10 48 20](https://user-images.githubusercontent.com/1774972/88903154-7ed18400-d253-11ea-9256-8c5b41a7f342.png)
