### PR TITLE
Toggle for track info and track info in "busstop"

### DIFF
--- a/src/containers/Admin/EditTab/ToggleDetailsPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ToggleDetailsPanel/index.tsx
@@ -8,11 +8,11 @@ import { useSettingsContext } from '../../../../settings'
 
 function ToggleDetailsPanel(): JSX.Element {
     const [settings, settingsSetters] = useSettingsContext()
-    const { hideSituations } = settings || {}
-    const { setHideSituations } = settingsSetters
+    const { hideSituations, hideTracks } = settings || {}
+    const { setHideSituations, setHideTracks } = settingsSetters
     return (
         <Fieldset className="toggle-detail-panel">
-            <div>
+            <div className="toggle-detail-panel__chips">
                 <FilterChip
                     className="toggle-detail-panel__filter-chip"
                     value="avviksinfo"
@@ -24,6 +24,18 @@ function ToggleDetailsPanel(): JSX.Element {
                     checked={!hideSituations}
                 >
                     Avviksinfo
+                </FilterChip>
+                <FilterChip
+                    className="toggle-detail-panel__filter-chip"
+                    value="sporinfo"
+                    onChange={(
+                        event: React.ChangeEvent<HTMLInputElement>,
+                    ): void => {
+                        setHideTracks(!event.currentTarget.checked)
+                    }}
+                    checked={!hideTracks}
+                >
+                    Sporinformasjon
                 </FilterChip>
             </div>
             <Label>

--- a/src/containers/Admin/EditTab/ToggleDetailsPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ToggleDetailsPanel/index.tsx
@@ -35,7 +35,7 @@ function ToggleDetailsPanel(): JSX.Element {
                     }}
                     checked={!hideTracks}
                 >
-                    Sporinformasjon
+                    Spor/plattform
                 </FilterChip>
             </div>
             <Label>

--- a/src/containers/Admin/EditTab/ToggleDetailsPanel/styles.scss
+++ b/src/containers/Admin/EditTab/ToggleDetailsPanel/styles.scss
@@ -7,12 +7,12 @@
     &__chips {
         display: flex;
         direction: row;
+        margin-top: 0.25rem;
     }
 
     .eds-filter-chip:not(:first-child) {
-        margin-top: 0.8rem;
-        margin-bottom: 0.8rem;
-        margin-left: 0.5rem;
+        margin-bottom: 0.75rem;
+        margin-left: 0.75rem;
     }
 
     .eds-chip {

--- a/src/containers/Admin/EditTab/ToggleDetailsPanel/styles.scss
+++ b/src/containers/Admin/EditTab/ToggleDetailsPanel/styles.scss
@@ -2,14 +2,19 @@
 @import '../../../../variables.scss';
 
 .toggle-detail-panel {
-    &__filter-chip {
-        margin-top: 0.5rem;
-        margin-bottom: 0.8rem;
+    display: inline-block;
+
+    &__chips {
+        display: flex;
+        direction: row;
     }
+
     .eds-filter-chip:not(:first-child) {
         margin-top: 0.8rem;
-        padding-left: 0.8rem;
+        margin-bottom: 0.8rem;
+        margin-left: 0.5rem;
     }
+
     .eds-chip {
         background-color: var(--tavla-border-color);
     }

--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -123,37 +123,22 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                             <DataCell>{data.time}</DataCell>
                             {!hideTracks ? (
                                 <DataCell>
-                                    {data.quay?.publicCode
-                                        ? data.quay?.publicCode
-                                        : '-'}
+                                    {data.quay?.publicCode || '-'}
                                 </DataCell>
                             ) : null}
-                            <DataCell>
-                                {!hideTracks ? (
-                                    <div>Hvis spor er på</div>
-                                ) : (
-                                    <div></div>
-                                )}
-                            </DataCell>
-                            <DataCell>
-                                {!hideSituations ? (
-                                    <div>
-                                        {isMobile && data?.situation ? (
-                                            <SituationModal
-                                                situationMessage={
-                                                    data?.situation
-                                                }
-                                            />
-                                        ) : (
-                                            <SubLabelIcon
-                                                subLabel={createTileSubLabel(
-                                                    data,
-                                                )}
-                                            />
-                                        )}
-                                    </div>
-                                ) : null}
-                            </DataCell>
+                            {!hideSituations ? (
+                                <DataCell>
+                                    {isMobile && data?.situation ? (
+                                        <SituationModal
+                                            situationMessage={data?.situation}
+                                        />
+                                    ) : (
+                                        <SubLabelIcon
+                                            subLabel={createTileSubLabel(data)}
+                                        />
+                                    )}
+                                </DataCell>
+                            ) : null}
                         </TableRow>
                     ))}
                 </TableBody>

--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -55,7 +55,7 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
     const { departures } = stopPlaceWithDepartures
     const headerIcons = getTransportHeaderIcons(departures)
     const [settings] = useSettingsContext()
-    const { hideSituations } = settings || {}
+    const { hideSituations, hideTracks } = settings || {}
     const [iconColorType, setIconColorType] = useState<IconColorType>(
         IconColorType.CONTRAST,
     )
@@ -76,24 +76,26 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                 <col
                     style={
                         !isMobile
-                            ? { width: '4%', minWidth: '2rem' }
-                            : { width: '15%' }
+                            ? { width: '5%', minWidth: '2rem' }
+                            : { width: '10%' }
                     }
                 />
-                <col style={!isMobile ? { width: '26%' } : { width: '41%' }} />
+                <col style={!isMobile ? { width: '25%' } : { width: '35%' }} />
                 <col
                     style={
                         !isMobile
-                            ? { width: '9%', minWidth: '5rem' }
-                            : { width: '28%' }
+                            ? { width: '7%', minWidth: '5rem' }
+                            : { width: '30%' }
                     }
                 />
-                <col style={!isMobile ? { width: '62%' } : { width: '16%' }} />
+                <col style={!isMobile ? { width: '7%' } : { width: '10%' }} />
+                <col style={!isMobile ? { width: '56%' } : { width: '10%' }} />
                 <TableHead>
                     <TableRow className="tableRow">
                         <HeaderCell> </HeaderCell>
                         <HeaderCell>Linje</HeaderCell>
                         <HeaderCell>Avgang</HeaderCell>
+                        {!hideTracks ? <HeaderCell>Spor</HeaderCell> : null}
                         {!hideSituations ? (
                             <HeaderCell>Avvik</HeaderCell>
                         ) : null}
@@ -119,6 +121,13 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                                 </Heading3>
                             </DataCell>
                             <DataCell>{data.time}</DataCell>
+                            <DataCell>
+                                {!hideTracks ? (
+                                    <div>Hvis spor er på</div>
+                                ) : (
+                                    <div></div>
+                                )}
+                            </DataCell>
                             <DataCell>
                                 {!hideSituations ? (
                                     <div>

--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -85,11 +85,11 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                     style={
                         !isMobile
                             ? { width: '7%', minWidth: '5rem' }
-                            : { width: '30%' }
+                            : { width: '23%' }
                     }
                 />
-                <col style={!isMobile ? { width: '7%' } : { width: '10%' }} />
-                <col style={!isMobile ? { width: '56%' } : { width: '10%' }} />
+                <col style={!isMobile ? { width: '20%' } : { width: '17%' }} />
+                <col style={!isMobile ? { width: '43%' } : { width: '10%' }} />
                 <TableHead>
                     <TableRow className="tableRow">
                         <HeaderCell> </HeaderCell>
@@ -121,13 +121,13 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
                                 </Heading3>
                             </DataCell>
                             <DataCell>{data.time}</DataCell>
-                            <DataCell>
-                                {!hideTracks ? (
-                                    <div>Hvis spor er på</div>
-                                ) : (
-                                    <div></div>
-                                )}
-                            </DataCell>
+                            {!hideTracks ? (
+                                <DataCell>
+                                    {data.quay?.publicCode
+                                        ? data.quay?.publicCode
+                                        : '-'}
+                                </DataCell>
+                            ) : null}
                             <DataCell>
                                 {!hideSituations ? (
                                     <div>

--- a/src/dashboards/BusStop/DepartureTile/styles.scss
+++ b/src/dashboards/BusStop/DepartureTile/styles.scss
@@ -57,13 +57,14 @@
             padding: 0;
         }
         &__data-cell {
-            align-items: left;
+            align-items: center;
+            padding: 0.25rem;
         }
         .eds-table__header-cell {
             padding: 0 0;
         }
     }
     .tableRow {
-        align-items: left;
+        align-items: center;
     }
 }

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -24,6 +24,7 @@ import { isEqualUnsorted, usePrevious } from '../../utils'
 
 import DepartureTile from './DepartureTile'
 import MapTile from './MapTile'
+
 import BikeTile from './BikeTile'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
@@ -58,7 +59,7 @@ const BREAKPOINTS = {
 }
 
 const COLS: { [key: string]: number } = {
-    lg: 4,
+    lg: 3,
     md: 3,
     sm: 1,
     xs: 1,

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -48,6 +48,7 @@ const DepartureTile = ({
     const routes = Object.keys(groupedDepartures)
     const [settings] = useSettingsContext()
     const hideSituations = settings?.hideSituations
+    const hideTracks = settings?.hideTracks
     const [iconColorType, setIconColorType] = useState<IconColorType>(
         IconColorType.CONTRAST,
     )
@@ -73,6 +74,7 @@ const DepartureTile = ({
                         subLabels={routeData.map(createTileSubLabel)}
                         icon={icon}
                         hideSituations={hideSituations}
+                        hideTracks={hideTracks}
                         platform={platform}
                         type={routeType}
                     />

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -31,13 +31,9 @@ export function TileRow({
             <div className="tilerow__icon">{icon}</div>
             <div className="tilerow__texts">
                 <Heading3 className="tilerow__label">{label}</Heading3>
-                <div>
-                    {!hideTracks ? (
-                        <PlatformInfo platform={platform} type={type} />
-                    ) : (
-                        [null]
-                    )}
-                </div>
+                {!hideTracks && (
+                    <PlatformInfo platform={platform} type={type} />
+                )}
                 <div className="tilerow__sublabels">
                     {subLabels.map((subLabel, index) => (
                         <div className="tilerow__sublabel" key={index}>

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -22,6 +22,7 @@ export function TileRow({
     icon,
     subLabels,
     hideSituations,
+    hideTracks,
     platform,
     type,
 }: Props): JSX.Element {
@@ -30,7 +31,13 @@ export function TileRow({
             <div className="tilerow__icon">{icon}</div>
             <div className="tilerow__texts">
                 <Heading3 className="tilerow__label">{label}</Heading3>
-                <PlatformInfo platform={platform} type={type} />
+                <div>
+                    {!hideTracks ? (
+                        <PlatformInfo platform={platform} type={type} />
+                    ) : (
+                        [null]
+                    )}
+                </div>
                 <div className="tilerow__sublabels">
                     {subLabels.map((subLabel, index) => (
                         <div className="tilerow__sublabel" key={index}>
@@ -82,6 +89,7 @@ interface Props {
     subLabels: TileSubLabel[]
     icon: JSX.Element | null
     hideSituations?: boolean
+    hideTracks?: boolean
     platform?: string
     type?: string
 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -44,6 +44,7 @@ export interface Settings {
     description?: string
     showMap?: boolean
     hideSituations?: boolean
+    hideTracks?: boolean
 }
 
 interface SettingsSetters {
@@ -68,6 +69,7 @@ interface SettingsSetters {
     setDescription: (description: string) => void
     setShowMap: (visible: boolean) => void
     setHideSituations: (hidden: boolean) => void
+    setHideTracks: (hidden: boolean) => void
 }
 
 export const SettingsContext = createContext<
@@ -94,6 +96,7 @@ export const SettingsContext = createContext<
         setDescription: (): void => undefined,
         setShowMap: (): void => undefined,
         setHideSituations: (): void => undefined,
+        setHideTracks: (): void => undefined,
     },
 ])
 
@@ -337,6 +340,12 @@ export function useSettings(): [Settings | null, SettingsSetters] {
         },
         [set],
     )
+    const setHideTracks = useCallback(
+        (hidden: boolean): void => {
+            set('hideTracks', hidden)
+        },
+        [set],
+    )
 
     const setters = {
         setBoardName,
@@ -358,6 +367,7 @@ export function useSettings(): [Settings | null, SettingsSetters] {
         setDescription,
         setShowMap,
         setHideSituations,
+        setHideTracks,
     }
 
     return [settings, setters]


### PR DESCRIPTION
Added a toggle for track info in the admin panel, as well as track info now being visible in view "busstop".

![Screenshot 2021-07-14 at 09 42 00](https://user-images.githubusercontent.com/32451773/125583224-519586c7-5fc1-4d00-8ecc-21d214bff4d2.png)
![Screenshot 2021-07-14 at 09 43 37](https://user-images.githubusercontent.com/32451773/125583300-725f2718-80da-4ae5-9ce2-061823767a7b.png)
