### PR TITLE
Fixed bugs: width of tiles on mobile and map bug

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -146,7 +146,7 @@ const EditTab = (): JSX.Element => {
     return (
         <div className="edit-tab">
             <Heading2 className="heading">Rediger innhold</Heading2>
-            <GridContainer spacing="extraLarge">
+            <GridContainer spacing="extraLarge" className="edit-tab__container">
                 <GridItem medium={6} small={12} className="edit-tab__tile">
                     <div className="edit-tab__header">
                         <Heading2>Kollektiv</Heading2>
@@ -182,7 +182,7 @@ const EditTab = (): JSX.Element => {
                     <BikePanel stations={stations} />
                 </GridItem>
 
-                <GridItem medium={3} small={8}>
+                <GridItem medium={3} small={12}>
                     <div className="edit-tab__tile">
                         <div className="edit-tab__header">
                             <Heading2>Sparkesykkel</Heading2>

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -146,7 +146,7 @@ const EditTab = (): JSX.Element => {
     return (
         <div className="edit-tab">
             <Heading2 className="heading">Rediger innhold</Heading2>
-            <GridContainer spacing="extraLarge" className="edit-tab__container">
+            <GridContainer spacing="extraLarge">
                 <GridItem medium={6} small={12} className="edit-tab__tile">
                     <div className="edit-tab__header">
                         <Heading2>Kollektiv</Heading2>

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -103,7 +103,12 @@
         &__set-stops {
             display: block;
         }
-
+        &__header {
+            align-items: 'center';
+        }
+        &__tile {
+            display: block;
+        }
         .distance-editor {
             margin: 1rem 0;
         }

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -154,7 +154,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     ) : (
                         []
                     )}
-                    {hasData ? (
+                    {hasData && settings?.showMap ? (
                         <div
                             id="compact-map-tile"
                             key={totalItems - 1}
@@ -168,21 +168,17 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                                 className="resizeHandle"
                                 variant="dark"
                             />
-                            {settings?.showMap ? (
-                                <MapTile
-                                    scooters={scooters}
-                                    stopPlaces={stopPlacesWithDepartures}
-                                    bikeRentalStations={bikeRentalStations}
-                                    walkTimes={null}
-                                    latitude={
-                                        settings?.coordinates?.latitude ?? 0
-                                    }
-                                    longitude={
-                                        settings?.coordinates?.longitude ?? 0
-                                    }
-                                    zoom={settings?.zoom ?? DEFAULT_ZOOM}
-                                />
-                            ) : null}
+                            <MapTile
+                                scooters={scooters}
+                                stopPlaces={stopPlacesWithDepartures}
+                                bikeRentalStations={bikeRentalStations}
+                                walkTimes={null}
+                                latitude={settings?.coordinates?.latitude ?? 0}
+                                longitude={
+                                    settings?.coordinates?.longitude ?? 0
+                                }
+                                zoom={settings?.zoom ?? DEFAULT_ZOOM}
+                            />
                         </div>
                     ) : (
                         []


### PR DESCRIPTION
Bug fix 1: Width of map and scooter tiles on mobile are now the same width as the rest of the tiles.
Bug fix 2: Map tile was rendered even though map wasn't active. Tile is now only rendered if there is any data and map is active.

