### PR TITLE
Pwa onboarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "react-beautiful-dnd": "^13.1.0",
                 "react-dom": "^16.14.0",
                 "react-grid-layout": "^1.2.5",
-                "react-ios-pwa-prompt": "^1.8.4",
+                "react-ios-pwa-prompt": "chrisdancee/react-ios-pwa-prompt#pull/71/head",
                 "react-map-gl": "^4.1.16",
                 "react-router": "^5.2.0",
                 "react-router-dom": "^5.2.0",
@@ -16469,8 +16469,8 @@
         },
         "node_modules/react-ios-pwa-prompt": {
             "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/react-ios-pwa-prompt/-/react-ios-pwa-prompt-1.8.4.tgz",
-            "integrity": "sha512-y2dMzPZWWcdCClb1JItMJkyEfapnJe/Nz2bC8HIMaXTRA4hQfL1nwxsjiENwKESYKQdm6wrrS4b8qD2Mx/bwtw==",
+            "resolved": "git+ssh://git@github.com/chrisdancee/react-ios-pwa-prompt.git#04303787adbf602f89639f5179f7e6b4081d6827",
+            "license": "MIT",
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0"
@@ -34980,9 +34980,8 @@
             }
         },
         "react-ios-pwa-prompt": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/react-ios-pwa-prompt/-/react-ios-pwa-prompt-1.8.4.tgz",
-            "integrity": "sha512-y2dMzPZWWcdCClb1JItMJkyEfapnJe/Nz2bC8HIMaXTRA4hQfL1nwxsjiENwKESYKQdm6wrrS4b8qD2Mx/bwtw==",
+            "version": "git+ssh://git@github.com/chrisdancee/react-ios-pwa-prompt.git#04303787adbf602f89639f5179f7e6b4081d6827",
+            "from": "react-ios-pwa-prompt@chrisdancee/react-ios-pwa-prompt#pull/71/head",
             "requires": {}
         },
         "react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "react-beautiful-dnd": "^13.1.0",
                 "react-dom": "^16.14.0",
                 "react-grid-layout": "^1.2.5",
+                "react-ios-pwa-prompt": "^1.8.4",
                 "react-map-gl": "^4.1.16",
                 "react-router": "^5.2.0",
                 "react-router-dom": "^5.2.0",
@@ -16464,6 +16465,15 @@
             "peerDependencies": {
                 "react": ">= 16.3.0",
                 "react-dom": ">= 16.3.0"
+            }
+        },
+        "node_modules/react-ios-pwa-prompt": {
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/react-ios-pwa-prompt/-/react-ios-pwa-prompt-1.8.4.tgz",
+            "integrity": "sha512-y2dMzPZWWcdCClb1JItMJkyEfapnJe/Nz2bC8HIMaXTRA4hQfL1nwxsjiENwKESYKQdm6wrrS4b8qD2Mx/bwtw==",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
             }
         },
         "node_modules/react-is": {
@@ -34968,6 +34978,12 @@
                 "react-draggable": "^4.0.0",
                 "react-resizable": "^3.0.1"
             }
