### PR TITLE
Add walking distance on bike tile in chrono view

### DIFF
--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react'
 import { BikeRentalStation } from '@entur/sdk'
-import { Heading3 } from '@entur/typography'
 import { colors } from '@entur/tokens'
 import { BicycleIcon } from '@entur/icons'
 
@@ -45,30 +44,6 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                 />,
             ]}
         >
-            {/* {stations.map(({ name, bikesAvailable, id, spacesAvailable }) => (
-                <div key={id} className="bikerow">
-                    <div className="bikerow__icon">
-                        <BicycleIcon
-                            color={colors.transport[iconColorType].mobility}
-                        />
-                    </div>
-                    <div className="bikerow__texts">
-                        <Heading3 className="bikerow__label">{name}</Heading3>
-                        <div className="bikerow__sublabels">
-                            {bikesAvailable === 1 ? (
-                                <span>1 sykkel</span>
-                            ) : (
-                                <span>{`${bikesAvailable} sykler`}</span>
-                            )}
-                            {spacesAvailable === 1 ? (
-                                <span>1 lås</span>
-                            ) : (
-                                <span>{`${spacesAvailable} låser`}</span>
-                            )}
-                        </div>
-                    </div>
-                </div>
-            ))} */}
             {stations.map((station) => {
                 return (
                     <TileRow

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -44,41 +44,36 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                 />,
             ]}
         >
-            {stations.map((station) => {
-                return (
-                    <TileRow
-                        key={station.id}
-                        icon={
-                            <BicycleIcon
-                                color={colors.transport[iconColorType].mobility}
-                            />
-                        }
-                        walkInfoBike={
-                            !hideWalkInfo
-                                ? getWalkInfoBike(
-                                      walkInfoBike || [],
-                                      station.id,
-                                  )
-                                : undefined
-                        }
-                        label={station.name}
-                        subLabels={[
-                            {
-                                time:
-                                    station.bikesAvailable === 1
-                                        ? '1 sykkel'
-                                        : `${station.bikesAvailable} sykler`,
-                            },
-                            {
-                                time:
-                                    station.spacesAvailable === 1
-                                        ? '1 lås'
-                                        : `${station.spacesAvailable} låser`,
-                            },
-                        ]}
-                    />
-                )
-            })}
+            {stations.map((station) => (
+                <TileRow
+                    key={station.id}
+                    icon={
+                        <BicycleIcon
+                            color={colors.transport[iconColorType].mobility}
+                        />
+                    }
+                    walkInfoBike={
+                        !hideWalkInfo
+                            ? getWalkInfoBike(walkInfoBike || [], station.id)
+                            : undefined
+                    }
+                    label={station.name}
+                    subLabels={[
+                        {
+                            time:
+                                station.bikesAvailable === 1
+                                    ? '1 sykkel'
+                                    : `${station.bikesAvailable} sykler`,
+                        },
+                        {
+                            time:
+                                station.spacesAvailable === 1
+                                    ? '1 lås'
+                                    : `${station.spacesAvailable} låser`,
+                        },
+                    ]}
+                />
+            ))}
         </Tile>
     )
 }

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -10,9 +10,19 @@ import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { IconColorType } from '../../../types'
 import { getIconColorType } from '../../../utils'
+import useWalkInfoBike, { WalkInfoBike } from '../../../logic/useWalkInfoBike'
+import TileRow from '../../Compact/components/TileRow'
+
+function getWalkInfoBike(
+    walkInfos: WalkInfoBike[],
+    id: string,
+): WalkInfoBike | undefined {
+    return walkInfos.find((walkInfoBike) => walkInfoBike.stopId === id)
+}
 
 const BikeTile = ({ stations }: Props): JSX.Element => {
     const [settings] = useSettingsContext()
+    const hideWalkInfo = settings?.hideWalkInfo
     const [iconColorType, setIconColorType] = useState<IconColorType>(
         IconColorType.CONTRAST,
     )
@@ -22,6 +32,8 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
             setIconColorType(getIconColorType(settings.theme))
         }
     }, [settings])
+
+    const walkInfoBike = useWalkInfoBike(stations)
 
     return (
         <Tile
@@ -33,7 +45,7 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                 />,
             ]}
         >
