### PR TITLE
Fix bug when distance from stop place is zero

### DIFF
--- a/src/logic/useWalkInfo.ts
+++ b/src/logic/useWalkInfo.ts
@@ -33,11 +33,16 @@ async function getWalkInfo(
                     modes: [QueryMode.FOOT],
                     limit: 1,
                 })
-                .then((result) => ({
-                    stopId: stopPlace.id,
-                    walkTime: result[0].duration,
-                    walkDistance: result[0].walkDistance,
-                }))
+                .then((result) => {
+                    if (!result[0].duration || !result[0].walkDistance) {
+                        return null
+                    }
+                    return {
+                        stopId: stopPlace.id,
+                        walkTime: result[0].duration,
+                        walkDistance: result[0].walkDistance,
+                    }
+                })
                 .catch(() => null),
         ),
     )


### PR DESCRIPTION
As in picture below, if position is _Jernbanetorget_ **and** stop place is _Jernbanetorget_, walking distance in minutes was previously set to NaN and meter set to zero.

Before:

<img width="1074" alt="Screenshot 2021-07-15 at 12 52 32" src="https://user-images.githubusercontent.com/67413374/125776698-804b87f8-7740-4a1a-84e4-5d76241c37ab.png">


After:
<img width="1206" alt="Screenshot 2021-07-15 at 12 51 52" src="https://user-images.githubusercontent.com/67413374/125776711-22dd25a0-c5c6-44f8-995f-4db066517d3d.png">
