### PR TITLE
Updated chronological view to match the new compact view

### DIFF
--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -55,10 +55,9 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
             {departures.map((data) => {
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
-
                 return (
                     <TileRow
-                        key={data.id}
+                        key={data.id + Math.random()}
                         label={data.route}
                         subLabel={subLabel}
                         icon={icon}

--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -18,6 +18,9 @@
 
         h2 {
             margin: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
         }
 
         svg {

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -61,9 +61,6 @@ const ChronoDashboard = ({ history }: Props): JSX.Element => {
 
     const maxWidthCols = cols[breakpoint]
 
-    console.log('maxWidthCols:', maxWidthCols)
-    console.log('gridLayouts:', gridLayouts)
-
     return (
         <DashboardWrapper
             className="chrono"

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -32,11 +32,10 @@ function getDataGrid(
 
 const ChronoDashboard = ({ history }: Props): JSX.Element => {
     const dashboardKey = history.location.key
-    const [breakpoint, setBreakpoint] = useState<string>('sm')
+    const [breakpoint, setBreakpoint] = useState<string>('lg')
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
         getFromLocalStorage(dashboardKey),
     )
-    console.log(gridLayouts)
     const bikeRentalStations = useBikeRentalStations()
     let stopPlacesWithDepartures = useStopPlacesWithDepartures()
 
@@ -49,16 +48,12 @@ const ChronoDashboard = ({ history }: Props): JSX.Element => {
 
     const numberOfStopPlaces = stopPlacesWithDepartures?.length || 0
 
-    const anyBikeRentalStations =
+    const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
 
-    const extraCols = anyBikeRentalStations ? 1 : 0
-
-    const totalItems = numberOfStopPlaces + extraCols
-
     const cols: { [key: string]: number } = {
-        lg: Math.min(totalItems, 4),
-        md: Math.min(totalItems, 3),
+        lg: 4,
+        md: 3,
         sm: 1,
         xs: 1,
         xxs: 1,
@@ -66,7 +61,8 @@ const ChronoDashboard = ({ history }: Props): JSX.Element => {
 
     const maxWidthCols = cols[breakpoint]
 
-    console.log(stopPlacesWithDepartures)
+    console.log('maxWidthCols:', maxWidthCols)
+    console.log('gridLayouts:', gridLayouts)
 
     return (
         <DashboardWrapper
@@ -99,7 +95,10 @@ const ChronoDashboard = ({ history }: Props): JSX.Element => {
                             key={index.toString()}
                             data-grid={getDataGrid(index, maxWidthCols)}
                         >
-                            <DepartureTile stopPlaceWithDepartures={stop} />
+                            <DepartureTile
+                                key={index}
+                                stopPlaceWithDepartures={stop}
+                            />
                         </div>
                     ))}
                     {bikeRentalStations && anyBikeRentalStations ? (

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -30,6 +30,14 @@ function getDataGrid(
     }
 }
 
+const COLS: { [key: string]: number } = {
+    lg: 4,
+    md: 3,
+    sm: 1,
+    xs: 1,
+    xxs: 1,
+}
+
 const ChronoDashboard = ({ history }: Props): JSX.Element => {
     const dashboardKey = history.location.key
     const [breakpoint, setBreakpoint] = useState<string>('lg')
@@ -48,18 +56,11 @@ const ChronoDashboard = ({ history }: Props): JSX.Element => {
 
     const numberOfStopPlaces = stopPlacesWithDepartures?.length || 0
 
-    const anyBikeRentalStations: number | null =
-        bikeRentalStations && bikeRentalStations.length
+    const anyBikeRentalStations = Boolean(
+        bikeRentalStations && bikeRentalStations.length,
+    )
 
-    const cols: { [key: string]: number } = {
-        lg: 4,
-        md: 3,
-        sm: 1,
-        xs: 1,
-        xxs: 1,
-    }
-
-    const maxWidthCols = cols[breakpoint]
+    const maxWidthCols = COLS[breakpoint]
 
     return (
         <DashboardWrapper
@@ -71,7 +72,7 @@ const ChronoDashboard = ({ history }: Props): JSX.Element => {
             <div className="chrono__tiles">
                 <ResponsiveReactGridLayout
                     key={breakpoint}
-                    cols={cols}
+                    cols={COLS}
                     layouts={gridLayouts}
                     isResizable={true}
                     onBreakpointChange={(newBreakpoint: string) => {

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -42,7 +42,7 @@ function getDataGrid(
 
 const EnturDashboard = ({ history }: Props): JSX.Element => {
     const [settings] = useSettingsContext()
-    const [breakpoint, setBreakpoint] = useState<string>('sm')
+    const [breakpoint, setBreakpoint] = useState<string>('lg')
     const dashboardKey = history.location.key
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
         getFromLocalStorage(dashboardKey),

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -42,7 +42,7 @@ function getDataGrid(
 
 const EnturDashboard = ({ history }: Props): JSX.Element => {
     const [settings] = useSettingsContext()
-    const [breakpoint, setBreakpoint] = useState<string>('lg')
+    const [breakpoint, setBreakpoint] = useState<string>('sm')
     const dashboardKey = history.location.key
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
         getFromLocalStorage(dashboardKey),


### PR DESCRIPTION
Updated chrono view to have a maximum amount of cards shown per row, in the same way it is done for compact view.

Before:
<img width="1592" alt="Screenshot 2021-06-28 at 10 49 41" src="https://user-images.githubusercontent.com/31273371/123608086-bdbedf80-d7fe-11eb-8dea-083d990d2cea.png">

After:
<img width="1619" alt="Screenshot 2021-06-28 at 10 49 11" src="https://user-images.githubusercontent.com/31273371/123608125-c8797480-d7fe-11eb-8471-b52ede7379a7.png">

