### PR TITLE
removed outline on focus for some divs in the admin panel

### DIFF
--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -72,6 +72,11 @@
     background-color: var(--tavla-background-color);
 }
 
+.eds-tab-panel:focus,
+.eds-tab:focus {
+    outline: none;
+}
+
 @media (min-width: 600px) {
     .admin {
         padding-bottom: 8rem;


### PR DESCRIPTION
In the admin panel when switching tabs or selecting colors, a blue outline will be shown around the div in focus. This did not look so nice, so we removed the outlines seen in these screenshots:

Before:
![Screenshot 2021-06-21 at 09 11 21](https://user-images.githubusercontent.com/31273371/122732426-8d19fb80-d27c-11eb-965a-b5abc7181c2b.png)

![Screenshot 2021-06-21 at 09 13 24](https://user-images.githubusercontent.com/31273371/122732429-8e4b2880-d27c-11eb-9a89-5f76e2239bd7.png)

After:
<img width="1596" alt="Screenshot 2021-06-21 at 10 35 16" src="https://user-images.githubusercontent.com/31273371/122732430-8e4b2880-d27c-11eb-8471-9ac189bf30c2.png">

<img width="238" alt="Screenshot 2021-06-21 at 10 35 47" src="https://user-images.githubusercontent.com/31273371/122732432-8ee3bf00-d27c-11eb-9f97-31f89acce357.png">

