### PR TITLE
Make map independent of scooters

### DIFF
--- a/src/dashboards/Compact/MapTile/index.tsx
+++ b/src/dashboards/Compact/MapTile/index.tsx
@@ -20,7 +20,7 @@ function MapTile(data: Props): JSX.Element {
 interface Props {
     stopPlaces: StopPlaceWithDepartures[] | null
     bikeRentalStations: BikeRentalStation[] | null
-    scooters: Scooter[]
+    scooters: Scooter[] | null
     walkTimes: Array<{ stopId: string; walkTime: number }> | null
     latitude: number
     longitude: number

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -67,12 +67,12 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    //const anyScooters = Boolean(scooters && scooters.length)
+    const anyScooters = Boolean(scooters && scooters.length)
 
     const bikeCol = anyBikeRentalStations ? 1 : 0
 
-    //const scooterCol = anyScooters ? 1 : 0
-    // ny
+    const scooterCol = anyScooters ? 1 : 0
+    
     const mapCol =
         bikeRentalStations?.length ||
         scooters?.length ||
@@ -80,7 +80,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
             ? 1
             : 0
 
-    const totalItems = numberOfStopPlaces + bikeCol + mapCol //oppdatert
+    const totalItems = numberOfStopPlaces + bikeCol + mapCol
 
     const cols: { [key: string]: number } = {
         lg: Math.min(totalItems, 4),
@@ -107,7 +107,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     layouts={gridLayouts}
                     isResizable={true}
                     onBreakpointChange={(newBreakpoint: string) => {
-                        setBreakpoint(newBreakpoint), console.log(gridLayouts)
+                        setBreakpoint(newBreakpoint)
                     }}
                     onLayoutChange={(
                         layout: Layout[],
@@ -116,7 +116,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                         if (numberOfStopPlaces > 0) {
                             setGridLayouts(layouts)
                             saveToLocalStorage(dashboardKey, layouts)
-                            console.log(gridLayouts, layouts)
                         }
                     }}
                 >

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -23,6 +23,7 @@ import BikeTile from './BikeTile'
 import MapTile from './MapTile'
 
 import './styles.scss'
+//import { MapController } from 'react-map-gl'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 
@@ -66,13 +67,20 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    const anyScooters = Boolean(scooters && scooters.length)
+    //const anyScooters = Boolean(scooters && scooters.length)
 
     const bikeCol = anyBikeRentalStations ? 1 : 0
 
-    const scooterCol = anyScooters ? 1 : 0
+    //const scooterCol = anyScooters ? 1 : 0
+    // ny
+    const mapCol =
+        bikeRentalStations?.length ||
+        scooters?.length ||
+        stopPlacesWithDepartures?.length
+            ? 1
+            : 0
 
-    const totalItems = numberOfStopPlaces + bikeCol + scooterCol
+    const totalItems = numberOfStopPlaces + bikeCol + mapCol //oppdatert
 
     const cols: { [key: string]: number } = {
         lg: Math.min(totalItems, 4),
@@ -99,7 +107,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     layouts={gridLayouts}
                     isResizable={true}
                     onBreakpointChange={(newBreakpoint: string) => {
-                        setBreakpoint(newBreakpoint)
+                        setBreakpoint(newBreakpoint), console.log(gridLayouts)
                     }}
                     onLayoutChange={(
                         layout: Layout[],
@@ -108,6 +116,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                         if (numberOfStopPlaces > 0) {
                             setGridLayouts(layouts)
                             saveToLocalStorage(dashboardKey, layouts)
+                            console.log(gridLayouts, layouts)
                         }
                     }}
                 >
@@ -145,12 +154,14 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     ) : (
                         []
                     )}
-                    {scooters?.length ? (
+                    {scooters?.length ||
+                    stopPlacesWithDepartures?.length ||
+                    bikeRentalStations?.length ? (
                         <div
                             id="compact-map-tile"
-                            key={numberOfStopPlaces + bikeCol}
+                            key={totalItems - 1}
                             data-grid={getDataGrid(
-                                numberOfStopPlaces + bikeCol,
+                                totalItems - 1,
                                 maxWidthCols,
                             )}
                         >

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -67,12 +67,11 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    const anyScooters = Boolean(scooters && scooters.length)
+    //const anyScooters = Boolean(scooters && scooters.length)
 
     const bikeCol = anyBikeRentalStations ? 1 : 0
 
-    const scooterCol = anyScooters ? 1 : 0
-    
+    //const scooterCol = anyScooters ? 1 : 0
     const mapCol =
         bikeRentalStations?.length ||
         scooters?.length ||


### PR DESCRIPTION
Map is now visible in compact mode independently of whether there are any scooters or not/if scooters are activated. Can now also show only bikes, only scooters and/or only stop places.