### PR TITLE
Map and menu bugs on mobile

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -101,6 +101,8 @@ const Map = ({
     return (
         <ReactMapGL
             {...viewport}
+            dragPan={false}
+            touchAction="pan-y"
             mapboxApiAccessToken={process.env.MAPBOX_TOKEN}
             mapStyle={mapStyle || process.env.MAPBOX_STYLE_MAPVIEW}
             onViewportChange={

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -25,7 +25,6 @@
     .react-grid-layout {
         position: relative;
         transition: height 200ms ease;
-        margin-bottom: 3rem;
     }
     .react-grid-layout:last-child {
         margin-bottom: 7rem;

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -25,6 +25,10 @@
     .react-grid-layout {
         position: relative;
         transition: height 200ms ease;
+        margin-bottom: 3rem;
+    }
+    .react-grid-layout:last-child {
+        margin-bottom: 7rem;
     }
 
     .react-grid-item {
@@ -147,13 +151,10 @@
         &__tiles {
             display: block;
         }
-
         .tile {
-            margin-bottom: 1rem;
             max-height: unset;
             width: 100%;
         }
-
         .maptile {
             margin-bottom: 1rem;
             max-height: unset;


### PR DESCRIPTION
**In compact mode on mobile**
Bug fix 1: Can now scroll on map as well as the other tiles. 
Bug fix 2: Edit-menu does not cover the last grid item in compact mode. 