### PR TITLE
Fix a bug in the handle of the chrono view

### DIFF
--- a/src/dashboards/Chrono/styles.scss
+++ b/src/dashboards/Chrono/styles.scss
@@ -9,6 +9,7 @@
 
         .tile {
             width: 100%;
+            height: 100%;
             max-height: 75vh;
             overflow-y: scroll;
         }
@@ -54,6 +55,50 @@
 
     .react-grid-item.dropping {
         visibility: hidden;
+    }
+
+    .react-grid-item.react-grid-placeholder {
+        background: var(--tavla-border-color);
+        opacity: 0.2;
+        transition-duration: 100ms;
+        z-index: 2;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        -o-user-select: none;
+        user-select: none;
+    }
+
+    .react-grid-item > .react-resizable-handle {
+        position: absolute;
+        width: 100%;
+        height: 30px;
+        bottom: 0;
+        cursor: ns-resize;
+        z-index: 2;
+        opacity: 0;
+        transition: opacity 0.3s;
+    }
+
+    .react-grid-item:hover > .react-resizable-handle {
+        opacity: 1;
+    }
+
+    .react-grid-item > .react-resizable-handle::after {
+        content: '';
+        position: absolute;
+        width: 20%;
+        height: 0.25rem;
+        bottom: 0;
+        margin: 0 40%;
+        border-radius: 50vh;
+        background-color: var(--tavla-font-color);
+        opacity: 0.7;
+        transition: bottom 0.3s;
+    }
+
+    .react-grid-item:hover > .react-resizable-handle::after {
+        bottom: 0.5rem;
     }
 }
 


### PR DESCRIPTION
There was bug in the chrono view where the handle was gone, and trying to drag one departure card vertically would increase the height of all the departure cards. There was some css that probably got lost in some merge that I've put back so that everything is working as expected. 
![image](https://user-images.githubusercontent.com/22595827/97185446-5993d980-17a0-11eb-968c-4dc1cf29082d.png)
