### PR TITLE
Default til første element i autosuggest

### DIFF
--- a/src/containers/Admin/EditTab/BikeSearch/index.tsx
+++ b/src/containers/Admin/EditTab/BikeSearch/index.tsx
@@ -58,6 +58,7 @@ const BikePanelSearch = ({ onSelected, position }: Props): JSX.Element => {
                 placeholder="Søk på bysykkelstativ for å legge til"
                 items={getItems}
                 onChange={onItemSelected}
+                highlightFirstItemOnOpen
             />
         </div>
     )

--- a/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
@@ -53,6 +53,7 @@ const SelectionPanelSearch = ({ handleAddNewStop }: Props): JSX.Element => {
                 placeholder="Søk på stoppested for å legge til flere"
                 items={getItems}
                 onChange={onItemSelected}
+                highlightFirstItemOnOpen
             />
         </div>
     )

--- a/src/containers/LandingPage/SearchPanel/index.tsx
+++ b/src/containers/LandingPage/SearchPanel/index.tsx
@@ -166,6 +166,7 @@ const SearchPanel = ({ handleCoordinatesSelected }: Props): JSX.Element => {
                             onChange={onItemSelected}
                             variant={errorMessage ? 'error' : undefined}
                             feedback={errorMessage || ''}
+                            highlightFirstItemOnOpen
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Når autosuggest er åpen bør den default velge første element i lista, slik at man bare kan trykke enter for å velge stedet.

Er støtte for dette fra designsystemet https://design.entur.org/komponenter/skjemaelementer/dropdown

<img width="1488" alt="Screenshot 2021-01-28 at 09 53 34" src="https://user-images.githubusercontent.com/31281040/106113370-b495ed80-614e-11eb-98fb-06e0a2fdd355.png">
