### PR TITLE
make tiles undraggable on mobile on compact dashboard

### DIFF
--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -26,7 +26,7 @@ import './styles.scss'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 
-export function isMobileWeb(): boolean {
+function isMobileWeb(): boolean {
     return (
         typeof window.orientation !== 'undefined' ||
         navigator.userAgent.indexOf('IEMobile') !== -1

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -26,6 +26,13 @@ import './styles.scss'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 
+export function isMobileWeb(): boolean {
+    return (
+        typeof window.orientation !== 'undefined' ||
+        navigator.userAgent.indexOf('IEMobile') !== -1
+    )
+}
+
 function getDataGrid(
     index: number,
     maxWidth: number,
@@ -97,7 +104,8 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     key={breakpoint}
                     cols={cols}
                     layouts={gridLayouts}
-                    isResizable={true}
+                    isResizable={!isMobileWeb()}
+                    isDraggable={!isMobileWeb()}
                     onBreakpointChange={(newBreakpoint: string) => {
                         setBreakpoint(newBreakpoint)
                     }}


### PR DESCRIPTION
Make is possible to scroll on mobile by making the tiles on dashboard not draggable and not resizable while on mobile. It is still possible to drag and resize on web.