### PR TITLE
Border radius for tiles in all views

### DIFF
--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { colors } from '@entur/tokens'
 import { Heading2, Heading3 } from '@entur/typography'
 import {
     Table,

--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -39,7 +39,7 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     )
 
     const transportIcons = transportModes.map(({ type, subType }) => ({
-        icon: getIcon(type, undefined, subType, colors.blues.blue60),
+        icon: getIcon(type, undefined, subType),
     }))
 
     return transportIcons.map(({ icon }) => icon).filter(isNotNullOrUndefined)

--- a/src/dashboards/BusStop/MapTile/styles.scss
+++ b/src/dashboards/BusStop/MapTile/styles.scss
@@ -10,6 +10,7 @@
     overflow: auto;
     overflow-x: hidden;
     padding-top: 0;
+    z-index: 0;
 
     &__header {
         display: flex;

--- a/src/dashboards/BusStop/index.tsx
+++ b/src/dashboards/BusStop/index.tsx
@@ -27,7 +27,7 @@ function getWalkInfoForStopPlace(
     return walkInfos?.find((walkInfo) => walkInfo.stopId === id)
 }
 
-function BusStop({ history }: Props): JSX.Element {
+function BusStop({ history }: Props): JSX.Element | null {
     const [settings] = useSettingsContext()
     const bikeRentalStations = useBikeRentalStations()
     let stopPlacesWithDepartures = useStopPlacesWithDepartures()
@@ -60,7 +60,7 @@ function BusStop({ history }: Props): JSX.Element {
                                     stop.id,
                                 )}
                             />
-                        ))}{' '}
+                        ))}
                     </div>
                 </GridItem>
                 {settings?.showMap ? (
@@ -80,9 +80,7 @@ function BusStop({ history }: Props): JSX.Element {
                             zoom={settings?.zoom ?? DEFAULT_ZOOM}
                         />
                     </GridItem>
-                ) : (
-                    []
-                )}
+                ) : null}
             </GridContainer>
         </DashboardWrapper>
     )

--- a/src/dashboards/BusStop/styles.scss
+++ b/src/dashboards/BusStop/styles.scss
@@ -10,13 +10,17 @@
 
         .tile {
             margin-right: 2rem;
-            margin-bottom: 1rem;
+            margin-bottom: 2rem;
             max-height: 75vh;
             overflow-y: hidden;
+            border-radius: 1rem;
         }
     }
     &__mapTile {
         height: 75vh;
+        overflow: hidden;
+        border-radius: 1rem;
+        z-index: 1;
     }
     .eds-table {
         &__head {

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -29,7 +29,7 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
             icons={[
                 <BicycleIcon
                     key="bike-tile-icon"
-                    color={colors.blues.blue60}
+                    color={colors.transport[iconColorType].mobility}
                 />,
             ]}
         >

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { colors } from '@entur/tokens'
 
 import {
     getIcon,

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -31,7 +31,7 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     )
 
     const transportIcons = transportModes.map(({ type, subType }) => ({
-        icon: getIcon(type, undefined, subType, colors.blues.blue60),
+        icon: getIcon(type, undefined, subType),
     }))
 
     return transportIcons.map(({ icon }) => icon).filter(isNotNullOrUndefined)

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -60,6 +60,15 @@ function getDataGrid(
     }
 }
 
+function getDefaultBreakpoint() {
+    if (window.innerWidth > BREAKPOINTS.lg) {
+        return 'lg'
+    } else if (window.innerWidth > BREAKPOINTS.md) {
+        return 'md'
+    }
+    return 'sm'
+}
+
 const BREAKPOINTS = {
     lg: 1200,
     md: 996,
@@ -83,7 +92,7 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
         useRouteMatch<{ documentId: string }>('/t/:documentId')?.params
             ?.documentId
 
-    const [breakpoint, setBreakpoint] = useState<string>('lg')
+    const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
         getFromLocalStorage(dashboardKey),
     )

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -278,6 +278,7 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
                     layouts={gridLayouts}
                     isResizable={!isMobileWeb()}
                     isDraggable={!isMobileWeb()}
+                    margin={[32, 32]}
                     onBreakpointChange={(newBreakpoint: string) => {
                         setBreakpoint(newBreakpoint)
                     }}

--- a/src/dashboards/Chrono/styles.scss
+++ b/src/dashboards/Chrono/styles.scss
@@ -15,6 +15,7 @@
             &__header-icons {
                 font-size: 2rem;
             }
+            border-radius: 1rem;
         }
 
         .maptile {
@@ -22,6 +23,8 @@
             width: 100%;
             overflow: hidden;
             margin-bottom: 1rem;
+            border-radius: 1rem;
+            z-index: 1;
         }
     }
 
