### PR TITLE
fixed bugs which led to inconsistent color themes for admin panel

### DIFF
--- a/src/containers/Admin/EditTab/ScooterPanel/styles.scss
+++ b/src/containers/Admin/EditTab/ScooterPanel/styles.scss
@@ -17,6 +17,13 @@
         padding-left: 0.8rem;
     }
 
+    .eds-chip {
+        background-color: var(--tavla-border-color);
+    }
+    .eds-filter-chip__icon {
+        background-color: var(--tavla-background-color);
+    }
+
     &__eds-paragraph,
     .eds-paragraph {
         color: var(--tavla-font-color);

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -56,7 +56,7 @@
     }
 
     .eds-form-control-wrapper {
-        --border-color: var(--tavla-input-border-color);
+        --border-color: transparent;
         --border-color-hover: var(--tavla-input-border-hover-color);
 
         background-color: var(--tavla-input-background-color);

--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -34,47 +34,48 @@
         padding-top: 2rem;
     }
 
+    .eds-tab {
+        background-color: var(--tavla-button-background-color);
+        color: var(--tavla-font-color);
+        border-color: var(--tavla-button-background-color);
+        width: 12rem;
+    }
+
+    .eds-tab:hover {
+        background-color: var(--tavla-hover-color);
+        border-color: var(--tavla-hover-color);
+        color: var(--tavla-font-color);
+    }
+
+    .eds-tab::after {
+        background-color: var(--tavla-button-background-color);
+    }
+
+    .eds-tab[aria-selected='true'] {
+        background-color: var(--tavla-background-color);
+        color: var(--tavla-font-color);
+        border-color: var(--tavla-button-background-color);
+    }
+
+    .eds-tab-list::after {
+        background-color: var(--tavla-button-background-color);
+        z-index: -1;
+    }
+
+    .eds-tab[aria-selected='true']::after {
+        background-color: var(--tavla-background-color);
+    }
+
+    .eds-tab-panel:focus,
+    .eds-tab:focus {
+        outline: none;
+    }
+
     @media (max-width: 400px) {
         .eds-grid--spacing-extraLarge {
             grid-gap: 1rem;
         }
     }
-}
-
-.eds-tab {
-    background-color: var(--tavla-button-background-color);
-    color: var(--tavla-font-color);
-    border-color: var(--tavla-button-background-color);
-    width: 12rem;
-}
-
-.eds-tab:hover {
-    background-color: var(--tavla-hover-color);
-    border-color: var(--tavla-hover-color);
-}
-
-.eds-tab::after {
-    background-color: var(--tavla-button-background-color);
-}
-
-.eds-tab[aria-selected='true'] {
-    background-color: var(--tavla-background-color);
-    color: var(--tavla-font-color);
-    border-color: var(--tavla-button-background-color);
-}
-
-.eds-tab-list::after {
-    background-color: var(--tavla-button-background-color);
-    z-index: -1;
-}
-
-.eds-tab[aria-selected='true']::after {
-    background-color: var(--tavla-background-color);
-}
-
-.eds-tab-panel:focus,
-.eds-tab:focus {
-    outline: none !important;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
Updated the styling for parts of the admin panel in order to make the filter chips and navbar colors handle contrast mode nicely again.

Before:
<img width="508" alt="Screenshot 2021-07-02 at 14 20 59" src="https://user-images.githubusercontent.com/31273371/124482009-27b02980-dda9-11eb-8133-5854b66c70b6.png">
<img width="851" alt="Screenshot 2021-07-02 at 14 20 54" src="https://user-images.githubusercontent.com/31273371/124482010-27b02980-dda9-11eb-8523-9798204b2008.png">

After:
<img width="507" alt="Screenshot 2021-07-05 at 15 49 39" src="https://user-images.githubusercontent.com/31273371/124482002-267efc80-dda9-11eb-8fa9-3deab02f7aca.png">
<img width="862" alt="Screenshot 2021-07-05 at 15 49 35" src="https://user-images.githubusercontent.com/31273371/124482004-27179300-dda9-11eb-9484-586989b4325d.png">

