### PR TITLE
updated transport icons to have colors

### DIFF
--- a/src/dashboards/Compact/BikeTile/index.tsx
+++ b/src/dashboards/Compact/BikeTile/index.tsx
@@ -25,7 +25,10 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
         <Tile
             title="Bysykkel"
             icons={[
-                <BicycleIcon key="bike-icon" color={colors.blues.blue60} />,
+                <BicycleIcon
+                    key="bike-icon"
+                    color={colors.transport[iconColorType].mobility}
+                />,
             ]}
         >
             {stations.map(({ name, bikesAvailable, id, spacesAvailable }) => (

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -30,11 +30,10 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
             getTransportIconIdentifier(a.type, a.subType) ===
             getTransportIconIdentifier(b.type, b.subType),
     )
+    console.log(transportModes)
 
     return transportModes
-        .map(({ type, subType }) =>
-            getIcon(type, undefined, subType, colors.blues.blue60),
-        )
+        .map(({ type, subType }) => getIcon(type, undefined, subType))
         .filter(isNotNullOrUndefined)
 }
 

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { colors } from '@entur/tokens'
 
 import {
     getIcon,
@@ -30,7 +29,6 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
             getTransportIconIdentifier(a.type, a.subType) ===
             getTransportIconIdentifier(b.type, b.subType),
     )
-    console.log(transportModes)
 
     return transportModes
         .map(({ type, subType }) => getIcon(type, undefined, subType))


### PR DESCRIPTION
The new design sheets has colorful icons in the header for tiles in compact view.

Before:
<img width="545" alt="Screenshot 2021-07-14 at 13 17 40" src="https://user-images.githubusercontent.com/31273371/125613731-3b8ab755-c5e6-4b16-a4ad-39c9e5859c33.png">

After:
<img width="563" alt="Screenshot 2021-07-14 at 13 17 18" src="https://user-images.githubusercontent.com/31273371/125613739-99311f85-4498-41b3-8133-d50a2832821e.png">