+        },
+        "react-ios-pwa-prompt": {
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/react-ios-pwa-prompt/-/react-ios-pwa-prompt-1.8.4.tgz",
+            "integrity": "sha512-y2dMzPZWWcdCClb1JItMJkyEfapnJe/Nz2bC8HIMaXTRA4hQfL1nwxsjiENwKESYKQdm6wrrS4b8qD2Mx/bwtw==",
+            "requires": {}
         },
         "react-is": {
             "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dom": "^16.14.0",
         "react-grid-layout": "^1.2.5",
+        "react-ios-pwa-prompt": "^1.8.4",
         "react-map-gl": "^4.1.16",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dom": "^16.14.0",
         "react-grid-layout": "^1.2.5",
-        "react-ios-pwa-prompt": "^1.8.4",
+        "react-ios-pwa-prompt": "chrisdancee/react-ios-pwa-prompt#pull/71/head",
         "react-map-gl": "^4.1.16",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -174,7 +174,7 @@ const Content = (): JSX.Element => {
 
     return (
         <UserProvider value={user}>
-            {!isMobileWeb() ? ProgressiveWebAppPrompt(location.pathname) : null}
+            {isMobileWeb() ? ProgressiveWebAppPrompt(location.pathname) : null}
             <SettingsContext.Provider
                 value={isOnTavle ? settings : [null, settings[1]]}
             >

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -18,6 +18,8 @@ import PrivateRoute from '../routers/PrivateRoute'
 import Header from '../components/Header'
 import BusStop from '../dashboards/BusStop'
 
+import { isMobileWeb } from '../utils'
+
 import LandingPage from './LandingPage'
 import Admin from './Admin'
 import Privacy from './Privacy'
@@ -119,16 +121,17 @@ function updateManifest(pathName: string): void {
 function ProgressiveWebAppPrompt(pathName: string): JSX.Element | null {
     if (pathName === '/' || pathName.includes('admin')) return null
     return (
-        <PWAPrompt
-            promptOnVisit={4}
-            timesToShow={1}
-            permanentlyHideOnDismiss={true}
-            copyTitle="Legg til Tavla på hjemskjermen"
-            copyShareButtonLabel="1) Trykk på 'Del'-knappen på menyen under."
-            copyAddHomeButtonLabel="2) Trykk 'Legg til på hjemskjerm'."
-            copyClosePrompt="Lukk"
-            delay={2000}
-        />
+        <div className="pwa-prompt">
+            <PWAPrompt
+                promptOnVisit={3}
+                timesToShow={1}
+                permanentlyHideOnDismiss={true}
+                copyTitle="Legg til Tavla på hjemskjermen"
+                copyShareButtonLabel="1) Trykk på 'Del'-knappen på menyen under."
+                copyAddHomeButtonLabel="2) Trykk 'Legg til på hjemskjerm'."
+                copyClosePrompt="Lukk"
+            />
+        </div>
     )
 }
 
@@ -153,7 +156,7 @@ const Content = (): JSX.Element => {
 
     return (
         <UserProvider value={user}>
-            {isInStandaloneMode()
+            {isInStandaloneMode() || !isMobileWeb()
                 ? null
                 : ProgressiveWebAppPrompt(location.pathname)}
             <SettingsContext.Provider

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -116,17 +116,18 @@ function updateManifest(pathName: string): void {
     }
 }
 
-export const ProgressiveWebAppPrompt = (): JSX.Element => {
+function ProgressiveWebAppPrompt(pathName: string): JSX.Element | null {
+    if (pathName === '/' || pathName.includes('admin')) return null
     return (
         <PWAPrompt
-            promptOnVisit={1}
+            promptOnVisit={4}
             timesToShow={1}
             permanentlyHideOnDismiss={true}
-            debug={1} // TODO: Remove this line
             copyTitle="Legg til Tavla på hjemskjermen"
             copyShareButtonLabel="1) Trykk på 'Del'-knappen på menyen under."
             copyAddHomeButtonLabel="2) Trykk 'Legg til på hjemskjerm'."
             copyClosePrompt="Lukk"
+            delay={2000}
         />
     )
 }
@@ -146,14 +147,20 @@ const Content = (): JSX.Element => {
         updateManifest(location.pathname)
     }, [location.pathname])
 
+    const isInStandaloneMode = () =>
+        window.matchMedia('(display-mode: standalone)').matches ||
+        document.referrer.includes('android-app://')
+
     return (
         <UserProvider value={user}>
+            {isInStandaloneMode()
+                ? null
+                : ProgressiveWebAppPrompt(location.pathname)}
             <SettingsContext.Provider
                 value={isOnTavle ? settings : [null, settings[1]]}
             >
                 <ThemeProvider>
                     <div className="themeBackground">
-                        <ProgressiveWebAppPrompt />
                         <ToastProvider>
                             <Header />
                             <Switch>

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -3,6 +3,7 @@ import { Route, Switch, Router, useLocation } from 'react-router-dom'
 import analytics from 'universal-ga'
 
 import { ToastProvider } from '@entur/alert'
+import PWAPrompt from 'react-ios-pwa-prompt'
 
 import { SettingsContext, useSettings } from '../settings'
 import { useFirebaseAuthentication, UserProvider } from '../auth'
@@ -115,6 +116,21 @@ function updateManifest(pathName: string): void {
     }
 }
 
+export const ProgressiveWebAppPrompt = (): JSX.Element => {
+    return (
+        <PWAPrompt
+            promptOnVisit={1}
+            timesToShow={1}
+            permanentlyHideOnDismiss={true}
+            debug={1} // TODO: Remove this line
+            copyTitle="Legg til Tavla på hjemskjermen"
+            copyShareButtonLabel="1) Trykk på 'Del'-knappen på menyen under."
+            copyAddHomeButtonLabel="2) Trykk 'Legg til på hjemskjerm'."
+            copyClosePrompt="Lukk"
+        />
+    )
+}
+
 const Content = (): JSX.Element => {
     const user = useFirebaseAuthentication()
     const settings = useSettings()
@@ -137,6 +153,7 @@ const Content = (): JSX.Element => {
             >
                 <ThemeProvider>
                     <div className="themeBackground">
+                        <ProgressiveWebAppPrompt />
                         <ToastProvider>
                             <Header />
                             <Switch>

--- a/src/containers/styles.scss
+++ b/src/containers/styles.scss
@@ -1,14 +1,12 @@
 @import '../assets/styles/import.scss';
 @import '../variables.scss';
 
-
 .themeBackground {
     background-color: var(--tavla-background-color);
     height: 100vh;
 }
 
 .pwa-prompt {
-
     .iOSPWA-overlay {
         display: none;
         background-color: transparent;

--- a/src/containers/styles.scss
+++ b/src/containers/styles.scss
@@ -4,37 +4,38 @@
 .themeBackground {
     background-color: var(--tavla-background-color);
     height: 100vh;
+}
 
-    .iOSPWA-overlay {
-        background-color: transparent;
-        opacity: 0;
+.iOSPWA-overlay {
+    display: none;
+    background-color: transparent;
+    opacity: 0;
+}
+
+.iOSPWA-container {
+    background-color: #e1eff8;
+    border: 0.0625rem solid #f5f5f8;
+    border-radius: 0.25rem;
+    opacity: 1;
+    .iOSPWA-title {
+        color: #181c56;
     }
 
-    .iOSPWA-container {
-        background-color: #e1eff8;
-        border: 0.0625rem solid #f5f5f8;
-        border-radius: 0.25rem;
-        opacity: 1;
-        .iOSPWA-title {
-            color: #181c56;
-        }
+    .iOSPWA-description {
+        display: none;
+    }
 
-        .iOSPWA-description {
-            display: none;
-        }
+    .iOSPWA-step1-copy,
+    .iOSPWA-step2-copy {
+        color: #181c56;
+    }
 
-        .iOSPWA-step1-copy,
-        .iOSPWA-step2-copy {
-            color: #181c56;
-        }
-
-        .iOSPWA-step1,
-        .iOSPWA-step2,
-        .iOSPWA-step1-icon,
-        .iOSPWA-step2-icon,
-        .iOSPWA-cancel {
-            color: #181c56;
-            fill: #181c56 !important;
-        }
+    .iOSPWA-step1,
+    .iOSPWA-step2,
+    .iOSPWA-step1-icon,
+    .iOSPWA-step2-icon,
+    .iOSPWA-cancel {
+        color: #181c56;
+        fill: #181c56 !important;
     }
 }

--- a/src/containers/styles.scss
+++ b/src/containers/styles.scss
@@ -4,4 +4,37 @@
 .themeBackground {
     background-color: var(--tavla-background-color);
     height: 100vh;
+
+    .iOSPWA-overlay {
+        background-color: transparent;
+        opacity: 0;
+    }
+
+    .iOSPWA-container {
+        background-color: #e1eff8;
+        border: 0.0625rem solid #f5f5f8;
+        border-radius: 0.25rem;
+        opacity: 1;
+        .iOSPWA-title {
+            color: #181c56;
+        }
+
+        .iOSPWA-description {
+            display: none;
+        }
+
+        .iOSPWA-step1-copy,
+        .iOSPWA-step2-copy {
+            color: #181c56;
+        }
+
+        .iOSPWA-step1,
+        .iOSPWA-step2,
+        .iOSPWA-step1-icon,
+        .iOSPWA-step2-icon,
+        .iOSPWA-cancel {
+            color: #181c56;
+            fill: #181c56 !important;
+        }
+    }
 }

--- a/src/containers/styles.scss
+++ b/src/containers/styles.scss
@@ -1,41 +1,45 @@
 @import '../assets/styles/import.scss';
 @import '../variables.scss';
 
+
 .themeBackground {
     background-color: var(--tavla-background-color);
     height: 100vh;
 }
 
-.iOSPWA-overlay {
-    display: none;
-    background-color: transparent;
-    opacity: 0;
-}
+.pwa-prompt {
 
-.iOSPWA-container {
-    background-color: #e1eff8;
-    border: 0.0625rem solid #f5f5f8;
-    border-radius: 0.25rem;
-    opacity: 1;
-    .iOSPWA-title {
-        color: #181c56;
-    }
-
-    .iOSPWA-description {
+    .iOSPWA-overlay {
         display: none;
+        background-color: transparent;
+        opacity: 0;
     }
 
-    .iOSPWA-step1-copy,
-    .iOSPWA-step2-copy {
-        color: #181c56;
-    }
+    .iOSPWA-container {
+        background-color: #e1eff8;
+        border: 0.0625rem solid #f5f5f8;
+        border-radius: 0.25rem;
+        opacity: 1;
+        .iOSPWA-title {
+            color: #181c56;
+        }
 
-    .iOSPWA-step1,
-    .iOSPWA-step2,
-    .iOSPWA-step1-icon,
-    .iOSPWA-step2-icon,
-    .iOSPWA-cancel {
-        color: #181c56;
-        fill: #181c56 !important;
+        .iOSPWA-description {
+            display: none;
+        }
+
+        .iOSPWA-step1-copy,
+        .iOSPWA-step2-copy {
+            color: #181c56;
+        }
+
+        .iOSPWA-step1,
+        .iOSPWA-step2,
+        .iOSPWA-step1-icon,
+        .iOSPWA-step2-icon,
+        .iOSPWA-cancel {
+            color: #181c56;
+            fill: #181c56 !important;
+        }
     }
 }

--- a/src/containers/styles.scss
+++ b/src/containers/styles.scss
@@ -14,12 +14,12 @@
     }
 
     .iOSPWA-container {
-        background-color: #e1eff8;
-        border: 0.0625rem solid #f5f5f8;
+        background-color: $colors-blues-blue80;
+        border: 0.0625rem solid $colors-blues-blue90;
         border-radius: 0.25rem;
         opacity: 1;
         .iOSPWA-title {
-            color: #181c56;
+            color: $colors-brand-blue;
         }
 
         .iOSPWA-description {
@@ -28,7 +28,7 @@
 
         .iOSPWA-step1-copy,
         .iOSPWA-step2-copy {
-            color: #181c56;
+            color: $colors-brand-blue;
         }
 
         .iOSPWA-step1,
@@ -36,8 +36,8 @@
         .iOSPWA-step1-icon,
         .iOSPWA-step2-icon,
         .iOSPWA-cancel {
-            color: #181c56;
-            fill: #181c56 !important;
+            color: $colors-brand-blue;
+            fill: $colors-brand-blue !important;
         }
     }
 }

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -34,7 +34,6 @@ import BikeTile from './BikeTile'
 import MapTile from './MapTile'
 
 import './styles.scss'
-import { ProgressiveWebAppPrompt } from '../../containers/App'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -34,6 +34,7 @@ import BikeTile from './BikeTile'
 import MapTile from './MapTile'
 
 import './styles.scss'
+import { ProgressiveWebAppPrompt } from '../../containers/App'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 
@@ -208,76 +209,92 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
         if (!tileOrder) return null
 
         return (
-            <DashboardWrapper
-                className="compact"
-                history={history}
-                bikeRentalStations={bikeRentalStations}
-                stopPlacesWithDepartures={stopPlacesWithDepartures}
-                scooters={scooters}
-            >
-                <div className="compact__tiles" {...longPress}>
-                    <RearrangeModal
-                        itemOrder={tileOrder}
-                        onTileOrderChanged={(item) => {
-                            setTileOrder(item)
-                            saveToLocalStorage(boardId + '-tile-order', item)
-                        }}
-                        modalVisible={modalVisible}
-                        onDismiss={() => setModalVisible(false)}
-                    />
-                    {tileOrder.map((item) => {
-                        if (item.id == 'map') {
-                            return hasData && mapCol ? (
-                                <div key={item.id}>
-                                    <MapTile
-                                        scooters={scooters}
-                                        stopPlaces={stopPlacesWithDepartures}
-                                        bikeRentalStations={bikeRentalStations}
-                                        walkTimes={null}
-                                        latitude={
-                                            settings?.coordinates?.latitude ?? 0
-                                        }
-                                        longitude={
-                                            settings?.coordinates?.longitude ??
-                                            0
-                                        }
-                                        zoom={settings?.zoom ?? DEFAULT_ZOOM}
-                                    />
-                                </div>
-                            ) : (
-                                []
-                            )
-                        } else if (item.id == 'city-bike') {
-                            return bikeRentalStations &&
-                                anyBikeRentalStations ? (
-                                <div key={item.id}>
-                                    <BikeTile stations={bikeRentalStations} />
-                                </div>
-                            ) : (
-                                []
-                            )
-                        } else if (stopPlacesWithDepartures) {
-                            const stopIndex =
-                                stopPlacesWithDepartures.findIndex(
-                                    (p) => p.id == item.id,
+            <>
+                <DashboardWrapper
+                    className="compact"
+                    history={history}
+                    bikeRentalStations={bikeRentalStations}
+                    stopPlacesWithDepartures={stopPlacesWithDepartures}
+                    scooters={scooters}
+                >
+                    <div className="compact__tiles" {...longPress}>
+                        <RearrangeModal
+                            itemOrder={tileOrder}
+                            onTileOrderChanged={(item) => {
+                                setTileOrder(item)
+                                saveToLocalStorage(
+                                    boardId + '-tile-order',
+                                    item,
                                 )
-                            return (
-                                <div key={item.id}>
-                                    <DepartureTile
-                                        walkInfo={getWalkInfoForStopPlace(
-                                            walkInfo || [],
-                                            item.id,
-                                        )}
-                                        stopPlaceWithDepartures={
-                                            stopPlacesWithDepartures[stopIndex]
-                                        }
-                                    />
-                                </div>
-                            )
-                        }
-                    })}
-                </div>
-            </DashboardWrapper>
+                            }}
+                            modalVisible={modalVisible}
+                            onDismiss={() => setModalVisible(false)}
+                        />
+                        {tileOrder.map((item) => {
+                            if (item.id == 'map') {
+                                return hasData && mapCol ? (
+                                    <div key={item.id}>
+                                        <MapTile
+                                            scooters={scooters}
+                                            stopPlaces={
+                                                stopPlacesWithDepartures
+                                            }
+                                            bikeRentalStations={
+                                                bikeRentalStations
+                                            }
+                                            walkTimes={null}
+                                            latitude={
+                                                settings?.coordinates
+                                                    ?.latitude ?? 0
+                                            }
+                                            longitude={
+                                                settings?.coordinates
+                                                    ?.longitude ?? 0
+                                            }
+                                            zoom={
+                                                settings?.zoom ?? DEFAULT_ZOOM
+                                            }
+                                        />
+                                    </div>
+                                ) : (
+                                    []
+                                )
+                            } else if (item.id == 'city-bike') {
+                                return bikeRentalStations &&
+                                    anyBikeRentalStations ? (
+                                    <div key={item.id}>
+                                        <BikeTile
+                                            stations={bikeRentalStations}
+                                        />
+                                    </div>
+                                ) : (
+                                    []
+                                )
+                            } else if (stopPlacesWithDepartures) {
+                                const stopIndex =
+                                    stopPlacesWithDepartures.findIndex(
+                                        (p) => p.id == item.id,
+                                    )
+                                return (
+                                    <div key={item.id}>
+                                        <DepartureTile
+                                            walkInfo={getWalkInfoForStopPlace(
+                                                walkInfo || [],
+                                                item.id,
+                                            )}
+                                            stopPlaceWithDepartures={
+                                                stopPlacesWithDepartures[
+                                                    stopIndex
+                                                ]
+                                            }
+                                        />
+                                    </div>
+                                )
+                            }
+                        })}
+                    </div>
+                </DashboardWrapper>
+            </>
         )
     }
     return (

--- a/types/react-ios-pwa-prompt/index.d.ts
+++ b/types/react-ios-pwa-prompt/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-ios-pwa-prompt'


### PR DESCRIPTION
On third visit on Tavla add-to-homescreen-prompt is shown on iOS. It's only shown once.


`"react-ios-pwa-prompt": "chrisdancee/react-ios-pwa-prompt#pull/71/head"` was needed because the original npm package had some issues with CaseSensitivePathsPlugin. This PR fixed the problem, but it was not merged when we needed it: https://github.com/chrisdancee/react-ios-pwa-prompt/pull/71


<img src="https://user-images.githubusercontent.com/67413374/126323818-5501fa52-b5ff-40b1-975b-d4ca7c664fe2.png" alt="Girl in a jacket" height="450">