### PR TITLE
Added clustering to map component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3194,8 +3194,7 @@
         "@types/geojson": {
             "version": "7946.0.7",
             "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-            "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
-            "dev": true
+            "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
         },
         "@types/glob": {
             "version": "7.1.3",
@@ -3362,11 +3361,27 @@
                 "@types/react-router": "*"
             }
         },
+        "@types/supercluster": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-5.0.2.tgz",
+            "integrity": "sha512-5PONNyiZXHS6oiW0H1rsNQ+Apkg+cqp3jP4HRhCAcgASIj3ifrFsdj1QB5TvArqT5N8RetK6UH7873COgRZwoQ==",
+            "requires": {
+                "@types/geojson": "*"
+            }
+        },
         "@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
             "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
             "dev": true
+        },
+        "@types/use-deep-compare-effect": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@types/use-deep-compare-effect/-/use-deep-compare-effect-1.2.0.tgz",
+            "integrity": "sha512-2uNqaSobMvUTGR7G72tUHDX+Kx341q25OuM0m2B6VID7eljIvYuDaFTKfmDnbvej67yEhCc35zA6dmIYriwOXA==",
+            "requires": {
+                "@types/react": "*"
+            }
         },
         "@types/viewport-mercator-project": {
             "version": "6.1.1",
@@ -6205,6 +6220,11 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
+        },
+        "dequal": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+            "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
         },
         "des.js": {
             "version": "1.0.1",
@@ -10860,6 +10880,16 @@
                 "supercluster": "^7.1.0",
                 "tinyqueue": "^2.0.3",
                 "vt-pbf": "^3.1.1"
+            },
+            "dependencies": {
+                "supercluster": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
+                    "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
+                    "requires": {
+                        "kdbush": "^3.0.0"
+                    }
+                }
             }
         },
         "markdown-escapes": {
@@ -15888,9 +15918,9 @@
             }
         },
         "supercluster": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
-            "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+            "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
             "requires": {
                 "kdbush": "^3.0.0"
             }
@@ -17076,6 +17106,16 @@
             "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.4.tgz",
             "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ=="
         },
+        "use-deep-compare-effect": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.4.0.tgz",
+            "integrity": "sha512-46rF7ULcRnxI4+1Zoul95+KB48hpn1MUH1aXEBMyU+Sh1KJDqrTAkwhnxQL6ydBAqu3gLebYylcr0zpVBzbxxQ==",
+            "requires": {
+                "@babel/runtime": "^7.11.2",
+                "@types/use-deep-compare-effect": "^1.2.0",
+                "dequal": "^2.0.2"
+            }
+        },
         "use-sidecar": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.3.tgz",
@@ -17083,6 +17123,15 @@
             "requires": {
                 "detect-node-es": "^1.0.0",
                 "tslib": "^1.9.3"
+            }
+        },
+        "use-supercluster": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/use-supercluster/-/use-supercluster-0.2.9.tgz",
+            "integrity": "sha512-nHGS/InkCtM0l1oNmy02LwdH2325rIZNgl5eexUStoyjhUJZejVK3WfgaAKJTjRseeipaVtV9GVDgGXIVCn9yw==",
+            "requires": {
+                "dequal": "^2.0.2",
+                "use-deep-compare-effect": "^1.4.0"
             }
         },
         "util": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@entur/typography": "^1.4.1",
         "@n8tb1t/use-scroll-position": "^1.0.47",
         "@react-hook/window-size": "^3.0.7",
+        "@types/supercluster": "^5.0.2",
         "connect-history-api-fallback": "^1.6.0",
         "copy-to-clipboard": "^3.3.1",
         "date-fns": "^2.16.1",
@@ -61,7 +62,9 @@
         "react-map-gl": "^4.1.6",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
