### PR TITLE
Add tileRow to Chrono view

### DIFF
--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -10,7 +10,7 @@ import { useSettingsContext } from '../../../settings'
 import { IconColorType } from '../../../types'
 import { getIconColorType } from '../../../utils'
 import useWalkInfoBike, { WalkInfoBike } from '../../../logic/useWalkInfoBike'
-import TileRow from '../../Compact/components/TileRow'
+import TileRow from '../components/TileRow'
 
 function getWalkInfoBike(
     walkInfos: WalkInfoBike[],

--- a/src/dashboards/Chrono/components/TileRow/index.tsx
+++ b/src/dashboards/Chrono/components/TileRow/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Heading3 } from '@entur/typography'
+
+import { TileSubLabel } from '../../../../types'
+import './styles.scss'
+
+import { WalkInfoBike } from '../../../../logic/useWalkInfoBike'
+
+function formatWalkInfo(walkInfoBike: WalkInfoBike) {
+    if (walkInfoBike.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(
+            walkInfoBike.walkDistance,
+        )} m)`
+    } else {
+        return `${Math.ceil(walkInfoBike.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfoBike.walkDistance,
+        )} m)`
+    }
+}
+
+export function TileRow({
+    label,
+    icon,
+    walkInfoBike,
+    subLabels,
+}: Props): JSX.Element {
+    return (
+        <div className="tilerow">
+            <div className="tilerow__icon">{icon}</div>
+            <div className="tilerow__texts">
+                <Heading3 className="tilerow__label">{label}</Heading3>
+                {walkInfoBike ? (
+                    <div className="tilerow__walking-time">
+                        {formatWalkInfo(walkInfoBike)}
+                    </div>
+                ) : null}
+                <div className="tilerow__sublabels">
+                    {subLabels.map((subLabel, index) => (
+                        <div className="tilerow__sublabel" key={index}>
+                            {subLabel.time}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+interface Props {
+    label: string
+    subLabels: TileSubLabel[]
+    icon: JSX.Element | null
+    walkInfoBike?: WalkInfoBike
+}
+
+export default TileRow

--- a/src/dashboards/Chrono/components/TileRow/styles.scss
+++ b/src/dashboards/Chrono/components/TileRow/styles.scss
@@ -1,0 +1,54 @@
+@import '../../../../assets/styles/import.scss';
+@import '../../../../variables.scss';
+
+.tilerow {
+    display: flex;
+    border-bottom: 2px solid var(--tavla-border-color);
+    padding: 1rem 0;
+    overflow-x: hidden;
+    overflow-y: hidden;
+
+    &:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+    }
+
+    &__label {
+        margin: 0;
+        margin-bottom: 0.5rem;
+        color: var(--tavla-font-color);
+    }
+
+    &__icon {
+        min-width: 2rem;
+        margin-right: 1rem;
+        font-size: $font-sizes-extra-large4;
+    }
+
+    &__texts {
+        flex-direction: column;
+        flex-grow: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &__walking-time {
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1rem;
+        margin: 0.5rem 0;
+        color: var(--tavla-label-font-color);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &__sublabels {
+        display: grid;
+        grid-template-columns: repeat(20, 1fr);
+        justify-content: space-between;
+        min-width: 130rem;
+        font-size: $font-sizes-extra-large;
+    }
+}


### PR DESCRIPTION
Add a tileRow component in Chrono view equivalent to the tileRow component in Compact view. Previously, the walkingDistance in bikeTile in Chrono view was using tileRow in Compact view, which we want to avoid. 