### PR TITLE
Tooltip added to distance edit field in admin panel

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -8,6 +8,7 @@ import React, {
 import { BikeRentalStation } from '@entur/sdk'
 import { Heading2, Heading3 } from '@entur/typography'
 import { Switch, TextField } from '@entur/form'
+import { Tooltip } from '@entur/tooltip'
 import { WidthProvider, Responsive } from 'react-grid-layout'
 
 import { useSettingsContext, Mode } from '../../../settings'
@@ -23,6 +24,10 @@ import { DEFAULT_DISTANCE, DEFAULT_ZOOM } from '../../../constants'
 import { StopPlaceWithLines } from '../../../types'
 import { useNearestPlaces, useScooters } from '../../../logic'
 import service, { getStopPlacesWithLines } from '../../../service'
+import {
+    saveToLocalStorage,
+    getFromLocalStorage,
+} from '../../../settings/LocalStorage'
 
 import StopPlacePanel from './StopPlacePanel'
 import BikePanelSearch from './BikeSearch'
@@ -185,6 +190,14 @@ const EditTab = (): JSX.Element => {
         },
         [setHiddenModes, hiddenModes],
     )
+    const [showTooltip, setShowTooltip] = useState<boolean>(false)
+
+    useEffect(() => {
+        if (!getFromLocalStorage('hasShownTooltip')) {
+            setShowTooltip(true)
+            saveToLocalStorage('hasShownTooltip', true)
+        }
+    }, [])
 
     const validateInput = (e: SyntheticEvent<HTMLInputElement>) => {
         const newDistance = Number(e.currentTarget.value)
@@ -196,27 +209,50 @@ const EditTab = (): JSX.Element => {
             setDistance(1000)
         }
     }
-
     return (
         <div className="edit-tab">
-            <Heading2 className="heading">
-                Viser kollektivtilbud innenfor
-                <div className="edit-tab__input-wrapper">
-                    <TextField
-                        className="edit-tab__expanding-text-field heading"
-                        size="large"
-                        defaultValue={distance}
-                        onKeyDown={validateInput}
-                        append="m"
-                        type="number"
-                        max={1000}
-                        min={1}
-                        maxLength={4}
-                        minLength={1}
-                    />
-                </div>
-                rundt {locationName?.split(',')[0]}
-            </Heading2>
+            <div>
+                <Heading2 className="heading">
+                    Viser kollektivtilbud innenfor
+                    <div className="edit-tab__input-wrapper">
+                        <Tooltip
+                            content={
+                                !isMobile
+                                    ? 'Endre på avstanden? Klikk på tallet for å skrive en ny verdi.'
+                                    : 'Klikk for å endre avstand.'
+                            }
+                            placement={!isMobile ? 'bottom' : 'bottom-left'}
+                            isOpen={showTooltip}
+                            showCloseButton={true}
+                            disableHoverListener={false}
+                            disableFocusListener={false}
+                            popperModifiers={[
+                                {
+                                    name: 'offset',
+                                    options: {
+                                        offset: !isMobile ? [20, 30] : [15, 20],
+                                    },
+                                },
+                            ]}
+                        >
+                            <TextField
+                                className="edit-tab__expanding-text-field heading"
+                                size="large"
+                                defaultValue={distance}
+                                onKeyDown={validateInput}
+                                append="m"
+                                type="number"
+                                max={1000}
+                                min={1}
+                                maxLength={4}
+                                minLength={1}
+                            />
+                        </Tooltip>
+                    </div>
+                    rundt {locationName?.split(',')[0]}
+                </Heading2>
+            </div>
+
             <ResponsiveReactGridLayout
                 key={breakpoint}
                 cols={COLS}


### PR DESCRIPTION
Upon entering the admin panel, a tooltip is shown underneath the distance edit panel. Saves to local storage the first time it is shown.

![Screenshot 2021-07-19 at 17 12 16](https://user-images.githubusercontent.com/32451773/126183714-8a5a2289-1190-4e81-874b-66be73ed9b01.png)
![Screenshot 2021-07-19 at 17 12 28](https://user-images.githubusercontent.com/32451773/126183721-2ced743d-8b0e-4215-89c1-eea7f247920d.png)
