### PR TITLE
Fix font style on platform-info in compact view

### DIFF
--- a/src/dashboards/Compact/components/TileRow/PlatformInfo/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/PlatformInfo/styles.scss
@@ -2,6 +2,8 @@
 @import '../../../../../variables.scss';
 
 .platform-info {
+    font-style: normal;
+    font-weight: normal;
     font-size: 1rem;
     color: var(--tavla-label-font-color);
     margin-bottom: 0.5rem;


### PR DESCRIPTION
Platform-info on mobile did note scale before this change, se pictures below

Before:
<img width="353" alt="Screenshot 2021-07-13 at 17 31 10" src="https://user-images.githubusercontent.com/67413374/125481185-974ef50f-ccc0-4897-b408-81ca8845bfec.png">
After:
<img width="352" alt="Screenshot 2021-07-13 at 17 35 22" src="https://user-images.githubusercontent.com/67413374/125481544-626c52ab-4d46-4f26-86a9-8eac92fab132.png">
