### PR TITLE
Remove some code that reintroduces the fade on the map tile in compact view.

### DIFF
--- a/src/dashboards/Timeline/styles.scss
+++ b/src/dashboards/Timeline/styles.scss
@@ -80,60 +80,6 @@
     }
 }
 
-.react-grid-layout {
-    position: relative;
-    transition: height 200ms ease;
-}
-
-.react-grid-item {
-    transition: all 200ms ease;
-    transition-property: left, top;
-    z-index: 1;
-}
-
-.react-grid-item::after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    height: 50px;
-    bottom: 0;
-    background-color: var(--tavla-box-background-color);
-    mask-image: linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 70%, rgba(0, 0, 0, 1) 100%);
-    -webkit-mask-image: -webkit-linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 70%, rgba(0, 0, 0, 1) 100%);
-    z-index: 1;
-}
-
-.react-grid-item.cssTransforms {
-    transition-property: transform;
-}
-
-.react-grid-item.resizing {
-    z-index: 1;
-    will-change: width, height;
-}
-
-.react-grid-item.react-draggable-dragging {
-    transition: none;
-    z-index: 3;
-    will-change: transform;
-}
-
-.react-grid-item.dropping {
-    visibility: hidden;
-}
-
-.react-grid-item.react-grid-placeholder {
-    background: var(--tavla-border-color);
-    opacity: 0.2;
-    transition-duration: 100ms;
-    z-index: 2;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -o-user-select: none;
-    user-select: none;
-}
-
 @keyframes pulse {
     0% {
         transform: scale(1);


### PR DESCRIPTION
In a previous PR some .react-grid-layout css was added to the timeline stylesheet. There are no react grid items in the timeline view, so all happened was that the fade on the bottom of the map tile was reintroduced. This PR removes that code.