### PR TITLE
fixed double hostname for src to icons in manifest generation

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -74,13 +74,13 @@ function updateManifest(pathName: string): void {
             lang: 'no',
             icons: [
                 {
-                    src: `${window.location.hostname}/images/logo/logo-192x192.png`,
+                    src: '/images/logo/logo-192x192.png',
                     sizes: '192x192',
                     type: 'image/png',
                     purpose: 'any maskable',
                 },
                 {
-                    src: `${window.location.hostname}/images/logo/logo-512x512.png`,
+                    src: '/images/logo/logo-512x512.png',
                     sizes: '512x512',
                     type: 'image/png',
                     purpose: 'any maskable',


### PR DESCRIPTION
Changed path to icons from absolute to relative, because the browsers treats these links as relative anyways and the hostname ended up being added twice to the URLs. 


Example:

`tavla.staging.entur.no/tavla.staging.entur.no/images/logo/logo-192x192.png`
is now
`tavla.staging.entur.no/images/logo/logo-192x192.png`