### PR TITLE
Reduce a lot of unnecessary calls to JourneyPlanner when on admin

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -150,7 +150,12 @@ export function useSettings(): [Settings | null, SettingsSetters] {
                     })
                 }
 
-                setSettings(settingsWithDefaults)
+                setSettings((prevSettings) => {
+                    const onAdmin = location.pathname.split('/')[1] === 'admin'
+                    return prevSettings && onAdmin
+                        ? prevSettings
+                        : settingsWithDefaults
+                })
             })
         }
 


### PR DESCRIPTION
When editing some setting on the admin page, the new settings is persisted to Firestore.
When something is edited on Firestore, this triggers a new onSnapshot call.
The new snapshot call sets a new Settings object, although nothing is really changed.
This triggers a bunch of hooks that fetches new data.

This PR fixes this by ignoring the onSnapshot setter when on admin