### PR TITLE
tiles looks better on mobile devices

### DIFF
--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -49,15 +49,15 @@ function getColumnSizes(
     )
     return (
         <>
-            {getColSize('14%', '16%')}
+            {getColSize('14%', '14%')}
             {!hideTracks && !hideSituations
-                ? getColSize('44%', '42%')
+                ? getColSize('44%', '38%')
                 : !hideTracks || !hideSituations
-                ? getColSize('54%', '54%')
-                : getColSize('64%', '66%')}
-            {getColSize('20%', '18%')}
-            {!hideTracks ? getColSize('10%', '12%') : null}
-            {!hideSituations ? getColSize('10%', '12%') : null}
+                ? getColSize('54%', '49%')
+                : getColSize('64%', '61%')}
+            {getColSize('20%', '20%')}
+            {!hideTracks ? getColSize('10%', '11%') : null}
+            {!hideSituations ? getColSize('10%', '11%') : null}
         </>
     )
 }

--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -52,4 +52,7 @@
         font-size: 1rem;
         color: var(--tavla-font-color);
     }
+    @media (max-width: 480px) {
+        padding: 2rem 1rem;
+    }
 }

--- a/src/dashboards/Chrono/components/TileRows/styles.scss
+++ b/src/dashboards/Chrono/components/TileRows/styles.scss
@@ -51,4 +51,11 @@
     @media (max-width: 1000px) {
         padding: 0.5rem;
     }
+
+    @media (max-width: 480px) {
+        &__icon {
+            min-width: 1.5rem;
+            font-size: 1.5rem;
+        }
+    }
 }


### PR DESCRIPTION
Removed a bit of padding, scaled down transport icons.

![Simulator Screen Shot - iPhone 12 mini - 2021-07-16 at 14 41 19](https://user-images.githubusercontent.com/31273371/125950430-46a020e3-2038-45d4-84b3-e84b1a2dd349.png)
