### PR TITLE
Add walking distance in timeline view

### DIFF
--- a/src/dashboards/Timeline/index.tsx
+++ b/src/dashboards/Timeline/index.tsx
@@ -194,24 +194,18 @@ const TimelineDashboard = ({ history }: Props): JSX.Element => {
                 {data.map(({ stopId, name, groupedDepartures }) => (
                     <div key={stopId} className="timeline__stop">
                         <header className="timeline__header">
-                            <Heading2
-                                className="timeline__heading"
-                                margin="none"
-                                style={{ margin: 0 }}
-                            >
+                            <Heading2 className="timeline__heading">
                                 {name}
                             </Heading2>
-                            {!hideWalkInfo ? (
-                                walkInfo ? (
-                                    <div className="timeline__walking-time">
-                                        {formatWalkInfo(
-                                            getWalkInfoForStopPlace(
-                                                walkInfo || [],
-                                                stopId,
-                                            ),
-                                        )}
-                                    </div>
-                                ) : null
+                            {!hideWalkInfo && walkInfo ? (
+                                <div className="timeline__walking-time">
+                                    {formatWalkInfo(
+                                        getWalkInfoForStopPlace(
+                                            walkInfo || [],
+                                            stopId,
+                                        ),
+                                    )}
+                                </div>
                             ) : undefined}
                         </header>
                         {groupedDepartures.map(([mode, departures]) => (

--- a/src/dashboards/Timeline/index.tsx
+++ b/src/dashboards/Timeline/index.tsx
@@ -13,11 +13,12 @@ import {
 } from '../../utils'
 import { LineData, IconColorType } from '../../types'
 
-import { useStopPlacesWithDepartures } from '../../logic'
+import { useStopPlacesWithDepartures, useWalkInfo } from '../../logic'
 import DashboardWrapper from '../../containers/DashboardWrapper'
 
 import './styles.scss'
 import { useSettingsContext } from '../../settings'
+import { WalkInfo } from '../../logic/useWalkInfo'
 
 const TICKS = [-1, 0, 1, 2, 3, 4, 5, 10, 15, 20, 30, 60]
 
@@ -30,6 +31,24 @@ function diffSincePreviousTick(minute: number): number {
     if (index < 0) return 0
     const prev = TICKS[index - 1] || 0
     return minute - prev
+}
+
+function getWalkInfoForStopPlace(
+    walkInfos: WalkInfo[] | undefined,
+    id: string,
+): WalkInfo | undefined {
+    return walkInfos?.find((walkInfo) => walkInfo.stopId === id)
+}
+
+function formatWalkInfo(walkInfo: WalkInfo | undefined) {
+    if (!walkInfo) return null
+    if (walkInfo.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(walkInfo.walkDistance)} m)`
+    } else {
+        return `${Math.ceil(walkInfo.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfo.walkDistance,
+        )} m)`
+    }
 }
 
 function competitorPosition(waitTime: number): number {
@@ -136,6 +155,9 @@ const TimelineDashboard = ({ history }: Props): JSX.Element => {
         IconColorType.CONTRAST,
     )
 
+    const walkInfo = useWalkInfo(stopPlacesWithDepartures)
+    const hideWalkInfo = settings?.hideWalkInfo
+
     useEffect(() => {
         if (settings) {
             setIconColorType(getIconColorType(settings.theme))
@@ -171,13 +193,27 @@ const TimelineDashboard = ({ history }: Props): JSX.Element => {
             <div className="timeline__body">
                 {data.map(({ stopId, name, groupedDepartures }) => (
                     <div key={stopId} className="timeline__stop">
-                        <Heading2
-                            className="timeline__heading"
-                            margin="none"
-                            style={{ margin: 0 }}
-                        >
-                            {name}
-                        </Heading2>
+                        <header className="timeline__header">
+                            <Heading2
+                                className="timeline__heading"
+                                margin="none"
+                                style={{ margin: 0 }}
+                            >
+                                {name}
+                            </Heading2>
+                            {!hideWalkInfo ? (
+                                walkInfo ? (
+                                    <div className="timeline__walking-time">
+                                        {formatWalkInfo(
+                                            getWalkInfoForStopPlace(
+                                                walkInfo || [],
+                                                stopId,
+                                            ),
+                                        )}
+                                    </div>
+                                ) : null
+                            ) : undefined}
+                        </header>
                         {groupedDepartures.map(([mode, departures]) => (
                             <Fragment key={mode}>
                                 <div className="timeline__track">

--- a/src/dashboards/Timeline/styles.scss
+++ b/src/dashboards/Timeline/styles.scss
@@ -16,11 +16,26 @@
         overflow: hidden;
         border-radius: 1rem;
     }
+
     &__stop:last-child {
         margin-bottom: 5rem;
     }
 
+    &__header {
+        flex-wrap: wrap;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
     &__heading {
+        color: var(--tavla-font-color);
+    }
+
+    &__walking-time {
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1rem;
         color: var(--tavla-font-color);
     }
 

--- a/src/dashboards/Timeline/styles.scss
+++ b/src/dashboards/Timeline/styles.scss
@@ -30,6 +30,7 @@
 
     &__heading {
         color: var(--tavla-font-color);
+        margin: 0;
     }
 
     &__walking-time {


### PR DESCRIPTION
Add walking distance (in minutes and meters) in timeline view. The walking information will be in the top right corner on each tile when possible. But when there's little space, the information is wrapped on two lines. (The latter is shown in the photo on small screen below)

It's possible to toggle of walking information if not of interest. 



Before:
<img width="1245" alt="Screenshot 2021-07-22 at 13 33 49" src="https://user-images.githubusercontent.com/67413374/126633150-d58c5a3f-c642-4536-a425-9d743aadee67.png">



After (on desktop):
<img width="1251" alt="Screenshot 2021-07-22 at 13 33 14" src="https://user-images.githubusercontent.com/67413374/126633238-d9834943-bc92-4b6e-b90c-b89195a58875.png">


After (on small screens and mobile):
<img width="351" alt="Screenshot 2021-07-22 at 13 34 14" src="https://user-images.githubusercontent.com/67413374/126633175-f44750f4-c1d0-4e3a-ac50-e78903f79939.png">