### PR TITLE
Fix resize handle mobile

### DIFF
--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -163,11 +163,14 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                                 maxWidthCols,
                             )}
                         >
-                            <ResizeHandle
-                                size="32"
-                                className="resizeHandle"
-                                variant="dark"
-                            />
+                            {isMobileWeb() ? (
+                                <ResizeHandle
+                                    size="32"
+                                    className="resizeHandle"
+                                    variant="dark"
+                                />
+                            ) : null}
+
                             <MapTile
                                 scooters={scooters}
                                 stopPlaces={stopPlacesWithDepartures}

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -163,7 +163,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                                 maxWidthCols,
                             )}
                         >
-                            {isMobileWeb() ? (
+                            {!isMobileWeb() ? (
                                 <ResizeHandle
                                     size="32"
                                     className="resizeHandle"

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -125,11 +125,13 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             key={index.toString()}
                             data-grid={getDataGrid(index, maxWidthCols)}
                         >
-                            <ResizeHandle
-                                size="32"
-                                className="resizeHandle"
-                                variant="light"
-                            />
+                            {!isMobileWeb() ? (
+                                <ResizeHandle
+                                    size="32"
+                                    className="resizeHandle"
+                                    variant="light"
+                                />
+                            ) : null}
                             <DepartureTile
                                 key={index}
                                 stopPlaceWithDepartures={stop}
@@ -144,11 +146,13 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                                 maxWidthCols,
                             )}
                         >
-                            <ResizeHandle
-                                size="32"
-                                className="resizeHandle"
-                                variant="light"
-                            />
+                            {!isMobileWeb() ? (
+                                <ResizeHandle
+                                    size="32"
+                                    className="resizeHandle"
+                                    variant="light"
+                                />
+                            ) : null}
                             <BikeTile stations={bikeRentalStations} />
                         </div>
                     ) : (

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -27,7 +27,7 @@
         transition: height 200ms ease;
     }
     .react-grid-layout:last-child {
-        margin-bottom: 7rem;
+        margin-bottom: 5rem;
     }
 
     .react-grid-item {


### PR DESCRIPTION
When user is on a mobile device, the resize handles are removed from the tiles in the compact view. The functionality for actually resizing them are already disabled.

Also reduced the margin of the last grid item in compact mode from 7rem>5rem.