-            {stations.map(({ name, bikesAvailable, id, spacesAvailable }) => (
+            {/* {stations.map(({ name, bikesAvailable, id, spacesAvailable }) => (
                 <div key={id} className="bikerow">
                     <div className="bikerow__icon">
                         <BicycleIcon
@@ -56,7 +68,42 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                         </div>
                     </div>
                 </div>
-            ))}
+            ))} */}
+            {stations.map((station) => {
+                return (
+                    <TileRow
+                        key={station.id}
+                        icon={
+                            <BicycleIcon
+                                color={colors.transport[iconColorType].mobility}
+                            />
+                        }
+                        walkInfoBike={
+                            !hideWalkInfo
+                                ? getWalkInfoBike(
+                                      walkInfoBike || [],
+                                      station.id,
+                                  )
+                                : undefined
+                        }
+                        label={station.name}
+                        subLabels={[
+                            {
+                                time:
+                                    station.bikesAvailable === 1
+                                        ? '1 sykkel'
+                                        : `${station.bikesAvailable} sykler`,
+                            },
+                            {
+                                time:
+                                    station.spacesAvailable === 1
+                                        ? '1 lås'
+                                        : `${station.spacesAvailable} låser`,
+                            },
+                        ]}
+                    />
+                )
+            })}
         </Tile>
     )
 }

--- a/src/dashboards/Chrono/BikeTile/styles.scss
+++ b/src/dashboards/Chrono/BikeTile/styles.scss
@@ -8,7 +8,8 @@
 
     &__label {
         margin: 0;
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.25rem;
+        color: var(--tavla-font-color);
     }
 
     &__texts {
@@ -19,7 +20,18 @@
     &__icon {
         min-width: 2rem;
         margin-right: 1rem;
-        font-size: 1.5rem;
+        font-size: $font-sizes-extra-large4;
+    }
+
+    &__walking-time {
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1rem;
+        margin: 0.5rem 0;
+        color: var(--tavla-label-font-color);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     &__sublabels {
@@ -28,9 +40,5 @@
         font-size: 1.25rem;
         justify-content: space-between;
         max-width: 18rem;
-
-        span {
-            font-weight: 400;
-        }
     }
 }

--- a/src/dashboards/Chrono/components/TileRows/index.tsx
+++ b/src/dashboards/Chrono/components/TileRows/index.tsx
@@ -12,14 +12,28 @@ import './styles.scss'
 
 import SituationModal from '../../../../components/SituationModal'
 import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
+import { WalkInfoBike } from '../../../../logic/useWalkInfoBike'
 
 const isMobile = isMobileWeb()
+
+function formatWalkInfo(walkInfoBike: WalkInfoBike) {
+    if (walkInfoBike.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(
+            walkInfoBike.walkDistance,
+        )} m)`
+    } else {
+        return `${Math.ceil(walkInfoBike.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfoBike.walkDistance,
+        )} m)`
+    }
+}
 
 export function TileRows({
     visibleDepartures,
     hideSituations,
     hideTracks,
     iconColorType,
+    walkInfoBike,
 }: Props): JSX.Element {
     return (
         <TableBody>
@@ -57,6 +71,11 @@ export function TileRows({
                                     />
                                 </div>
                             </DataCell>
+                        ) : null}
+                        {walkInfoBike ? (
+                            <div className="tilerow__walking-time">
+                                {formatWalkInfo(walkInfoBike)}
+                            </div>
                         ) : null}
                     </TableRow>
                 )
@@ -99,6 +118,7 @@ interface Props {
     visibleDepartures: LineData[]
     hideSituations: boolean | undefined
     hideTracks: boolean | undefined
+    walkInfoBike?: WalkInfoBike
     iconColorType: IconColorType
 }
 

--- a/src/dashboards/Chrono/components/TileRows/index.tsx
+++ b/src/dashboards/Chrono/components/TileRows/index.tsx
@@ -12,28 +12,14 @@ import './styles.scss'
 
 import SituationModal from '../../../../components/SituationModal'
 import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
-import { WalkInfoBike } from '../../../../logic/useWalkInfoBike'
 
 const isMobile = isMobileWeb()
-
-function formatWalkInfo(walkInfoBike: WalkInfoBike) {
-    if (walkInfoBike.walkTime / 60 < 1) {
-        return `Mindre enn 1 min å gå (${Math.ceil(
-            walkInfoBike.walkDistance,
-        )} m)`
-    } else {
-        return `${Math.ceil(walkInfoBike.walkTime / 60)} min å gå (${Math.ceil(
-            walkInfoBike.walkDistance,
-        )} m)`
-    }
-}
 
 export function TileRows({
     visibleDepartures,
     hideSituations,
     hideTracks,
     iconColorType,
-    walkInfoBike,
 }: Props): JSX.Element {
     return (
         <TableBody>
@@ -71,11 +57,6 @@ export function TileRows({
                                     />
                                 </div>
                             </DataCell>
-                        ) : null}
-                        {walkInfoBike ? (
-                            <div className="tilerow__walking-time">
-                                {formatWalkInfo(walkInfoBike)}
-                            </div>
                         ) : null}
                     </TableRow>
                 )
@@ -118,7 +99,6 @@ interface Props {
     visibleDepartures: LineData[]
     hideSituations: boolean | undefined
     hideTracks: boolean | undefined
-    walkInfoBike?: WalkInfoBike
     iconColorType: IconColorType
 }
 

--- a/src/dashboards/Chrono/components/TileRows/styles.scss
+++ b/src/dashboards/Chrono/components/TileRows/styles.scss
@@ -26,7 +26,6 @@
         font-weight: 400;
         margin: 0;
         margin-top: 7px;
-        margin-left: auto;
         min-width: 5rem;
         text-align: right;
 

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -32,7 +32,7 @@
         white-space: nowrap;
         text-overflow: ellipsis;
     }
-    
+
     &__walking-time {
         font-style: normal;
         font-weight: normal;

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -28,13 +28,20 @@
     &__texts {
         flex-direction: column;
         flex-grow: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
+    
     &__walking-time {
         font-style: normal;
         font-weight: normal;
         font-size: 1rem;
         margin: 0.5rem 0;
         color: var(--tavla-label-font-color);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     &__sublabels {


### PR DESCRIPTION
Add walking distance (in meter and minutes) for each bike station in the bikeTile in Chrono view.

Before:
<img width="634" alt="Screenshot 2021-07-19 at 14 02 14" src="https://user-images.githubusercontent.com/67413374/126157069-55ddab04-7ad0-4177-a744-145c8f4b2e04.png">

After:
<img width="693" alt="Screenshot 2021-07-19 at 14 02 29" src="https://user-images.githubusercontent.com/67413374/126157071-d83ed18c-7044-453f-9a1a-128a9ab22e2d.png">