@@ -38,26 +41,6 @@
         transition-property: left, top;
         z-index: 1;
         display: flex;
-    }
-
-    .react-grid-item:not(#chrono-map-tile)::after {
-        content: '';
-        position: absolute;
-        width: 100%;
-        height: 50px;
-        bottom: 0;
-        background-color: var(--tavla-box-background-color);
-        mask-image: linear-gradient(
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 0.7) 70%,
-            rgba(0, 0, 0, 1) 100%
-        );
-        -webkit-mask-image: -webkit-linear-gradient(
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 0.7) 70%,
-            rgba(0, 0, 0, 1) 100%
-        );
-        z-index: 1;
     }
 
     .react-grid-item.cssTransforms {
@@ -121,6 +104,21 @@
 
     .react-grid-item:hover > .react-resizable-handle::after {
         bottom: 0.5rem;
+    }
+}
+
+@media (min-width: 996px) {
+    .chrono {
+        &__tiles {
+            /*
+            react-grid-layout uses a margin of 32px between all grid-items.
+            This makes the tiles not lign up with the header, so to counteract
+            these margins on the sides, this styling is needed. 
+            */
+
+            margin-left: -2rem;
+            margin-right: -2rem;
+        }
     }
 }
 

--- a/src/dashboards/Chrono/styles.scss
+++ b/src/dashboards/Chrono/styles.scss
@@ -15,6 +15,7 @@
             &__header-icons {
                 font-size: 2rem;
             }
+
             border-radius: 1rem;
         }
 

--- a/src/dashboards/Map/DepartureTag/styles.scss
+++ b/src/dashboards/Map/DepartureTag/styles.scss
@@ -7,7 +7,7 @@
     color: $colors-brand-blue;
     margin-left: 1rem;
     margin-right: 1rem;
-    border-radius: 0.25rem;
+    border-radius: 1rem;
     min-width: 376px;
     max-width: 376px;
     height: auto;

--- a/src/dashboards/Timeline/styles.scss
+++ b/src/dashboards/Timeline/styles.scss
@@ -11,9 +11,10 @@
     &__stop {
         background-color: var(--tavla-box-background-color);
         width: 100%;
-        margin-bottom: 1rem;
+        margin-bottom: 2rem;
         padding: 2rem;
         overflow: hidden;
+        border-radius: 1rem;
     }
     &__stop:last-child {
         margin-bottom: 5rem;


### PR DESCRIPTION
Added border radius in all views, in addition to some colorful transport mode icons where suitable.

Screenshots:

<img width="1629" alt="Screenshot 2021-07-15 at 10 45 31" src="https://user-images.githubusercontent.com/31273371/125759092-36af1731-6e83-4c25-8788-a5d927cd692d.png">
<img width="1615" alt="Screenshot 2021-07-15 at 10 45 08" src="https://user-images.githubusercontent.com/31273371/125759099-2777ded0-770b-433e-b90f-cb8d84b57975.png">
<img width="814" alt="Screenshot 2021-07-15 at 10 44 53" src="https://user-images.githubusercontent.com/31273371/125759107-3f714f56-4f15-454d-aeff-2aebe2fbc221.png">
<img width="1594" alt="Screenshot 2021-07-15 at 10 44 39" src="https://user-images.githubusercontent.com/31273371/125759109-ae5e03a2-737c-41fe-a1be-139bf87d226b.png">
