### PR TITLE
Add walking distance (in meters and minutes) in chrono and busStop view

### DIFF
--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -28,6 +28,7 @@ import SubLabelIcon from '../components/SubLabelIcon'
 import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import SituationModal from '../../../components/SituationModal'
+import { WalkInfo } from '../../../logic/useWalkInfo'
 
 function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     const transportModes = unique(
@@ -44,6 +45,14 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     return transportIcons.map(({ icon }) => icon).filter(isNotNullOrUndefined)
 }
 
+function formatWalkTime(walkTime: number) {
+    if (walkTime / 60 < 1) {
+        return 'Mindre enn 1 min å gå'
+    } else {
+        return `${Math.ceil(walkTime / 60)} min å gå`
+    }
+}
+
 function isMobileWeb(): boolean {
     return (
         typeof window.orientation !== 'undefined' ||
@@ -51,7 +60,10 @@ function isMobileWeb(): boolean {
     )
 }
 
-const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
+const DepartureTile = ({
+    stopPlaceWithDepartures,
+    walkInfo,
+}: Props): JSX.Element => {
     const { departures } = stopPlaceWithDepartures
     const headerIcons = getTransportHeaderIcons(departures)
     const [settings] = useSettingsContext()
@@ -72,6 +84,13 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                 <Heading2>{stopPlaceWithDepartures.name}</Heading2>
                 <div className="tile__header__icons">{headerIcons}</div>
             </header>
+            {walkInfo ? (
+                <div className="tile__walking-time">
+                    {`${formatWalkTime(walkInfo.walkTime)} (${Math.ceil(
+                        walkInfo.walkDistance,
+                    )} m)`}
+                </div>
+            ) : null}
             <Table spacing="small" fixed>
                 <col
                     style={
@@ -148,6 +167,7 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
 
 interface Props {
     stopPlaceWithDepartures: StopPlaceWithDepartures
+    walkInfo?: WalkInfo
 }
 
 export default DepartureTile

--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -45,11 +45,13 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     return transportIcons.map(({ icon }) => icon).filter(isNotNullOrUndefined)
 }
 
-function formatWalkTime(walkTime: number) {
-    if (walkTime / 60 < 1) {
-        return 'Mindre enn 1 min å gå'
+function formatWalkInfo(walkInfo: WalkInfo) {
+    if (walkInfo.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(walkInfo.walkDistance)} m)`
     } else {
-        return `${Math.ceil(walkTime / 60)} min å gå`
+        return `${Math.ceil(walkInfo.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfo.walkDistance,
+        )} m)`
     }
 }
 
@@ -86,9 +88,7 @@ const DepartureTile = ({
             </header>
             {walkInfo ? (
                 <div className="tile__walking-time">
-                    {`${formatWalkTime(walkInfo.walkTime)} (${Math.ceil(
-                        walkInfo.walkDistance,
-                    )} m)`}
+                    {formatWalkInfo(walkInfo)}
                 </div>
             ) : null}
             <Table spacing="small" fixed>

--- a/src/dashboards/BusStop/DepartureTile/styles.scss
+++ b/src/dashboards/BusStop/DepartureTile/styles.scss
@@ -43,6 +43,12 @@
         white-space: wrap;
         text-overflow: ellipsis;
     }
+    &__walking-time {
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1rem;
+        color: var(--tavla-label-font-color);
+    }
 }
 
 @media (max-width: 1000px) {

--- a/src/dashboards/BusStop/index.tsx
+++ b/src/dashboards/BusStop/index.tsx
@@ -8,7 +8,9 @@ import {
     useBikeRentalStations,
     useStopPlacesWithDepartures,
     useScooters,
+    useWalkInfo,
 } from '../../logic'
+import { WalkInfo } from '../../logic/useWalkInfo'
 
 import { useSettingsContext } from '../../settings'
 
@@ -17,6 +19,13 @@ import DepartureTile from './DepartureTile'
 import MapTile from './MapTile'
 
 import './styles.scss'
+
+function getWalkInfoForStopPlace(
+    walkInfos: WalkInfo[],
+    id: string,
+): WalkInfo | undefined {
+    return walkInfos?.find((walkInfo) => walkInfo.stopId === id)
+}
 
 function BusStop({ history }: Props): JSX.Element {
     const [settings] = useSettingsContext()
@@ -29,6 +38,9 @@ function BusStop({ history }: Props): JSX.Element {
             ({ departures }) => departures.length > 0,
         )
     }
+
+    const walkInfo = useWalkInfo(stopPlacesWithDepartures)
+
     const mediumWidth = settings?.showMap ? 8 : 12
     return (
         <DashboardWrapper
@@ -43,6 +55,10 @@ function BusStop({ history }: Props): JSX.Element {
                             <DepartureTile
                                 key={index.toString()}
                                 stopPlaceWithDepartures={stop}
+                                walkInfo={getWalkInfoForStopPlace(
+                                    walkInfo || [],
+                                    stop.id,
+                                )}
                             />
                         ))}{' '}
                     </div>

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -20,6 +20,7 @@ import TileRow from '../components/TileRow'
 
 import './styles.scss'
 import { useSettingsContext } from '../../../settings'
+import { WalkInfo } from '../../../logic/useWalkInfo'
 
 function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     const transportModes = unique(
@@ -38,6 +39,7 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
 
 const DepartureTile = ({
     stopPlaceWithDepartures,
+    walkInfo,
     isMobile = false,
     numberOfTileRows = 7,
 }: Props): JSX.Element => {
@@ -59,7 +61,7 @@ const DepartureTile = ({
     }, [settings])
 
     return (
-        <Tile title={name} icons={headerIcons}>
+        <Tile title={name} icons={headerIcons} walkInfo={walkInfo}>
             {visibleDepartures.map((data) => {
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
@@ -79,6 +81,7 @@ const DepartureTile = ({
 
 interface Props {
     stopPlaceWithDepartures: StopPlaceWithDepartures
+    walkInfo?: WalkInfo
     isMobile?: boolean
     numberOfTileRows?: number
 }

--- a/src/dashboards/Chrono/components/Tile/index.tsx
+++ b/src/dashboards/Chrono/components/Tile/index.tsx
@@ -4,11 +4,13 @@ import { Heading2 } from '@entur/typography'
 import './styles.scss'
 import { WalkInfo } from '../../../../logic/useWalkInfo'
 
-function formatWalkTime(walkTime: number) {
-    if (walkTime / 60 < 1) {
-        return 'Mindre enn 1 min å gå'
+function formatWalkInfo(walkInfo: WalkInfo) {
+    if (walkInfo.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(walkInfo.walkDistance)} m)`
     } else {
-        return `${Math.ceil(walkTime / 60)} min å gå`
+        return `${Math.ceil(walkInfo.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfo.walkDistance,
+        )} m)`
     }
 }
 
@@ -21,9 +23,7 @@ function Tile({ title, icons, walkInfo, children }: Props): JSX.Element {
             </header>
             {walkInfo ? (
                 <div className="tile__walking-time">
-                    {`${formatWalkTime(walkInfo.walkTime)} (${Math.ceil(
-                        walkInfo.walkDistance,
-                    )} m)`}
+                    {formatWalkInfo(walkInfo)}
                 </div>
             ) : null}
             {children}

--- a/src/dashboards/Chrono/components/Tile/index.tsx
+++ b/src/dashboards/Chrono/components/Tile/index.tsx
@@ -2,14 +2,30 @@ import React from 'react'
 import { Heading2 } from '@entur/typography'
 
 import './styles.scss'
+import { WalkInfo } from '../../../../logic/useWalkInfo'
 
-function Tile({ title, icons, children }: Props): JSX.Element {
+function formatWalkTime(walkTime: number) {
+    if (walkTime / 60 < 1) {
+        return 'Mindre enn 1 min å gå'
+    } else {
+        return `${Math.ceil(walkTime / 60)} min å gå`
+    }
+}
+
+function Tile({ title, icons, walkInfo, children }: Props): JSX.Element {
     return (
         <div className="tile">
             <header className="tile__header">
                 <Heading2>{title}</Heading2>
                 <div className="tile__header-icons">{icons}</div>
             </header>
+            {walkInfo ? (
+                <div className="tile__walking-time">
+                    {`${formatWalkTime(walkInfo.walkTime)} (${Math.ceil(
+                        walkInfo.walkDistance,
+                    )} m)`}
+                </div>
+            ) : null}
             {children}
         </div>
     )
@@ -18,6 +34,7 @@ function Tile({ title, icons, children }: Props): JSX.Element {
 interface Props {
     title: string
     icons: JSX.Element | JSX.Element[]
+    walkInfo?: WalkInfo
     children: JSX.Element[]
 }
 

--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -32,4 +32,11 @@
         display: flex;
         align-items: center;
     }
+
+    &__walking-time {
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1rem;
+        color: var(--tavla-label-font-color);
+    }
 }

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -8,6 +8,7 @@ import {
     useBikeRentalStations,
     useStopPlacesWithDepartures,
     useScooters,
+    useWalkInfo,
 } from '../../logic'
 import DashboardWrapper from '../../containers/DashboardWrapper'
 import { DEFAULT_ZOOM } from '../../constants'
@@ -22,6 +23,8 @@ import { useSettingsContext } from '../../settings'
 
 import { isEqualUnsorted, usePrevious } from '../../utils'
 
+import { WalkInfo } from '../../logic/useWalkInfo'
+
 import DepartureTile from './DepartureTile'
 import MapTile from './MapTile'
 import BikeTile from './BikeTile'
@@ -33,6 +36,13 @@ function isMobileWeb(): boolean {
         typeof window.orientation !== 'undefined' ||
         navigator.userAgent.indexOf('IEMobile') !== -1
     )
+}
+
+function getWalkInfoForStopPlace(
+    walkInfos: WalkInfo[],
+    id: string,
+): WalkInfo | undefined {
+    return walkInfos?.find((walkInfo) => walkInfo.stopId === id)
 }
 
 function getDataGrid(
@@ -96,6 +106,9 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
             ({ departures }) => departures.length > 0,
         )
     }
+
+    const walkInfo = useWalkInfo(stopPlacesWithDepartures)
+
     const numberOfStopPlaces = stopPlacesWithDepartures?.length || 0
     const anyBikeRentalStations: number | null =
         bikeRentalStations && bikeRentalStations.length
@@ -233,6 +246,10 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
                                         stopPlaceWithDepartures={
                                             stopPlacesWithDepartures[stopIndex]
                                         }
+                                        walkInfo={getWalkInfoForStopPlace(
+                                            walkInfo || [],
+                                            item.id,
+                                        )}
                                         isMobile
                                         numberOfTileRows={numberOfTileRows}
                                     />
@@ -281,6 +298,10 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
                             <DepartureTile
                                 key={index}
                                 stopPlaceWithDepartures={stop}
+                                walkInfo={getWalkInfoForStopPlace(
+                                    walkInfo || [],
+                                    stop.id,
+                                )}
                             />
                         </div>
                     ))}

