### PR TITLE
Fix visual expression on tab-list on mobile

### DIFF
--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -110,7 +110,7 @@
         }
 
         .eds-tab {
-            min-width: 10em;
+            min-width: 10rem;
         }
     }
 }

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -114,3 +114,14 @@
         }
     }
 }
+@media (max-width: 480px) {
+    .admin {
+        .eds-tab-list {
+            mask-image: linear-gradient(
+                to right,
+                rgba(0, 0, 0, 1) 85%,
+                rgba(0, 0, 0, 0) 100%
+            );
+        }
+    }
+}

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -108,5 +108,9 @@
             flex-direction: column;
             align-items: baseline;
         }
+
+        .eds-tab {
+            min-width: 10em;
+        }
     }
 }


### PR DESCRIPTION
Change min-width on tab in tab-panel on small screens, s.t all text is visable.
Make fading on the right end of tab-list on mobile screens.

Before: left, after: right
<img src="https://user-images.githubusercontent.com/67413374/123651838-19539200-d82c-11eb-8c85-8e6661687a00.png" alt="preview" width="250"/><img src="https://user-images.githubusercontent.com/67413374/123651843-1a84bf00-d82c-11eb-97e9-5b21c32ef8ca.png" alt="preview" width="250"/>

