### PR TITLE
Fix BottomMenu padding issue on dashboard

### DIFF
--- a/src/containers/DashboardWrapper/index.tsx
+++ b/src/containers/DashboardWrapper/index.tsx
@@ -69,12 +69,12 @@ function DashboardWrapper(props: Props): JSX.Element {
         <ThemeContrastWrapper useContrast={isDarkOrDefaultTheme(theme)}>
             <div className={`dashboard-wrapper ${className}`}>
                 {renderContents()}
+                {logo && (
+                    <div className="dashboard-wrapper__byline">
+                        Tjenesten leveres av {getEnturLogo()}
+                    </div>
+                )}
                 <ThemeContrastWrapper useContrast={true}>
-                    {logo && (
-                        <div className="dashboard-wrapper__byline">
-                            Tjenesten leveres av {getEnturLogo()}
-                        </div>
-                    )}
                     <BottomMenu
                         className="dashboard-wrapper__bottom-menu"
                         history={history}


### PR DESCRIPTION
When the byline is the first element of the wrapper, it breaks the [`.bottom-menu:first-child` rule in BottomMenu/styles.scss](https://github.com/entur/tavla/blob/master/src/containers/DashboardWrapper/BottomMenu/styles.scss#L19). This means the left padding looks slightly off when byline is visible.

### Before
![Screenshot 2020-08-06 at 14 32 14](https://user-images.githubusercontent.com/1774972/89532852-c1b2cf00-d7f2-11ea-8da0-99df89f71a45.png)

### After
![Screenshot 2020-08-06 at 14 31 47](https://user-images.githubusercontent.com/1774972/89532855-c2e3fc00-d7f2-11ea-8819-4c8d78b502e3.png)

