### PR TITLE
Remove "Finn din tavle.." on mobile

### DIFF
--- a/src/components/Header/DashboardHeader.tsx
+++ b/src/components/Header/DashboardHeader.tsx
@@ -6,6 +6,7 @@ import { useSettings } from '../../settings'
 import Clock from '../Clock'
 import { TavlaLogo } from '../../assets/icons'
 import UpgradeTavlaBanner from '../../containers/DashboardWrapper/UpgradeTavlaBanner'
+import { isMobileWeb } from '../../utils'
 
 export function DashboardHeader(): JSX.Element | null {
     const settings = useSettings()[0]
@@ -37,7 +38,7 @@ export function DashboardHeader(): JSX.Element | null {
             <div className="header">
                 <div className="header__logo-wrapper">
                     {headerLogo}
-                    {boardDescription}
+                    {!isMobileWeb() ? boardDescription : null}
                 </div>
                 <Clock className="header__clock" />
             </div>


### PR DESCRIPTION
Remove "Finn din tavle på entur.no eller i entur-appen" on mobile.

This info takes up a lot of space on the screen on mobile, and doesn't add that much value.

Before:
<img width="275" alt="Screenshot 2021-07-22 at 15 22 27" src="https://user-images.githubusercontent.com/67413374/126645975-d18d9546-186a-479d-bf99-b577026d72b8.png">

After:
<img width="282" alt="Screenshot 2021-07-22 at 15 21 54" src="https://user-images.githubusercontent.com/67413374/126645898-23208a2e-4a7a-47df-9df8-83c5e0e005a3.png">