--- a/src/dashboards/Compact/components/Tile/index.tsx
+++ b/src/dashboards/Compact/components/Tile/index.tsx
@@ -4,11 +4,13 @@ import { Heading2 } from '@entur/typography'
 import './styles.scss'
 import { WalkInfo } from '../../../../logic/useWalkInfo'
 
-function formatWalkTime(walkTime: number) {
-    if (walkTime / 60 < 1) {
-        return 'Mindre enn 1 min å gå'
+function formatWalkInfo(walkInfo: WalkInfo) {
+    if (walkInfo.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(walkInfo.walkDistance)} m)`
     } else {
-        return `${Math.ceil(walkTime / 60)} min å gå`
+        return `${Math.ceil(walkInfo.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfo.walkDistance,
+        )} m)`
     }
 }
 
@@ -21,9 +23,7 @@ export function Tile({ title, icons, walkInfo, children }: Props): JSX.Element {
             </header>
             {walkInfo ? (
                 <div className="tile__walking-time">
-                    {`${formatWalkTime(walkInfo.walkTime)} (${Math.ceil(
-                        walkInfo.walkDistance,
-                    )} m)`}
+                    {formatWalkInfo(walkInfo)}
                 </div>
             ) : null}
             {children}


### PR DESCRIPTION
Add walking distance in meters and minutes in chrono view. This is equivalent to what previously done in compact view.

<img width="1658" alt="Screenshot 2021-07-13 at 15 58 05" src="https://user-images.githubusercontent.com/67413374/125465028-521278a5-4091-44cb-805f-9a19fde9bb05.png">

<img width="346" alt="Screenshot 2021-07-13 at 15 58 42" src="https://user-images.githubusercontent.com/67413374/125465050-030b0e01-6978-4307-86bc-a98cc900d53f.png">
