### PR TITLE
Updated the styling of compact view to match new design sheets

### DIFF
--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -5,6 +5,7 @@
     display: flex;
     border-bottom: 2px solid var(--tavla-border-color);
     padding: 1rem 0;
+    overflow-x: hidden;
 
     &:last-child {
         border-bottom: 0;

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -91,7 +91,7 @@ const COLS: { [key: string]: number } = {
 
 const EnturDashboard = ({ history }: Props): JSX.Element | null => {
     const [settings] = useSettingsContext()
-    const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint)
+    const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
     const dashboardKey = history.location.key
     const boardId =
         useRouteMatch<{ documentId: string }>('/t/:documentId')?.params

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -64,6 +64,15 @@ function getDataGrid(
     }
 }
 
+function getDefaultBreakpoint() {
+    if (window.innerWidth > BREAKPOINTS.lg) {
+        return 'lg'
+    } else if (window.innerWidth > BREAKPOINTS.md) {
+        return 'md'
+    }
+    return 'sm'
+}
+
 const BREAKPOINTS = {
     lg: 1200,
     md: 996,
@@ -73,8 +82,8 @@ const BREAKPOINTS = {
 }
 
 const COLS: { [key: string]: number } = {
-    lg: 4,
-    md: 3,
+    lg: 3,
+    md: 2,
     sm: 1,
     xs: 1,
     xxs: 1,
@@ -82,7 +91,7 @@ const COLS: { [key: string]: number } = {
 
 const EnturDashboard = ({ history }: Props): JSX.Element | null => {
     const [settings] = useSettingsContext()
-    const [breakpoint, setBreakpoint] = useState<string>('lg')
+    const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint)
     const dashboardKey = history.location.key
     const boardId =
         useRouteMatch<{ documentId: string }>('/t/:documentId')?.params
@@ -299,6 +308,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
                         layouts={gridLayouts}
                         isResizable={!isMobileWeb()}
                         isDraggable={!isMobileWeb()}
+                        margin={[32, 32]}
                         onBreakpointChange={(newBreakpoint: string) => {
                             setBreakpoint(newBreakpoint)
                         }}

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -13,6 +13,7 @@
             overflow-y: hidden;
             overflow-x: hidden;
             margin-bottom: 1rem;
+            border-radius: 16px;
         }
 
         .maptile {
@@ -46,43 +47,7 @@
         transition-property: left, top;
         z-index: 1;
         display: flex;
-    }
-
-    .react-grid-item:not(#compact-map-tile)::after {
-        content: '';
-        position: absolute;
-        width: 100%;
-        height: 50px;
-        bottom: 0;
-        background-color: var(--tavla-box-background-color);
-        mask-image: linear-gradient(
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 0.7) 70%,
-            rgba(0, 0, 0, 1) 100%
-        );
-        -webkit-mask-image: -webkit-linear-gradient(
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 0.7) 70%,
-            rgba(0, 0, 0, 1) 100%
-        );
-        z-index: 1;
-    }
-
-    .react-grid-item:not(#compact-map-tile)::before {
-        content: '';
-        position: absolute;
-        width: 2rem;
-        height: 80%;
-        right: 0;
-        bottom: 0;
-        background-color: var(--tavla-box-background-color);
-        mask-image: linear-gradient(
-            to right,
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 0.7) 70%,
-            rgba(0, 0, 0, 1) 100%
-        );
-        z-index: 1;
+        border-radius: 16px;
     }
 
     .react-grid-item.cssTransforms {
@@ -150,6 +115,21 @@
 
     .react-grid-item:hover > .resizeHandle {
         opacity: 1;
+    }
+}
+
+@media (min-width: 996px) {
+    .compact {
+        &__tiles {
+            /*
+            react-grid-layout uses a margin of 32px between all grid-items.
+            This makes the tiles not lign up with the header, so to counteract
+            these margins on the sides, this styling is needed. 
+            */
+
+            margin-left: -32px;
+            margin-right: -32px;
+        }
     }
 }
 

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -13,7 +13,7 @@
             overflow-y: hidden;
             overflow-x: hidden;
             margin-bottom: 1rem;
-            border-radius: 16px;
+            border-radius: 1rem;
         }
 
         .maptile {
@@ -21,6 +21,8 @@
             width: 100%;
             overflow: hidden;
             margin-bottom: 1rem;
+            border-radius: 1rem;
+            z-index: 1;
         }
     }
 
@@ -47,7 +49,6 @@
         transition-property: left, top;
         z-index: 1;
         display: flex;
-        border-radius: 16px;
     }
 
     .react-grid-item.cssTransforms {
@@ -127,8 +128,8 @@
             these margins on the sides, this styling is needed. 
             */
 
-            margin-left: -32px;
-            margin-right: -32px;
+            margin-left: -2rem;
+            margin-right: -2rem;
         }
     }
 }


### PR DESCRIPTION
Updated the styling for compact view tiles to match the new design sheets in Figma.

Before:
<img width="1606" alt="Screenshot 2021-07-14 at 10 55 15" src="https://user-images.githubusercontent.com/31273371/125593942-22b415c7-e945-4714-84db-0eb605983ea9.png">

After:
<img width="1609" alt="Screenshot 2021-07-14 at 10 52 50" src="https://user-images.githubusercontent.com/31273371/125593952-fb891430-45c2-4a92-970e-9c9c14e820eb.png">