-        "universal-ga": "^1.2.0"
+        "supercluster": "^6.0.0",
+        "universal-ga": "^1.2.0",
+        "use-supercluster": "^0.2.9"
     },
     "devDependencies": {
         "@babel/cli": "^7.11.6",

--- a/src/assets/icons/scooterOperatorLogo.tsx
+++ b/src/assets/icons/scooterOperatorLogo.tsx
@@ -33,7 +33,7 @@ function ScooterOperatorLogo({
 }
 
 interface Props {
-    logo: ScooterOperator
+    logo: ScooterOperator | null
     className?: string
     size?: number
 }

--- a/src/components/Map/ScooterMarkerTag/index.tsx
+++ b/src/components/Map/ScooterMarkerTag/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { ScooterIcon } from '@entur/icons'
+
+import { ScooterOperator } from '@entur/sdk'
+
+import ScooterOperatorLogo from '../../../assets/icons/scooterOperatorLogo'
+
+import './styles.scss'
+
+const ScooterMarkerTag = ({ pointCount, operator }: Props): JSX.Element => {
+    return pointCount ? (
+        <div className="cluster-marker">
+            <ScooterIcon className="scooter-icon"></ScooterIcon>
+            <div className="point-count">
+                {pointCount < 10 ? pointCount : `${pointCount}+`}
+            </div>
+        </div>
+    ) : (
+        <ScooterOperatorLogo logo={operator} size={24}></ScooterOperatorLogo>
+    )
+}
+
+interface Props {
+    pointCount: number
+    operator: ScooterOperator | null
+}
+
+export default ScooterMarkerTag

--- a/src/components/Map/ScooterMarkerTag/styles.scss
+++ b/src/components/Map/ScooterMarkerTag/styles.scss
@@ -1,0 +1,29 @@
+@import '../../../assets/styles/import.scss';
+@import '../../../variables.scss';
+
+.cluster-marker {
+    color: var(--tavla-background-color);
+    background: #fff;
+    border: 2px;
+    border-color: black;
+    border-radius: 0.75rem;
+    padding: 0.25rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: auto;
+    height: 1.5rem;
+}
+
+.scooter-icon {
+    height: 1rem;
+    color: $colors-transport-default-mobility;
+    margin: 0.25rem;
+}
+
+.point-count {
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-right: 0.5rem;
+    margin-top: 0.1rem;
+}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,15 +1,18 @@
 import { BikeRentalStation, Scooter } from '@entur/sdk'
-import React, { useState, memo } from 'react'
+import React, { useState, memo, useRef } from 'react'
 
-import ReactMapGL, { Marker } from 'react-map-gl'
+import ReactMapGL, { InteractiveMap, Marker } from 'react-map-gl'
+import useSupercluster from 'use-supercluster'
+
+import { ClusterProperties } from 'supercluster'
 
 import PositionPin from '../../assets/icons/positionPin'
-import ScooterOperatorLogo from '../../assets/icons/scooterOperatorLogo'
 
 import { StopPlaceWithDepartures } from '../../types'
 
 import BikeRentalStationTag from './BikeRentalStationTag'
 import StopPlaceTag from './StopPlaceTag'
+import ScooterMarkerTag from './ScooterMarkerTag'
 
 const Map = ({
     stopPlaces,
@@ -31,6 +34,73 @@ const Map = ({
         maxZoom: 18,
         minZoom: 13.5,
     })
+    const mapRef = useRef<InteractiveMap>(null)
+    const scooterpoints = scooters?.map((scooter: Scooter) => ({
+        type: 'Feature' as 'Feature',
+        properties: {
+            cluster: false,
+            scooterId: scooter.id,
+            scooterOperator: scooter.operator,
+        },
+        geometry: {
+            type: 'Point' as 'Point',
+            coordinates: [scooter.lon, scooter.lat],
+        },
+    }))
+    const bikeRentalStationPoints = bikeRentalStations?.map(
+        (bikeRentalStation: BikeRentalStation) => ({
+            type: 'Feature' as 'Feature',
+            properties: {
+                cluster: false,
+                stationId: bikeRentalStation.id,
+                bikesAvailable: bikeRentalStation.bikesAvailable,
+                spacesAvailable: bikeRentalStation.spacesAvailable,
+            },
+            geometry: {
+                type: 'Point' as 'Point',
+                coordinates: [
+                    bikeRentalStation.longitude,
+                    bikeRentalStation.latitude,
+                ],
+            },
+        }),
+    )
+    viewport.zoom
+    const bounds = mapRef.current
+        ? (mapRef.current.getMap().getBounds().toArray().flat() as [
+              number,
+              number,
+              number,
+              number,
+          ])
+        : ([0, 0, 0, 0] as [number, number, number, number])
+
+    const { clusters: scooterClusters } = useSupercluster({
+        points: scooterpoints ? scooterpoints : [],
+        bounds,
+        zoom: viewport.zoom,
+        options: { radius: 38, maxZoom: 18 },
+    })
+
+    const { clusters: stationClusters } = useSupercluster({
+        points: bikeRentalStationPoints ? bikeRentalStationPoints : [],
+        bounds,
+        zoom: viewport.zoom,
+        options: {
+            radius: 45,
+            maxZoom: 18,
+            map: (props): {} => ({
+                bikesAvailable: props.bikesAvailable,
+                spacesAvailable: props.spacesAvailable,
+            }),
+            reduce: (acc, props): {} => {
+                acc.bikesAvailable += props.bikesAvailable
+                acc.spacesAvailable += props.spacesAvailable
+                return acc
+            },
+        },
+    })
+
     return (
         <ReactMapGL
             {...viewport}
@@ -56,16 +126,42 @@ const Map = ({
                       }
                     : undefined
             }
+            ref={mapRef}
         >
-            {scooters?.map((scooter) => (
-                <Marker
-                    key={scooter.id}
-                    latitude={scooter.lat}
-                    longitude={scooter.lon}
-                >
-                    <ScooterOperatorLogo logo={scooter.operator} size={24} />
-                </Marker>
-            ))}
+            {scooterClusters.map((scooterCluster) => {
+                const [
+                    slongitude,
+                    slatitude,
+                ] = scooterCluster.geometry.coordinates
+
+                const { cluster: isCluster } = scooterCluster.properties
+                let pointCount = 0
+
+                if (isCluster)
+                    pointCount = (scooterCluster.properties as ClusterProperties)
+                        .point_count
+
+                return (
+                    <Marker
+                        key={
+                            pointCount
+                                ? `cluster-${scooterCluster.id}`
+                                : scooterCluster.properties.scooterId
+                        }
+                        latitude={slatitude}
+                        longitude={slongitude}
+                    >
+                        <ScooterMarkerTag
+                            pointCount={pointCount}
+                            operator={
+                                pointCount
+                                    ? null
+                                    : scooterCluster.properties.scooterOperator
+                            }
+                        ></ScooterMarkerTag>
+                    </Marker>
+                )
+            })}
             {stopPlaces?.map((stopPlace) =>
                 stopPlace.departures.length > 0 ? (
                     <Marker
@@ -90,19 +186,32 @@ const Map = ({
                     []
                 ),
             )}
-            {bikeRentalStations?.map((station) => (
-                <Marker
-                    key={station.id}
-                    latitude={station.latitude}
-                    longitude={station.longitude}
-                    marker-size="large"
-                >
-                    <BikeRentalStationTag
-                        bikes={station.bikesAvailable ?? 0}
-                        spaces={station.spacesAvailable ?? 0}
-                    ></BikeRentalStationTag>
-                </Marker>
-            ))}
+            {stationClusters.map((stationCluster) => {
+                const [
+                    slongitude,
+                    slatitude,
+                ] = stationCluster.geometry.coordinates
+
+                const { cluster: isCluster } = stationCluster.properties
+
+                return (
+                    <Marker
+                        key={
+                            isCluster
+                                ? stationCluster.id
+                                : stationCluster.properties.stationId
+                        }
+                        latitude={slatitude}
+                        longitude={slongitude}
+                        marker-size="large"
+                    >
+                        <BikeRentalStationTag
+                            bikes={stationCluster.properties.bikesAvailable}
+                            spaces={stationCluster.properties.spacesAvailable}
+                        ></BikeRentalStationTag>
+                    </Marker>
+                )
+            })}
             <Marker
                 latitude={viewport.latitude ?? 0}
                 longitude={viewport.longitude ?? 0}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -65,7 +65,6 @@ const Map = ({
             },
         }),
     )
-    viewport.zoom
     const bounds = mapRef.current
         ? (mapRef.current.getMap().getBounds().toArray().flat() as [
               number,
@@ -76,14 +75,14 @@ const Map = ({
         : ([0, 0, 0, 0] as [number, number, number, number])
 
     const { clusters: scooterClusters } = useSupercluster({
-        points: scooterpoints ? scooterpoints : [],
+        points: scooterpoints || [],
         bounds,
         zoom: viewport.zoom,
         options: { radius: 38, maxZoom: 18 },
     })
 
     const { clusters: stationClusters } = useSupercluster({
-        points: bikeRentalStationPoints ? bikeRentalStationPoints : [],
+        points: bikeRentalStationPoints || [],
         bounds,
         zoom: viewport.zoom,
         options: {
@@ -137,9 +136,10 @@ const Map = ({
                 const { cluster: isCluster } = scooterCluster.properties
                 let pointCount = 0
 
-                if (isCluster)
+                if (isCluster) {
                     pointCount = (scooterCluster.properties as ClusterProperties)
                         .point_count
+                }
 
                 return (
                     <Marker

--- a/src/dashboards/Map/index.tsx
+++ b/src/dashboards/Map/index.tsx
@@ -5,6 +5,7 @@ import {
     useStopPlacesWithDepartures,
     useBikeRentalStations,
     useWalkTime,
+    useScooters,
 } from '../../logic'
 
 import MapView from '../../components/Map'
@@ -20,6 +21,7 @@ const MapDashboard = ({ history }: Props): JSX.Element => {
     const stopPlacesWithDepartures = useStopPlacesWithDepartures()
     const bikeRentalStations = useBikeRentalStations()
     const walkTimes = useWalkTime(stopPlacesWithDepartures)
+    const scooters = useScooters()
     const HEADER_MARGIN = 16
     //Used to calculate the height of the viewport for the map
     const headerHeight =
@@ -34,7 +36,7 @@ const MapDashboard = ({ history }: Props): JSX.Element => {
         >
             <div style={{ height: `calc(100vh - ${headerHeight}px)` }}>
                 <MapView
-                    scooters={null}
+                    scooters={scooters}
                     bikeRentalStations={bikeRentalStations}
                     stopPlaces={stopPlacesWithDepartures}
                     walkTimes={walkTimes}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "outDir": "./dist/",
         "sourceMap": true,
         "module": "commonjs",
-        "lib": ["es2017", "dom", "dom.iterable"],
+        "lib": ["es2019", "dom", "dom.iterable"],
         "target": "es5",
         "jsx": "react",
         "esModuleInterop": true,


### PR DESCRIPTION
Added clustering to the map component through the useSupercluster-hook. The casting is because the useSupercluster-hook expects that exact type at those fields. 

It can be tuned by passing an options object. Passing Radius you control how for from coordinates it considers a point overlapping. For example typescript infers `type: 'Feature' as 'Feature',` to be of the type string, but the useSupercluster expects it to be `'Feature'` and only feature.

![image](https://user-images.githubusercontent.com/14358485/98091577-e6682280-1e85-11eb-909d-f73e73f87f27.png)
