### PR TITLE
add-to-homescreen icon for ios

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Tavla - Enturs avgangstavle",
     "short_name": "Tavla",
-    "start_url": "/",
+    "start_url": "./",
     "display": "standalone",
     "background_color": "#181C56",
     "theme_color": "#181C56",

--- a/src/index.html
+++ b/src/index.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <html>
+    <head>
+        <link rel="manifest" href="manifest.json" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Tavla - Enturs avgangstavle</title>
+        <link rel="apple-touch-icon" href="images/logo/logo-512x512.png" />
+    </head>
 
-<head>
-    <link rel="manifest" href="manifest.json">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tavla - Enturs avgangstavle</title>
-</head>
-
-<body>
-    <div id="app"></div>
-</body>
-
+    <body>
+        <div id="app"></div>
+    </body>
 </html>


### PR DESCRIPTION
Small fix for enabling a custom icon when adding website to homescreen on iOS.

<img src="https://user-images.githubusercontent.com/31273371/123644166-697b2600-d825-11eb-976e-adf9c2f344aa.png" alt="preview" width="250"/><img src="https://user-images.githubusercontent.com/31273371/123644178-6c761680-d825-11eb-8385-4dbd03303102.png" alt="preview" width="250"/><img src="https://user-images.githubusercontent.com/31273371/123644196-70a23400-d825-11eb-8bea-51462c5119ad.png" alt="preview" width="250"/>