### PR TITLE
Updated EditTab's tiles to match the new design sketches

### DIFF
--- a/src/containers/Admin/EditTab/BikeSearch/index.tsx
+++ b/src/containers/Admin/EditTab/BikeSearch/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 
 import { Coordinates, BikeRentalStation } from '@entur/sdk'
 import { Dropdown } from '@entur/dropdown'
-import { Label } from '@entur/typography'
 
 import service from '../../../../service'
 
@@ -51,7 +50,6 @@ const BikePanelSearch = ({ onSelected, position }: Props): JSX.Element => {
 
     return (
         <div className="bike-search">
-            <Label>Bysykkelstativ</Label>
             <Dropdown
                 searchable
                 openOnFocus

--- a/src/containers/Admin/EditTab/ScooterPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ScooterPanel/index.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback } from 'react'
-import { Checkbox, Fieldset } from '@entur/form'
+import { Fieldset } from '@entur/form'
+import { FilterChip } from '@entur/chip'
+import { Label } from '@entur/typography'
 
 import { ALL_OPERATORS } from '../../../../constants'
 import { toggleValueInList } from '../../../../utils'
@@ -10,14 +12,6 @@ import './styles.scss'
 function ScooterPanel(): JSX.Element {
     const [settings, { setHiddenOperators }] = useSettingsContext()
     const { hiddenOperators = [] } = settings || {}
-
-    const onChooseAllPressed = useCallback(() => {
-        if (hiddenOperators.length > 0) {
-            setHiddenOperators([])
-        } else {
-            setHiddenOperators(ALL_OPERATORS)
-        }
-    }, [hiddenOperators.length, setHiddenOperators])
 
     const onToggleOperator = useCallback(
         (event) => {
@@ -32,30 +26,29 @@ function ScooterPanel(): JSX.Element {
     )
 
     return (
-        <Fieldset className="bike-panel">
-            <Checkbox
-                id="check-all-stop-places-bike"
-                name="check-all-stop-places-bike"
-                label="Velg alle"
-                onChange={onChooseAllPressed}
-                checked={!hiddenOperators.length}
-            >
-                Velg alle
-            </Checkbox>
-            {ALL_OPERATORS.map((operator) => (
-                <Checkbox
-                    key={operator}
-                    id={operator}
-                    label={operator}
-                    name={operator}
-                    checked={!hiddenOperators.includes(operator)}
-                    onChange={onToggleOperator}
-                >
-                    <span className="bike-panel__eds-paragraph">
-                        {operator.charAt(0).toUpperCase() + operator.slice(1)}
-                    </span>
-                </Checkbox>
-            ))}
+        <Fieldset className="scooter-panel">
+            <div className="scooter-panel__container">
+                {ALL_OPERATORS.map((operator) => (
+                    <div
+                        key={operator + 'btn'}
+                        className="scooter-panel__buttons"
+                    >
+                        <FilterChip
+                            key={operator}
+                            id={operator}
+                            value={operator}
+                            name={operator}
+                            checked={!hiddenOperators.includes(operator)}
+                            onChange={onToggleOperator}
+                        >
+                            <span className="scooter-panel__eds-paragraph">
+                                {operator.charAt(0).toUpperCase() +
+                                    operator.slice(1)}
+                            </span>
+                        </FilterChip>
+                    </div>
+                ))}
+            </div>
         </Fieldset>
     )
 }

--- a/src/containers/Admin/EditTab/ScooterPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ScooterPanel/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
-import { Label } from '@entur/typography'
 
 import { ALL_OPERATORS } from '../../../../constants'
 import { toggleValueInList } from '../../../../utils'

--- a/src/containers/Admin/EditTab/ScooterPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ScooterPanel/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
+import { Label } from '@entur/typography'
 
 import { ALL_OPERATORS } from '../../../../constants'
 import { toggleValueInList } from '../../../../utils'
@@ -27,6 +28,10 @@ function ScooterPanel(): JSX.Element {
     return (
         <Fieldset className="scooter-panel">
             <div className="scooter-panel__container">
+                <Label>
+                    Sparkesykkel krever visningstype som støtter kart.
+                </Label>
+                <br />
                 {ALL_OPERATORS.map((operator) => (
                     <div
                         key={operator + 'btn'}

--- a/src/containers/Admin/EditTab/ScooterPanel/styles.scss
+++ b/src/containers/Admin/EditTab/ScooterPanel/styles.scss
@@ -1,9 +1,20 @@
 @import '../../../../assets/styles/import.scss';
 @import '../../../../variables.scss';
 
-.bike-panel {
-    .eds-checkbox__container:not(:first-child) {
+.scooter-panel {
+    &__container {
+        width: 100%;
+        height: 100%;
+    }
+
+    &__buttons {
+        display: inline-block;
+        padding-right: 0.5rem;
         margin-top: 0.8rem;
+    }
+    .eds-filter-chip:not(:first-child) {
+        margin-top: 0.8rem;
+        padding-left: 0.8rem;
     }
 
     &__eds-paragraph,

--- a/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Coordinates, Feature } from '@entur/sdk'
 
 import { Dropdown } from '@entur/dropdown'
-import { Label } from '@entur/typography'
 
 import service from '../../../../service'
 
@@ -45,12 +44,11 @@ const SelectionPanelSearch = ({ handleAddNewStop }: Props): JSX.Element => {
 
     return (
         <div className="stop-place-search">
-            <Label>Stoppested</Label>
             <Dropdown
                 searchable
                 openOnFocus
                 debounceTimeout={500}
-                placeholder="Søk på stoppested for å legge til flere"
+                placeholder="Søk på stoppested for å legge til"
                 items={getItems}
                 onChange={onItemSelected}
                 highlightFirstItemOnOpen

--- a/src/containers/Admin/EditTab/ZoomEditor/index.tsx
+++ b/src/containers/Admin/EditTab/ZoomEditor/index.tsx
@@ -29,35 +29,34 @@ function ZoomEditor(props: Props): JSX.Element {
     return (
         <div className="zoom-editor">
             <div style={{ marginBottom: '0.5rem' }}></div>
-            <div className="__map-wrapper">
-                <ReactMapGL
-                    latitude={latitude}
-                    longitude={longitude}
-                    width="auto"
-                    height="40vh"
-                    zoom={zoom || DEFAULT_ZOOM}
-                    mapboxApiAccessToken={process.env.MAPBOX_TOKEN}
-                    mapStyle={process.env.MAPBOX_STYLE}
-                >
-                    <Marker latitude={latitude} longitude={longitude}>
-                        <PositionPin size={24} />
-                    </Marker>
-                    {props.scooters
-                        ? props.scooters.map((sctr) => (
-                              <Marker
-                                  key={sctr.id}
-                                  latitude={sctr.lat}
-                                  longitude={sctr.lon}
-                              >
-                                  <ScooterOperatorLogo
-                                      logo={sctr.operator}
-                                      size={24}
-                                  />
-                              </Marker>
-                          ))
-                        : []}
-                </ReactMapGL>
-            </div>
+            <ReactMapGL
+                latitude={latitude}
+                longitude={longitude}
+                width="auto"
+                height="40vh"
+                zoom={zoom || DEFAULT_ZOOM}
+                mapboxApiAccessToken={process.env.MAPBOX_TOKEN}
+                mapStyle={process.env.MAPBOX_STYLE}
+                className="settings-map"
+            >
+                <Marker latitude={latitude} longitude={longitude}>
+                    <PositionPin size={24} />
+                </Marker>
+                {props.scooters
+                    ? props.scooters.map((sctr) => (
+                          <Marker
+                              key={sctr.id}
+                              latitude={sctr.lat}
+                              longitude={sctr.lon}
+                          >
+                              <ScooterOperatorLogo
+                                  logo={sctr.operator}
+                                  size={24}
+                              />
+                          </Marker>
+                      ))
+                    : []}
+            </ReactMapGL>
             <Slider
                 handleChange={handleSliderChange}
                 value={zoom}

--- a/src/containers/Admin/EditTab/ZoomEditor/index.tsx
+++ b/src/containers/Admin/EditTab/ZoomEditor/index.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback } from 'react'
 import ReactMapGL, { Marker } from 'react-map-gl'
 
-import { Label } from '@entur/typography'
 import { Scooter } from '@entur/sdk'
 
 import { Slider } from '../../../../components'
@@ -29,7 +28,36 @@ function ZoomEditor(props: Props): JSX.Element {
 
     return (
         <div className="zoom-editor">
-            <Label>Juster zoom-nivå i kartet</Label>
+            <div style={{ marginBottom: '0.5rem' }}></div>
+            <div className="__map-wrapper">
+                <ReactMapGL
+                    latitude={latitude}
+                    longitude={longitude}
+                    width="auto"
+                    height="40vh"
+                    zoom={zoom || DEFAULT_ZOOM}
+                    mapboxApiAccessToken={process.env.MAPBOX_TOKEN}
+                    mapStyle={process.env.MAPBOX_STYLE}
+                >
+                    <Marker latitude={latitude} longitude={longitude}>
+                        <PositionPin size={24} />
+                    </Marker>
+                    {props.scooters
+                        ? props.scooters.map((sctr) => (
+                              <Marker
+                                  key={sctr.id}
+                                  latitude={sctr.lat}
+                                  longitude={sctr.lon}
+                              >
+                                  <ScooterOperatorLogo
+                                      logo={sctr.operator}
+                                      size={24}
+                                  />
+                              </Marker>
+                          ))
+                        : []}
+                </ReactMapGL>
+            </div>
             <Slider
                 handleChange={handleSliderChange}
                 value={zoom}
@@ -37,34 +65,6 @@ function ZoomEditor(props: Props): JSX.Element {
                 max={18}
                 step={0.1}
             />
-            <div style={{ marginBottom: '0.5rem' }}></div>
-            <ReactMapGL
-                latitude={latitude}
-                longitude={longitude}
-                width="auto"
-                height="40vh"
-                zoom={zoom || DEFAULT_ZOOM}
-                mapboxApiAccessToken={process.env.MAPBOX_TOKEN}
-                mapStyle={process.env.MAPBOX_STYLE}
-            >
-                <Marker latitude={latitude} longitude={longitude}>
-                    <PositionPin size={24} />
-                </Marker>
-                {props.scooters
-                    ? props.scooters.map((sctr) => (
-                          <Marker
-                              key={sctr.id}
-                              latitude={sctr.lat}
-                              longitude={sctr.lon}
-                          >
-                              <ScooterOperatorLogo
-                                  logo={sctr.operator}
-                                  size={24}
-                              />
-                          </Marker>
-                      ))
-                    : []}
-            </ReactMapGL>
         </div>
     )
 }

--- a/src/containers/Admin/EditTab/ZoomEditor/index.tsx
+++ b/src/containers/Admin/EditTab/ZoomEditor/index.tsx
@@ -28,12 +28,11 @@ function ZoomEditor(props: Props): JSX.Element {
 
     return (
         <div className="zoom-editor">
-            <div style={{ marginBottom: '0.5rem' }}></div>
             <ReactMapGL
                 latitude={latitude}
                 longitude={longitude}
                 width="auto"
-                height="40vh"
+                height="100%"
                 zoom={zoom || DEFAULT_ZOOM}
                 mapboxApiAccessToken={process.env.MAPBOX_TOKEN}
                 mapStyle={process.env.MAPBOX_STYLE}

--- a/src/containers/Admin/EditTab/ZoomEditor/styles.scss
+++ b/src/containers/Admin/EditTab/ZoomEditor/styles.scss
@@ -44,7 +44,7 @@
     }
 
     .slider {
-        margin-top: 0.8rem;
+        margin-top: 1rem;
     }
 }
 

--- a/src/containers/Admin/EditTab/ZoomEditor/styles.scss
+++ b/src/containers/Admin/EditTab/ZoomEditor/styles.scss
@@ -42,6 +42,14 @@
             outline: none;
         }
     }
+
+    &__map-wrapper {
+        overflow: hidden !important;
+    }
+
+    .mapboxgl-map {
+        border-radius: 16px !important;
+    }
 }
 
 @media (max-width: 1000px) {

--- a/src/containers/Admin/EditTab/ZoomEditor/styles.scss
+++ b/src/containers/Admin/EditTab/ZoomEditor/styles.scss
@@ -47,12 +47,12 @@
     .slider {
         margin-top: 1rem;
     }
-}
 
-.settings-map {
-    border-radius: 8px !important;
-    z-index: 0;
-    padding-top: 0;
+    .settings-map {
+        border-radius: 8px;
+        z-index: -1;
+        padding-top: 0;
+    }
 }
 
 @media (max-width: 1000px) {

--- a/src/containers/Admin/EditTab/ZoomEditor/styles.scss
+++ b/src/containers/Admin/EditTab/ZoomEditor/styles.scss
@@ -3,6 +3,7 @@
 
 .zoom-editor {
     width: 400px;
+    height: 70%;
     display: flex;
     flex-direction: column;
 
@@ -51,6 +52,7 @@
 .settings-map {
     border-radius: 8px !important;
     z-index: 0;
+    padding-top: 0;
 }
 
 @media (max-width: 1000px) {

--- a/src/containers/Admin/EditTab/ZoomEditor/styles.scss
+++ b/src/containers/Admin/EditTab/ZoomEditor/styles.scss
@@ -43,13 +43,14 @@
         }
     }
 
-    &__map-wrapper {
-        overflow: hidden !important;
+    .slider {
+        margin-top: 0.8rem;
     }
+}
 
-    .mapboxgl-map {
-        border-radius: 16px !important;
-    }
+.settings-map {
+    border-radius: 8px !important;
+    z-index: 0;
 }
 
 @media (max-width: 1000px) {

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -198,21 +198,19 @@ const EditTab = (): JSX.Element => {
         <div className="edit-tab">
             <Heading2 className="heading">
                 Viser kollektivtilbud innenfor
-                <div className="edit-tab__inputWrapper">
-                    <Heading2 className="heading" margin="none">
-                        <TextField
-                            className="edit-tab__radius-input"
-                            size="large"
-                            defaultValue={distance}
-                            onKeyDown={validateInput}
-                            append="m"
-                            type="number"
-                            max={1000}
-                            min={1}
-                            maxLength={4}
-                            minLength={1}
-                        />
-                    </Heading2>
+                <div className="edit-tab__input-wrapper">
+                    <TextField
+                        className="edit-tab__expanding-text-field heading"
+                        size="large"
+                        defaultValue={distance}
+                        onKeyDown={validateInput}
+                        append="m"
+                        type="number"
+                        max={1000}
+                        min={1}
+                        maxLength={4}
+                        minLength={1}
+                    />
                 </div>
                 rundt {locationName?.split(',')[0]}
             </Heading2>

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -59,6 +59,8 @@ const EditTab = (): JSX.Element => {
         debouncedDistance,
     )
 
+    const locationName = settings?.boardName
+
     const nearestStopPlaceIds = useMemo(
         () =>
             nearestPlaces
@@ -146,7 +148,8 @@ const EditTab = (): JSX.Element => {
     return (
         <div className="edit-tab">
             <Heading2 className="heading">
-                Viser kollektivtilbud innenfor {distance} m rundt x
+                Viser kollektivtilbud innenfor {distance} m rundt{' '}
+                {locationName?.split(',')[0]}
             </Heading2>
             <GridContainer
                 spacing="extraLarge"
@@ -169,6 +172,10 @@ const EditTab = (): JSX.Element => {
                     </div>
                     <div className="edit-tab__set-stops">
                         <StopPlaceSearch handleAddNewStop={addNewStop} />
+                        <DistanceEditor
+                            distance={distance}
+                            onDistanceUpdated={setDistance}
+                        />
                     </div>
                     <StopPlacePanel stops={stopPlaces} />
                 </GridItem>

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -146,7 +146,7 @@ const EditTab = (): JSX.Element => {
     return (
         <div className="edit-tab">
             <Heading2 className="heading">
-                Viser kollektivtilbud innenfor x m rundt x
+                Viser kollektivtilbud innenfor {distance} m rundt x
             </Heading2>
             <GridContainer
                 spacing="extraLarge"

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -145,8 +145,14 @@ const EditTab = (): JSX.Element => {
 
     return (
         <div className="edit-tab">
-            <Heading2 className="heading">Rediger innhold</Heading2>
-            <GridContainer spacing="large" rowSpacing="large">
+            <Heading2 className="heading">
+                Viser kollektivtilbud innenfor x m rundt x
+            </Heading2>
+            <GridContainer
+                spacing="extraLarge"
+                rowSpacing="extraLarge"
+                className="edit-tab__grid"
+            >
                 <GridItem
                     large={6}
                     medium={8}
@@ -163,10 +169,6 @@ const EditTab = (): JSX.Element => {
                     </div>
                     <div className="edit-tab__set-stops">
                         <StopPlaceSearch handleAddNewStop={addNewStop} />
-                        <DistanceEditor
-                            distance={distance}
-                            onDistanceUpdated={setDistance}
-                        />
                     </div>
                     <StopPlacePanel stops={stopPlaces} />
                 </GridItem>
@@ -205,7 +207,6 @@ const EditTab = (): JSX.Element => {
                         />
                     </div>
                     <ScooterPanel />
-                    <div className="edit-tab__tile edit-tab__tile__second"></div>
                 </GridItem>
                 <GridItem
                     large={3}

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -185,7 +185,6 @@ const EditTab = (): JSX.Element => {
 
     const validateInput = (e: SyntheticEvent<HTMLInputElement>) => {
         const newDistance = Number(e.currentTarget.value)
-        console.log(e.currentTarget)
         if (1 <= newDistance && 1000 >= newDistance) {
             setDistance(newDistance)
         } else if (newDistance < 1) {
@@ -202,7 +201,7 @@ const EditTab = (): JSX.Element => {
                 <div className="edit-tab__inputWrapper">
                     <Heading2 className="heading" margin="none">
                         <TextField
-                            className="edit-tab__radiusInput"
+                            className="edit-tab__radius-input"
                             size="large"
                             defaultValue={distance}
                             onKeyDown={validateInput}

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -146,8 +146,13 @@ const EditTab = (): JSX.Element => {
     return (
         <div className="edit-tab">
             <Heading2 className="heading">Rediger innhold</Heading2>
-            <GridContainer spacing="extraLarge">
-                <GridItem medium={6} small={12} className="edit-tab__tile">
+            <GridContainer spacing="large" rowSpacing="large">
+                <GridItem
+                    large={6}
+                    medium={8}
+                    small={12}
+                    className="edit-tab__tile"
+                >
                     <div className="edit-tab__header">
                         <Heading2>Kollektiv</Heading2>
                         <Switch
@@ -165,8 +170,12 @@ const EditTab = (): JSX.Element => {
                     </div>
                     <StopPlacePanel stops={stopPlaces} />
                 </GridItem>
-
-                <GridItem medium={3} small={12} className="edit-tab__tile">
+                <GridItem
+                    large={3}
+                    medium={4}
+                    small={12}
+                    className="edit-tab__tile"
+                >
                     <div className="edit-tab__header">
                         <Heading2>Bysykkel</Heading2>
                         <Switch
@@ -181,40 +190,46 @@ const EditTab = (): JSX.Element => {
                     />
                     <BikePanel stations={stations} />
                 </GridItem>
-
-                <GridItem medium={3} small={12}>
-                    <div className="edit-tab__tile">
-                        <div className="edit-tab__header">
-                            <Heading2>Sparkesykkel</Heading2>
-                            <Switch
-                                onChange={(): void =>
-                                    toggleMode('sparkesykkel')
-                                }
-                                checked={!hiddenModes?.includes('sparkesykkel')}
-                                size="large"
-                            />
-                        </div>
-                        <ScooterPanel />
-                    </div>
-                    <div className="edit-tab__tile edit-tab__tile__second">
-                        <div className="edit-tab__header">
-                            <Heading2>Kart</Heading2>
-                            <Switch
-                                onChange={(
-                                    event: React.ChangeEvent<HTMLInputElement>,
-                                ): void => {
-                                    setShowMap(event.currentTarget.checked)
-                                }}
-                                checked={showMap}
-                                size="large"
-                            />
-                        </div>
-                        <ZoomEditor
-                            zoom={zoom}
-                            onZoomUpdated={setZoom}
-                            scooters={scooters}
+                <GridItem
+                    large={3}
+                    medium={4}
+                    small={12}
+                    className="edit-tab__tile"
+                >
+                    <div className="edit-tab__header">
+                        <Heading2>Sparkesykkel</Heading2>
+                        <Switch
+                            onChange={(): void => toggleMode('sparkesykkel')}
+                            checked={!hiddenModes?.includes('sparkesykkel')}
+                            size="large"
                         />
                     </div>
+                    <ScooterPanel />
+                    <div className="edit-tab__tile edit-tab__tile__second"></div>
+                </GridItem>
+                <GridItem
+                    large={3}
+                    medium={6}
+                    small={12}
+                    className="edit-tab__tile"
+                >
+                    <div className="edit-tab__header">
+                        <Heading2>Kart</Heading2>
+                        <Switch
+                            onChange={(
+                                event: React.ChangeEvent<HTMLInputElement>,
+                            ): void => {
+                                setShowMap(event.currentTarget.checked)
+                            }}
+                            checked={showMap}
+                            size="large"
+                        />
+                    </div>
+                    <ZoomEditor
+                        zoom={zoom}
+                        onZoomUpdated={setZoom}
+                        scooters={scooters}
+                    />
                 </GridItem>
             </GridContainer>
         </div>

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -23,7 +23,6 @@ import { StopPlaceWithLines } from '../../../types'
 import { useNearestPlaces, useScooters } from '../../../logic'
 import service, { getStopPlacesWithLines } from '../../../service'
 
-import DistanceEditor from './DistanceEditor'
 import StopPlacePanel from './StopPlacePanel'
 import BikePanelSearch from './BikeSearch'
 import StopPlaceSearch from './StopPlaceSearch'
@@ -41,6 +40,21 @@ const COLS: { [key: string]: number } = {
     sm: 1,
     xs: 1,
     xxs: 1,
+}
+
+const LAYOUT = {
+    lg: [
+        { i: 'busStopPanel', x: 0, y: 0, w: 1.5, h: 4.5 },
+        { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
+        { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.5 },
+        { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 2.5 },
+    ],
+    md: [
+        { i: 'busStopPanel', x: 0, y: 0, w: 2, h: 4.5 },
+        { i: 'bikePanel', x: 2, y: 0, w: 1, h: 3 },
+        { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.5 },
+        { i: 'mapPanel', x: 0, y: 4.5, w: 3, h: 3 },
+    ],
 }
 
 const EditTab = (): JSX.Element => {
@@ -163,21 +177,6 @@ const EditTab = (): JSX.Element => {
         [setHiddenModes, hiddenModes],
     )
 
-    const gridLayout = {
-        lg: [
-            { i: 'busStopPanel', x: 0, y: 0, w: 1.5, h: 4.5 },
-            { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
-            { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.5 },
-            { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 2.5 },
-        ],
-        md: [
-            { i: 'busStopPanel', x: 0, y: 0, w: 1.5, h: 4.5 },
-            { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
-            { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.5 },
-            { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 2.5 },
-        ],
-    }
-
     const validateInput = (e: SyntheticEvent<HTMLInputElement>) => {
         const newDistance = Number(e.currentTarget.value)
 
@@ -202,7 +201,7 @@ const EditTab = (): JSX.Element => {
             <ResponsiveReactGridLayout
                 key={breakpoint}
                 cols={COLS}
-                layouts={gridLayout}
+                layouts={LAYOUT}
                 autoSize={true}
                 margin={[32, 32]}
                 isResizable={false}

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -44,16 +44,22 @@ const COLS: { [key: string]: number } = {
 
 const LAYOUT = {
     lg: [
-        { i: 'busStopPanel', x: 0, y: 0, w: 1.5, h: 4.5 },
+        { i: 'busStopPanel', x: 0, y: 0, w: 1.5, h: 4.3 },
         { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
-        { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.5 },
-        { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 2.5 },
+        { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.3 },
+        { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 3.3 },
     ],
     md: [
-        { i: 'busStopPanel', x: 0, y: 0, w: 2, h: 4.5 },
+        { i: 'busStopPanel', x: 0, y: 0, w: 2, h: 4.7 },
         { i: 'bikePanel', x: 2, y: 0, w: 1, h: 3 },
-        { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.5 },
+        { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.7 },
         { i: 'mapPanel', x: 0, y: 4.5, w: 3, h: 3 },
+    ],
+    sm: [
+        { i: 'busStopPanel', x: 0, y: 0, w: 1, h: 3 },
+        { i: 'bikePanel', x: 0, y: 3, w: 1, h: 2 },
+        { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.3 },
+        { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },
     ],
 }
 
@@ -179,9 +185,13 @@ const EditTab = (): JSX.Element => {
 
     const validateInput = (e: SyntheticEvent<HTMLInputElement>) => {
         const newDistance = Number(e.currentTarget.value)
-
+        console.log(e.currentTarget)
         if (1 <= newDistance && 1000 >= newDistance) {
             setDistance(newDistance)
+        } else if (newDistance < 1) {
+            setDistance(1)
+        } else {
+            setDistance(1000)
         }
     }
 
@@ -189,14 +199,23 @@ const EditTab = (): JSX.Element => {
         <div className="edit-tab">
             <Heading2 className="heading">
                 Viser kollektivtilbud innenfor
-                <TextField
-                    className="edit-tab__radiusInput"
-                    size="large"
-                    defaultValue={distance}
-                    pattern="[0-9]*"
-                    onInput={validateInput}
-                />
-                m rundt {locationName?.split(',')[0]}
+                <div className="edit-tab__inputWrapper">
+                    <Heading2 className="heading" margin="none">
+                        <TextField
+                            className="edit-tab__radiusInput"
+                            size="large"
+                            defaultValue={distance}
+                            onKeyDown={validateInput}
+                            append="m"
+                            type="number"
+                            max={1000}
+                            min={1}
+                            maxLength={4}
+                            minLength={1}
+                        />
+                    </Heading2>
+                </div>
+                rundt {locationName?.split(',')[0]}
             </Heading2>
             <ResponsiveReactGridLayout
                 key={breakpoint}

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -5,21 +5,47 @@
     .eds-contrast {
         background: inherit;
     }
+
     &__radiusInput {
-        display: inline-block;
-        width: 8rem;
         background-color: transparent !important;
-        margin: auto 0;
-        // border-bottom: 5px dotted var(--tavla-input-dotted-border-color);
+        color: var(--tavla-font-color);
 
         .eds-form-control,
         .eds-form-control__append {
+            font-size: inherit;
+
+            white-space: nowrap;
             text-align: center;
-            margin: 0;
-            font-size: 2rem;
-            color: var(--tavla-font-color);
+            padding: 0;
         }
     }
+
+    &__inputWrapper {
+        display: inline-block;
+        width: 10rem;
+        // border-bottom: 5px dotted var(--tavla-input-dotted-border-color) !important;
+    }
+
+    &__inputWrapper:after {
+        content: ''; /* This is necessary for the pseudo element to work. */
+        display: block; /* This will put the pseudo element on its own line. */
+        margin: 0 auto; /* This will center the border. */
+        width: 7rem; /* Change this to whatever width you want. */
+        border-bottom: 5px dotted var(--tavla-input-dotted-border-color) !important; /* This creates the border. Replace black with whatever color you want. */
+    }
+
+    /* Chrome, Safari, Edge, Opera */
+    .eds-form-control::-webkit-outer-spin-button,
+    .eds-form-control::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    /* Firefox */
+    .eds-form-control[type='number'] {
+        -moz-appearance: textfield;
+    }
+
     &__tile {
         padding: 2rem;
         padding-top: 0;

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -5,8 +5,24 @@
     .eds-contrast {
         background: inherit;
     }
+    &__radiusInput {
+        display: inline-block;
+        width: 8rem;
+        background-color: transparent !important;
+        margin: auto 0;
+        // border-bottom: 5px dotted var(--tavla-input-dotted-border-color);
+
+        .eds-form-control,
+        .eds-form-control__append {
+            text-align: center;
+            margin: 0;
+            font-size: 2rem;
+            color: var(--tavla-font-color);
+        }
+    }
     &__tile {
         padding: 2rem;
+        padding-top: 0;
         background-color: var(--tavla-box-background-color);
         display: block;
         overflow: auto;
@@ -74,10 +90,6 @@
     &__header {
         display: flex;
         justify-content: space-between;
-
-        &--spacing {
-            margin-top: 2rem;
-        }
 
         .eds-switch {
             padding: 0;

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -13,7 +13,6 @@
         .eds-form-control,
         .eds-form-control__append {
             font-size: inherit;
-
             white-space: nowrap;
             text-align: center;
             padding: 0;
@@ -23,14 +22,13 @@
     &__inputWrapper {
         display: inline-block;
         width: 10rem;
-        // border-bottom: 5px dotted var(--tavla-input-dotted-border-color) !important;
     }
 
-    &__inputWrapper:after {
-        content: ''; /* This is necessary for the pseudo element to work. */
-        display: block; /* This will put the pseudo element on its own line. */
-        margin: 0 auto; /* This will center the border. */
-        width: 7rem; /* Change this to whatever width you want. */
+    &__inputWrapper::after {
+        content: '';
+        display: block;
+        margin: 0 auto;
+        width: 7rem;
         border-bottom: 5px dotted var(--tavla-input-dotted-border-color) !important; /* This creates the border. Replace black with whatever color you want. */
     }
 

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -6,30 +6,12 @@
         background: inherit;
     }
 
-    &__radius-input {
-        background-color: transparent !important;
-        color: var(--tavla-font-color);
-
-        .eds-form-control,
-        .eds-form-control__append {
-            font-size: inherit;
-            white-space: nowrap;
-            text-align: center;
-            padding: 0;
-        }
-    }
-
-    &__inputWrapper {
-        display: inline-block;
-        width: 10rem;
-    }
-
-    &__inputWrapper::after {
-        content: '';
-        display: block;
-        margin: 0 auto;
-        width: 7rem;
-        border-bottom: 5px dotted var(--tavla-input-dotted-border-color) !important; /* This creates the border. Replace black with whatever color you want. */
+    .eds-form-control,
+    .eds-form-control__append {
+        font-size: inherit;
+        white-space: nowrap;
+        text-align: center;
+        padding: 0;
     }
 
     /* Chrome, Safari, Edge, Opera */
@@ -122,6 +104,26 @@
         .eds-switch {
             padding: 0;
         }
+    }
+
+    &__expanding-text-field {
+        font-size: inherit;
+    }
+
+    &__expanding-text-field.eds-form-control-wrapper {
+        background-color: transparent;
+    }
+
+    &__input-wrapper {
+        display: inline-block;
+    }
+
+    &__input-wrapper::after {
+        content: '';
+        display: block;
+        margin: 0 auto;
+        width: 7.5rem;
+        border-bottom: 5px dotted var(--tavla-input-dotted-border-color);
     }
 
     &__set-stops {

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -122,9 +122,6 @@
     .eds-dropdown__input[value=''] + .eds-form-control__append {
         display: none;
     }
-
-    &__grid {
-    }
 }
 
 .heading {

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -8,9 +8,8 @@
     &__tile {
         padding: 2rem;
         background-color: var(--tavla-box-background-color);
-        &__second {
-            margin-top: 2rem;
-        }
+        display: block;
+        overflow: auto;
     }
     .eds-checkbox-icon {
         background-color: var(--tavla-checkbox-color);
@@ -57,12 +56,17 @@
         color: var(--tavla-input-icon-color);
     }
 
-    .eds-grid__item {
-        height: fit-content;
+    .eds-grid {
+        &__item {
+            height: fit-content;
 
-        h2 {
-            margin: 0;
-            color: var(--tavla-font-color);
+            h2 {
+                margin: 0;
+                color: var(--tavla-font-color);
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
         }
     }
 

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -87,6 +87,10 @@
         }
     }
 
+    .react-grid-layout {
+        padding: 0;
+    }
+
     &__header {
         display: flex;
         justify-content: space-between;

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -6,7 +6,7 @@
         background: inherit;
     }
 
-    &__radiusInput {
+    &__radius-input {
         background-color: transparent !important;
         color: var(--tavla-font-color);
 

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -10,6 +10,7 @@
         background-color: var(--tavla-box-background-color);
         display: block;
         overflow: auto;
+        border-radius: 16px;
     }
     .eds-checkbox-icon {
         background-color: var(--tavla-checkbox-color);
@@ -120,6 +121,9 @@
 
     .eds-dropdown__input[value=''] + .eds-form-control__append {
         display: none;
+    }
+
+    &__grid {
     }
 }
 

--- a/src/containers/Admin/index.tsx
+++ b/src/containers/Admin/index.tsx
@@ -5,6 +5,12 @@ import { ClosedLockIcon } from '@entur/icons'
 import './styles.scss'
 import { useFirebaseAuthentication } from '../../auth'
 
+import { useSettingsContext } from '../../settings'
+
+import ThemeContrastWrapper from '../ThemeWrapper/ThemeContrastWrapper'
+
+import { isDarkOrDefaultTheme } from '../../utils'
+
 import LogoTab from './LogoTab'
 import EditTab from './EditTab'
 import ThemeTab from './ThemeTab'
@@ -18,39 +24,45 @@ const AdminPage = (): JSX.Element => {
 
     const lockIcon = !(user && !user.isAnonymous) && <ClosedLockIcon />
 
+    const [settings] = useSettingsContext()
+
+    const { theme } = settings || {}
+
     return (
-        <div className="admin">
-            <Tabs
-                index={currentIndex}
-                onChange={setCurrentIndex}
-                className="admin__tabs"
-            >
-                <TabList className="admin__tabs">
-                    <Tab className="admin__tabs">Rediger innhold</Tab>
-                    <Tab>Velg visning</Tab>
-                    <Tab>Velg farger</Tab>
-                    <Tab>Last opp logo {lockIcon}</Tab>
-                </TabList>
-                <TabPanels className="admin__tabs__tab-panels">
-                    <TabPanel>
-                        <EditTab />
-                    </TabPanel>
-                    <TabPanel>
-                        <VisningTab />
-                    </TabPanel>
-                    <TabPanel>
-                        <ThemeTab />
-                    </TabPanel>
-                    <TabPanel>
-                        <LogoTab
-                            tabIndex={currentIndex}
-                            setTabIndex={setCurrentIndex}
-                        />
-                    </TabPanel>
-                </TabPanels>
-            </Tabs>
-            <FloatingButtons />
-        </div>
+        <ThemeContrastWrapper useContrast={isDarkOrDefaultTheme(theme)}>
+            <div className="admin">
+                <Tabs
+                    index={currentIndex}
+                    onChange={setCurrentIndex}
+                    className="admin__tabs"
+                >
+                    <TabList className="admin__tabs">
+                        <Tab className="admin__tabs">Rediger innhold</Tab>
+                        <Tab>Velg visning</Tab>
+                        <Tab>Velg farger</Tab>
+                        <Tab>Last opp logo {lockIcon}</Tab>
+                    </TabList>
+                    <TabPanels className="admin__tabs__tab-panels">
+                        <TabPanel>
+                            <EditTab />
+                        </TabPanel>
+                        <TabPanel>
+                            <VisningTab />
+                        </TabPanel>
+                        <TabPanel>
+                            <ThemeTab />
+                        </TabPanel>
+                        <TabPanel>
+                            <LogoTab
+                                tabIndex={currentIndex}
+                                setTabIndex={setCurrentIndex}
+                            />
+                        </TabPanel>
+                    </TabPanels>
+                </Tabs>
+                <FloatingButtons />
+            </div>
+        </ThemeContrastWrapper>
     )
 }
 

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -8,6 +8,9 @@
     justify-content: center;
     padding: 2rem 4rem;
     color: var(--tavla-font-color);
+    &focus {
+        outline: none;
+    }
 
     &__tabs {
         background-color: var(--tavla-background-color);
@@ -74,7 +77,7 @@
 
 .eds-tab-panel:focus,
 .eds-tab:focus {
-    outline: none;
+    outline: none !important;
 }
 
 @media (min-width: 600px) {

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -8,9 +8,6 @@
     justify-content: center;
     padding: 2rem 4rem;
     color: var(--tavla-font-color);
-    &focus {
-        outline: none;
-    }
 
     &__tabs {
         background-color: var(--tavla-background-color);

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -110,7 +110,7 @@
         }
 
         .eds-tab {
-            min-width: 10em;
+            min-width: 10rem;
         }
     }
 }

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -114,3 +114,14 @@
         }
     }
 }
+@media (max-width: 480px) {
+    .admin {
+        .eds-tab-list {
+            mask-image: linear-gradient(
+                to right,
+                rgba(0, 0, 0, 1) 85%,
+                rgba(0, 0, 0, 0) 100%
+            );
+        }
+    }
+}

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -108,5 +108,9 @@
             flex-direction: column;
             align-items: baseline;
         }
+
+        .eds-tab {
+            min-width: 10em;
+        }
     }
 }

--- a/src/containers/LandingPage/index.tsx
+++ b/src/containers/LandingPage/index.tsx
@@ -112,7 +112,7 @@ function LandingPage({ history }: Props): JSX.Element {
                                 heve brukeropplevelsen av den. Hvis du opplever
                                 noe merkelig når du bruker Tavla eller har
                                 innspill eller ideer til hvordan tjenesten kan
-                                bli bedre, kan du skrive til oss på Github.
+                                bli bedre, kan du skrive til oss på GitHub.
                             </Paragraph>
                         </GridItem>
                     </GridContainer>

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -28,6 +28,7 @@
     --floating-button-primary-background: rgb(174, 183, 226);
     --floating-button-primary-font-color: rgb(24, 28, 86);
     --tavla-modal-overlay-color: rgba(24, 28, 86, 0.8);
+    --tavla-input-dotted-border-color: #ff5959;
 }
 
 .default-theme {
@@ -54,6 +55,7 @@
     --tavla-slider-thumb-color: #fff;
     --tavla-slider-fill-color: rgb(174, 183, 226);
     --tavla-modal-overlay-color: rgba(24, 28, 86, 0.8);
+    --tavla-input-dotted-border-color: #ff5959;
 }
 
 .dark-theme {
@@ -84,6 +86,7 @@
     --floating-button-primary-background: rgba(36, 36, 36);
     --floating-button-primary-font-color: #fff;
     --tavla-modal-overlay-color: rgba(0, 0, 0, 0.8);
+    --tavla-input-dotted-border-color: #ff5959;
 }
 
 .light-theme {
@@ -114,6 +117,7 @@
     --floating-button-primary-background: rgb(243, 243, 243);
     --floating-button-primary-font-color: #000;
     --tavla-modal-overlay-color: rgba(220, 216, 216, 0.8);
+    --tavla-input-dotted-border-color: #ff5959;
 }
 
 .grey-theme {
@@ -142,4 +146,5 @@
     --floating-button-primary-background: #fff;
     --floating-button-primary-font-color: #000;
     --tavla-modal-overlay-color: rgba(233, 233, 233, 0.8);
+    --tavla-input-dotted-border-color: #ff5959;
 }


### PR DESCRIPTION
Updated the underlaying grid layout to the same kind used on Compact and Chrono view, in addition to styling the overall tile looks to match the new design sketches for the EditTab Panel.

The "Kollektiv" and "Bysykkel" tabs are still untouched, and do not match the new design yet.

Before:
<img width="1603" alt="Screenshot 2021-07-02 at 13 11 06" src="https://user-images.githubusercontent.com/31273371/124266227-fc260880-db36-11eb-8e82-84ba59fc9836.png">


After:
<img width="1565" alt="Screenshot 2021-07-02 at 13 10 56" src="https://user-images.githubusercontent.com/31273371/124266229-fdefcc00-db36-11eb-8775-9e624e32abf4.png">
