### PR TITLE
Safari bugfix

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -65,14 +65,12 @@ const Map = ({
             },
         }),
     )
-    const bounds = mapRef.current
-        ? (mapRef.current.getMap().getBounds().toArray().flat() as [
-              number,
-              number,
-              number,
-              number,
-          ])
-        : ([0, 0, 0, 0] as [number, number, number, number])
+
+    const bounds = (mapRef.current
+        ?.getMap()
+        ?.getBounds()
+        ?.toArray()
+        ?.flat() || [0, 0, 0, 0]) as [number, number, number, number]
 
     const { clusters: scooterClusters } = useSupercluster({
         points: scooterpoints || [],


### PR DESCRIPTION
`getMap()` was null in certain states, which cased `getBounds()` to crash