### PR TITLE
Reduce margin above tiles, add left margin to edit tab header

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -220,7 +220,7 @@ const EditTab = (): JSX.Element => {
     return (
         <div className="edit-tab">
             <div>
-                <Heading2 className="heading">
+                <Heading2 className="edit-tab__heading">
                     Viser kollektivtilbud innenfor
                     <div className="edit-tab__input-wrapper">
                         <Tooltip

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -2,6 +2,10 @@
 @import '../../../variables.scss';
 
 .edit-tab {
+    &__heading {
+        margin-left: 2rem;
+    }
+
     .eds-contrast {
         background: inherit;
     }
@@ -110,7 +114,7 @@
             padding: 0;
         }
         .eds-h2 {
-            margin: 0 0 0 0;
+            margin: 0;
         }
     }
 
@@ -198,7 +202,4 @@
         margin-left: -2rem;
         margin-right: -2rem;
     }
-}
-.heading {
-    color: var(--tavla-font-color);
 }

--- a/src/dashboards/Chrono/styles.scss
+++ b/src/dashboards/Chrono/styles.scss
@@ -121,11 +121,9 @@
             /*
             react-grid-layout uses a margin of 32px between all grid-items.
             This makes the tiles not lign up with the header, so to counteract
-            these margins on the sides, this styling is needed. 
+            these margins on the sides and top, this styling is needed.
             */
-
-            margin-left: -2rem;
-            margin-right: -2rem;
+            margin: -2rem;
         }
     }
 }

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -133,11 +133,9 @@
             /*
             react-grid-layout uses a margin of 32px between all grid-items.
             This makes the tiles not lign up with the header, so to counteract
-            these margins on the sides, this styling is needed. 
+            these margins on the sides and top, this styling is needed.
             */
-
-            margin-left: -2rem;
-            margin-right: -2rem;
+            margin: -2rem;
         }
     }
 }


### PR DESCRIPTION
The margin added between tiles on the grid also puts margin on
the top of the tiles, making the margin 2 rems too big above them.

Also, the header in Admin Edit Tab was too far to the left.

BEFORE:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/4339443/126775383-8a09d069-36fa-4f90-b1c3-3f8aacf2c8a5.png">

<img width="215" alt="image" src="https://user-images.githubusercontent.com/4339443/126775466-09e9d7ed-4aa8-445a-8b46-fb87e9a802a2.png">


AFTER:
<img width="429" alt="image" src="https://user-images.githubusercontent.com/4339443/126775397-f59bc332-55d5-451c-8a20-34362782aee1.png">

<img width="215" alt="image" src="https://user-images.githubusercontent.com/4339443/126775481-28a09a49-020c-426f-991d-09d4802ed87c.png">

