### PR TITLE
Change font colour on walkingDistance

### DIFF
--- a/src/dashboards/BusStop/DepartureTile/styles.scss
+++ b/src/dashboards/BusStop/DepartureTile/styles.scss
@@ -47,7 +47,7 @@
         font-style: normal;
         font-weight: normal;
         font-size: 1rem;
-        color: var(--tavla-label-font-color);
+        color: var(--tavla-font-color);
     }
 }
 

--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -37,6 +37,6 @@
         font-style: normal;
         font-weight: normal;
         font-size: 1rem;
-        color: var(--tavla-label-font-color);
+        color: var(--tavla-font-color);
     }
 }

--- a/src/dashboards/Compact/components/Tile/styles.scss
+++ b/src/dashboards/Compact/components/Tile/styles.scss
@@ -38,6 +38,6 @@
         font-style: normal;
         font-weight: normal;
         font-size: 1rem;
-        color: var(--tavla-label-font-color);
+        color: var(--tavla-font-color);
     }
 }


### PR DESCRIPTION
Change font colour on walking distance from purple to white, so that it is easier to separate this information from information on the next row. This is especially prominent in BusStop view, se pictures below.

Before:
<img width="1231" alt="Screenshot 2021-07-15 at 13 42 23" src="https://user-images.githubusercontent.com/67413374/125782580-8a17515d-9b36-4251-a5d7-f976f87ce903.png">

After:
<img width="1235" alt="Screenshot 2021-07-15 at 13 43 05" src="https://user-images.githubusercontent.com/67413374/125782602-8eb16d3d-7042-4ddf-b2e8-2651f0dde2a0.png">

