### PR TITLE
tileOrder is stored in localStorage

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -34,7 +34,7 @@ analytics.pageview(window.location.pathname)
 
 function getDashboardComponent(
     dashboardKey?: string | void,
-): (props: Props) => JSX.Element {
+): (props: Props) => JSX.Element | null {
     switch (dashboardKey) {
         case 'Timeline':
             return Timeline

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -357,3 +357,8 @@ export const useThemeColor = (
 export function isDarkOrDefaultTheme(theme?: Theme): boolean {
     return !theme || theme === Theme.DARK || theme === Theme.DEFAULT
 }
+
+export function isEqualUnsorted<T>(array: T[], includes: T[]): boolean {
+    if (array.length !== includes.length) return false
+    return includes.every((i) => array.includes(i))
+}


### PR DESCRIPTION
The tile order is now stored in localStorage, but is set to default if no local ordering is found or if there is a mismatch between the contents of the stored order compared to the default one.