### PR TITLE
Make own map box with toggle

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react'
-
 import { BikeRentalStation } from '@entur/sdk'
 import { Heading2 } from '@entur/typography'
 import { GridContainer, GridItem } from '@entur/grid'
@@ -30,8 +29,9 @@ import './styles.scss'
 
 const EditTab = (): JSX.Element => {
     const [settings, settingsSetters] = useSettingsContext()
-    const { newStops, newStations, hiddenModes } = settings || {}
-    const { setNewStops, setNewStations, setHiddenModes } = settingsSetters
+    const { newStops, newStations, hiddenModes, showMap } = settings || {}
+    const { setNewStops, setNewStations, setHiddenModes, setShowMap } =
+        settingsSetters
     const [distance, setDistance] = useState<number>(
         settings?.distance || DEFAULT_DISTANCE,
     )
@@ -147,7 +147,7 @@ const EditTab = (): JSX.Element => {
         <div className="edit-tab">
             <Heading2 className="heading">Rediger innhold</Heading2>
             <GridContainer spacing="extraLarge">
-                <GridItem medium={6} small={12}>
+                <GridItem medium={6} small={12} className="edit-tab__tile">
                     <div className="edit-tab__header">
                         <Heading2>Kollektiv</Heading2>
                         <Switch
@@ -166,7 +166,7 @@ const EditTab = (): JSX.Element => {
                     <StopPlacePanel stops={stopPlaces} />
                 </GridItem>
 
-                <GridItem medium={3} small={12}>
+                <GridItem medium={3} small={12} className="edit-tab__tile">
                     <div className="edit-tab__header">
                         <Heading2>Bysykkel</Heading2>
                         <Switch
@@ -183,20 +183,38 @@ const EditTab = (): JSX.Element => {
                 </GridItem>
 
                 <GridItem medium={3} small={8}>
-                    <div className="edit-tab__header">
-                        <Heading2>Sparkesykkel</Heading2>
-                        <Switch
-                            onChange={(): void => toggleMode('sparkesykkel')}
-                            checked={!hiddenModes?.includes('sparkesykkel')}
-                            size="large"
+                    <div className="edit-tab__tile">
+                        <div className="edit-tab__header">
+                            <Heading2>Sparkesykkel</Heading2>
+                            <Switch
+                                onChange={(): void =>
+                                    toggleMode('sparkesykkel')
+                                }
+                                checked={!hiddenModes?.includes('sparkesykkel')}
+                                size="large"
+                            />
+                        </div>
+                        <ScooterPanel />
+                    </div>
+                    <div className="edit-tab__tile edit-tab__tile__second">
+                        <div className="edit-tab__header">
+                            <Heading2>Kart</Heading2>
+                            <Switch
+                                onChange={(
+                                    event: React.ChangeEvent<HTMLInputElement>,
+                                ): void => {
+                                    setShowMap(event.currentTarget.checked)
+                                }}
+                                checked={showMap}
+                                size="large"
+                            />
+                        </div>
+                        <ZoomEditor
+                            zoom={zoom}
+                            onZoomUpdated={setZoom}
+                            scooters={scooters}
                         />
                     </div>
-                    <ScooterPanel />
-                    <ZoomEditor
-                        zoom={zoom}
-                        onZoomUpdated={setZoom}
-                        scooters={scooters}
-                    />
                 </GridItem>
             </GridContainer>
         </div>

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -5,7 +5,13 @@
     .eds-contrast {
         background: inherit;
     }
-
+    &__tile {
+        padding: 2rem;
+        background-color: var(--tavla-box-background-color);
+        &__second {
+            margin-top: 2rem;
+        }
+    }
     .eds-checkbox-icon {
         background-color: var(--tavla-checkbox-color);
     }
@@ -52,8 +58,6 @@
     }
 
     .eds-grid__item {
-        background-color: var(--tavla-box-background-color);
-        padding: 2rem;
         height: fit-content;
 
         h2 {
@@ -65,6 +69,10 @@
     &__header {
         display: flex;
         justify-content: space-between;
+
+        &--spacing {
+            margin-top: 2rem;
+        }
 
         .eds-switch {
             padding: 0;

--- a/src/dashboards/Compact/MapTile/index.tsx
+++ b/src/dashboards/Compact/MapTile/index.tsx
@@ -20,7 +20,7 @@ function MapTile(data: Props): JSX.Element {
 interface Props {
     stopPlaces: StopPlaceWithDepartures[] | null
     bikeRentalStations: BikeRentalStation[] | null
-    scooters: Scooter[]
+    scooters: Scooter[] | null
     walkTimes: Array<{ stopId: string; walkTime: number }> | null
     latitude: number
     longitude: number

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -23,7 +23,6 @@ import BikeTile from './BikeTile'
 import MapTile from './MapTile'
 
 import './styles.scss'
-//import { MapController } from 'react-map-gl'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 
@@ -67,18 +66,13 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    //const anyScooters = Boolean(scooters && scooters.length)
-
     const bikeCol = anyBikeRentalStations ? 1 : 0
-
-    //const scooterCol = anyScooters ? 1 : 0
-    const mapCol =
+    const hasData = Boolean(
         bikeRentalStations?.length ||
-        scooters?.length ||
-        stopPlacesWithDepartures?.length
-            ? 1
-            : 0
-
+            scooters?.length ||
+            stopPlacesWithDepartures?.length,
+    )
+    const mapCol = hasData ? 1 : 0
     const totalItems = numberOfStopPlaces + bikeCol + mapCol
 
     const cols: { [key: string]: number } = {
@@ -152,9 +146,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     ) : (
                         []
                     )}
-                    {scooters?.length ||
-                    stopPlacesWithDepartures?.length ||
-                    bikeRentalStations?.length ? (
+                    {hasData ? (
                         <div
                             id="compact-map-tile"
                             key={totalItems - 1}

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -67,12 +67,12 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    //const anyScooters = Boolean(scooters && scooters.length)
+    const anyScooters = Boolean(scooters && scooters.length)
 
     const bikeCol = anyBikeRentalStations ? 1 : 0
 
-    //const scooterCol = anyScooters ? 1 : 0
-    // ny
+    const scooterCol = anyScooters ? 1 : 0
+    
     const mapCol =
         bikeRentalStations?.length ||
         scooters?.length ||
@@ -80,7 +80,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
             ? 1
             : 0
 
-    const totalItems = numberOfStopPlaces + bikeCol + mapCol //oppdatert
+    const totalItems = numberOfStopPlaces + bikeCol + mapCol
 
     const cols: { [key: string]: number } = {
         lg: Math.min(totalItems, 4),
@@ -107,7 +107,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     layouts={gridLayouts}
                     isResizable={true}
                     onBreakpointChange={(newBreakpoint: string) => {
-                        setBreakpoint(newBreakpoint), console.log(gridLayouts)
+                        setBreakpoint(newBreakpoint)
                     }}
                     onLayoutChange={(
                         layout: Layout[],
@@ -116,7 +116,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                         if (numberOfStopPlaces > 0) {
                             setGridLayouts(layouts)
                             saveToLocalStorage(dashboardKey, layouts)
-                            console.log(gridLayouts, layouts)
                         }
                     }}
                 >

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -23,6 +23,7 @@ import BikeTile from './BikeTile'
 import MapTile from './MapTile'
 
 import './styles.scss'
+//import { MapController } from 'react-map-gl'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 
@@ -66,13 +67,20 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    const anyScooters = Boolean(scooters && scooters.length)
+    //const anyScooters = Boolean(scooters && scooters.length)
 
     const bikeCol = anyBikeRentalStations ? 1 : 0
 
-    const scooterCol = anyScooters ? 1 : 0
+    //const scooterCol = anyScooters ? 1 : 0
+    // ny
+    const mapCol =
+        bikeRentalStations?.length ||
+        scooters?.length ||
+        stopPlacesWithDepartures?.length
+            ? 1
+            : 0
 
-    const totalItems = numberOfStopPlaces + bikeCol + scooterCol
+    const totalItems = numberOfStopPlaces + bikeCol + mapCol //oppdatert
 
     const cols: { [key: string]: number } = {
         lg: Math.min(totalItems, 4),
@@ -99,7 +107,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     layouts={gridLayouts}
                     isResizable={true}
                     onBreakpointChange={(newBreakpoint: string) => {
-                        setBreakpoint(newBreakpoint)
+                        setBreakpoint(newBreakpoint), console.log(gridLayouts)
                     }}
                     onLayoutChange={(
                         layout: Layout[],
@@ -108,6 +116,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                         if (numberOfStopPlaces > 0) {
                             setGridLayouts(layouts)
                             saveToLocalStorage(dashboardKey, layouts)
+                            console.log(gridLayouts, layouts)
                         }
                     }}
                 >
@@ -145,12 +154,14 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     ) : (
                         []
                     )}
-                    {scooters?.length ? (
+                    {scooters?.length ||
+                    stopPlacesWithDepartures?.length ||
+                    bikeRentalStations?.length ? (
                         <div
                             id="compact-map-tile"
-                            key={numberOfStopPlaces + bikeCol}
+                            key={totalItems - 1}
                             data-grid={getDataGrid(
-                                numberOfStopPlaces + bikeCol,
+                                totalItems - 1,
                                 maxWidthCols,
                             )}
                         >

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -67,12 +67,11 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    const anyScooters = Boolean(scooters && scooters.length)
+    //const anyScooters = Boolean(scooters && scooters.length)
 
     const bikeCol = anyBikeRentalStations ? 1 : 0
 
-    const scooterCol = anyScooters ? 1 : 0
-    
+    //const scooterCol = anyScooters ? 1 : 0
     const mapCol =
         bikeRentalStations?.length ||
         scooters?.length ||

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -168,17 +168,21 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                                 className="resizeHandle"
                                 variant="dark"
                             />
-                            <MapTile
-                                scooters={scooters}
-                                stopPlaces={stopPlacesWithDepartures}
-                                bikeRentalStations={bikeRentalStations}
-                                walkTimes={null}
-                                latitude={settings?.coordinates?.latitude ?? 0}
-                                longitude={
-                                    settings?.coordinates?.longitude ?? 0
-                                }
-                                zoom={settings?.zoom ?? DEFAULT_ZOOM}
-                            />
+                            {settings?.showMap ? (
+                                <MapTile
+                                    scooters={scooters}
+                                    stopPlaces={stopPlacesWithDepartures}
+                                    bikeRentalStations={bikeRentalStations}
+                                    walkTimes={null}
+                                    latitude={
+                                        settings?.coordinates?.latitude ?? 0
+                                    }
+                                    longitude={
+                                        settings?.coordinates?.longitude ?? 0
+                                    }
+                                    zoom={settings?.zoom ?? DEFAULT_ZOOM}
+                                />
+                            ) : null}
                         </div>
                     ) : (
                         []

--- a/src/settings/FirestoreStorage.ts
+++ b/src/settings/FirestoreStorage.ts
@@ -8,6 +8,7 @@ import {
 
 export type FieldTypes =
     | string
+    | boolean
     | number
     | string[]
     | firebase.firestore.GeoPoint

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -19,7 +19,7 @@ import {
 } from './UrlStorage'
 import { persist as persistToFirebase, FieldTypes } from './FirestoreStorage'
 
-export type Mode = 'bysykkel' | 'kollektiv' | 'sparkesykkel' | 'kartfunksjon'
+export type Mode = 'bysykkel' | 'kollektiv' | 'sparkesykkel'
 
 export interface Settings {
     boardName?: string

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -19,7 +19,7 @@ import {
 } from './UrlStorage'
 import { persist as persistToFirebase, FieldTypes } from './FirestoreStorage'
 
-export type Mode = 'bysykkel' | 'kollektiv' | 'sparkesykkel'
+export type Mode = 'bysykkel' | 'kollektiv' | 'sparkesykkel' | 'kartfunksjon'
 
 export interface Settings {
     boardName?: string
@@ -42,6 +42,7 @@ export interface Settings {
     logo?: string
     logoSize?: string
     description?: string
+    showMap?: boolean
 }
 
 interface SettingsSetters {
@@ -64,6 +65,7 @@ interface SettingsSetters {
     setLogo: (url: string | null) => void
     setLogoSize: (size: string) => void
     setDescription: (description: string) => void
+    setShowMap: (visible: boolean) => void
 }
 
 export const SettingsContext = createContext<
@@ -88,6 +90,7 @@ export const SettingsContext = createContext<
         setLogo: (): void => undefined,
         setLogoSize: (): void => undefined,
         setDescription: (): void => undefined,
+        setShowMap: (): void => undefined,
     },
 ])
 
@@ -318,6 +321,13 @@ export function useSettings(): [Settings | null, SettingsSetters] {
         [set],
     )
 
+    const setShowMap = useCallback(
+        (visible: boolean): void => {
+            set('showMap', visible)
+        },
+        [set],
+    )
+
     const setters = {
         setBoardName,
         setHiddenOperators,
@@ -336,6 +346,7 @@ export function useSettings(): [Settings | null, SettingsSetters] {
         setLogo,
         setLogoSize,
         setDescription,
+        setShowMap,
     }
 
     return [settings, setters]


### PR DESCRIPTION
Map is now visible in compact mode independently of whether there are any scooters or not/if scooters are activated. Can now also show only bikes, only scooters and/or only stop places. Map has its own box in the admin panel, and can be toggled on/off. 