### PR TITLE
Restructuring of busstop, now with longpress and new grid

### DIFF
--- a/src/dashboards/BusStop/components/Tile/index.tsx
+++ b/src/dashboards/BusStop/components/Tile/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Heading2 } from '@entur/typography'
+
+import './styles.scss'
+import { WalkInfo } from '../../../../logic/useWalkInfo'
+import { useIsLongPressed } from '../../../../logic/longPressContext'
+
+function formatWalkInfo(walkInfo: WalkInfo) {
+    if (walkInfo.walkTime / 60 < 1) {
+        return `Mindre enn 1 min å gå (${Math.ceil(walkInfo.walkDistance)} m)`
+    } else {
+        return `${Math.ceil(walkInfo.walkTime / 60)} min å gå (${Math.ceil(
+            walkInfo.walkDistance,
+        )} m)`
+    }
+}
+
+function Tile({ title, icons, walkInfo, children }: Props): JSX.Element {
+    const isPressed = useIsLongPressed()
+    return (
+        <div className={isPressed ? 'tile tile--pressed' : 'tile'}>
+            <header className="tile__header">
+                <Heading2>{title}</Heading2>
+                <div className="tile__header-icons">{icons}</div>
+            </header>
+            {walkInfo ? (
+                <div className="tile__walking-time">
+                    {formatWalkInfo(walkInfo)}
+                </div>
+            ) : null}
+            {children}
+        </div>
+    )
+}
+
+interface Props {
+    title: string
+    icons: JSX.Element | JSX.Element[]
+    walkInfo?: WalkInfo
+    children: JSX.Element[] | JSX.Element
+}
+
+export default Tile

--- a/src/dashboards/BusStop/components/Tile/styles.scss
+++ b/src/dashboards/BusStop/components/Tile/styles.scss
@@ -1,0 +1,66 @@
+@import '../../../../assets/styles/import.scss';
+@import '../../../../variables.scss';
+
+.busStop .tile {
+    height: 100%;
+    width: 100%;
+    background-color: var(--tavla-box-background-color);
+    color: var(--tavla-font-color);
+    flex: none;
+    padding: 2rem;
+    overflow-x: hidden;
+    overflow-y: hidden;
+
+    &--pressed {
+        box-shadow: inset 0 0 65px -20px rgba(0, 0, 0, 0.54);
+    }
+
+    .eds-table__head {
+        border-bottom: none;
+    }
+
+    .eds-table__header-cell {
+        text-align: left;
+    }
+
+    .eds-table__data-cell:not(:first-child),
+    .eds-table__header-cell:not(:first-child) {
+        padding: 1rem 0.2rem 1rem 0.2rem;
+    }
+
+    &__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+
+        h2 {
+            margin: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        svg {
+            margin-left: 0.5rem;
+        }
+    }
+
+    &__header-icons {
+        display: flex;
+        align-items: center;
+    }
+
+    &__walking-time {
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1rem;
+        color: var(--tavla-font-color);
+    }
+    @media (max-width: 480px) {
+        padding: 2rem 1rem;
+        .eds-table__data-cell {
+            justify-content: center;
+        }
+    }
+}

--- a/src/dashboards/BusStop/components/Tile/styles.scss
+++ b/src/dashboards/BusStop/components/Tile/styles.scss
@@ -8,8 +8,7 @@
     color: var(--tavla-font-color);
     flex: none;
     padding: 2rem;
-    overflow-x: hidden;
-    overflow-y: hidden;
+    overflow: hidden;
 
     &--pressed {
         box-shadow: inset 0 0 65px -20px rgba(0, 0, 0, 0.54);

--- a/src/dashboards/BusStop/components/TileRows/index.tsx
+++ b/src/dashboards/BusStop/components/TileRows/index.tsx
@@ -66,37 +66,6 @@ export function TileRows({
         </TableBody>
     )
 }
-
-/* function SubLabelIcon({
-    subLabel,
-    hideSituations,
-}: {
-    subLabel: TileSubLabel
-    hideSituations?: boolean
-}): JSX.Element | null {
-    if (!hideSituations && subLabel?.situation)
-        if (isMobile)
-            return (
-                <div className="tilerow__sublabel__situation">
-                    <SituationModal situationMessage={subLabel.situation} />
-                </div>
-            )
-        else
-            return (
-                <div className="tilerow__sublabel__situation">
-                    <ValidationExclamation />
-                </div>
-            )
-
-    if (subLabel.hasCancellation)
-        return (
-            <div className="tilerow__sublabel__cancellation">
-                <ValidationError />
-            </div>
-        )
-    return null
-}
-*/
 interface Props {
     visibleDepartures: LineData[]
     hideSituations: boolean | undefined

--- a/src/dashboards/BusStop/components/TileRows/index.tsx
+++ b/src/dashboards/BusStop/components/TileRows/index.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+
+import { Heading3 } from '@entur/typography'
+
+import { DataCell, TableBody, TableRow } from '@entur/table'
+
+import { IconColorType, LineData } from '../../../../types'
+
+import './styles.scss'
+
+import SituationModal from '../../../../components/SituationModal'
+import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
+import SubLabelIcon from '../SubLabelIcon'
+
+const isMobile = isMobileWeb()
+
+export function TileRows({
+    visibleDepartures,
+    hideSituations,
+    hideTracks,
+    iconColorType,
+}: Props): JSX.Element {
+    return (
+        <TableBody>
+            {visibleDepartures.map((data) => {
+                const icon = getIcon(data.type, iconColorType, data.subType)
+                const subLabel = createTileSubLabel(data)
+                return (
+                    <TableRow key={data.id}>
+                        <DataCell>
+                            <div className="tilerow__icon">{icon}</div>
+                        </DataCell>
+                        <DataCell>
+                            <Heading3 className="tilerow__label">
+                                {data.route}
+                            </Heading3>
+                        </DataCell>
+                        <DataCell>
+                            <div className="tilerow__sublabel">
+                                {subLabel.time}
+                            </div>
+                        </DataCell>
+                        {!hideTracks ? (
+                            <DataCell>
+                                <div className="tilerow__sublabel">
+                                    {data.quay?.publicCode || '-'}
+                                </div>
+                            </DataCell>
+                        ) : null}
+                        {!hideSituations ? (
+                            <DataCell>
+                                {isMobile && data?.situation ? (
+                                    <SituationModal
+                                        situationMessage={data?.situation}
+                                    />
+                                ) : (
+                                    <SubLabelIcon
+                                        subLabel={createTileSubLabel(data)}
+                                    />
+                                )}
+                            </DataCell>
+                        ) : null}
+                    </TableRow>
+                )
+            })}
+        </TableBody>
+    )
+}
+
+/* function SubLabelIcon({
+    subLabel,
+    hideSituations,
+}: {
+    subLabel: TileSubLabel
+    hideSituations?: boolean
+}): JSX.Element | null {
+    if (!hideSituations && subLabel?.situation)
+        if (isMobile)
+            return (
+                <div className="tilerow__sublabel__situation">
+                    <SituationModal situationMessage={subLabel.situation} />
+                </div>
+            )
+        else
+            return (
+                <div className="tilerow__sublabel__situation">
+                    <ValidationExclamation />
+                </div>
+            )
+
+    if (subLabel.hasCancellation)
+        return (
+            <div className="tilerow__sublabel__cancellation">
+                <ValidationError />
+            </div>
+        )
+    return null
+}
+*/
+interface Props {
+    visibleDepartures: LineData[]
+    hideSituations: boolean | undefined
+    hideTracks: boolean | undefined
+    iconColorType: IconColorType
+}
+
+export default TileRows

--- a/src/dashboards/BusStop/components/TileRows/styles.scss
+++ b/src/dashboards/BusStop/components/TileRows/styles.scss
@@ -1,0 +1,59 @@
+@import '../../../../assets/styles/import.scss';
+@import '../../../../variables.scss';
+
+.busStop .tilerow {
+    border-bottom: 2px solid var(--tavla-border-color);
+    padding: 1rem;
+
+    &__icon {
+        min-width: 2rem;
+        margin-right: 1rem;
+        font-size: 2rem;
+    }
+
+    &__label {
+        margin: 0;
+        margin-top: 0.25rem;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &__sublabel {
+        align-items: center;
+        display: flex;
+        font-size: 1.25rem;
+        font-weight: 400;
+        margin: 0;
+        margin-top: 7px;
+        min-width: 5rem;
+        text-align: right;
+
+        &__cancellation {
+            align-items: center;
+            background-color: $colors-brand-white;
+            border-radius: 0.5rem;
+            display: flex;
+            height: 0.875rem;
+            justify-content: center;
+            margin-left: 1rem;
+            overflow: visible;
+            width: 0.875rem;
+        }
+
+        &__situation {
+            font-size: 1.125rem;
+            height: 1.25rem;
+        }
+    }
+    @media (max-width: 1000px) {
+        padding: 0.5rem;
+    }
+
+    @media (max-width: 480px) {
+        &__icon {
+            min-width: 1.5rem;
+            font-size: 1.5rem;
+        }
+    }
+}

--- a/src/dashboards/BusStop/index.tsx
+++ b/src/dashboards/BusStop/index.tsx
@@ -1,18 +1,29 @@
-import React from 'react'
-import { GridContainer, GridItem } from '@entur/grid'
+import React, { useState, useRef, useEffect } from 'react'
+import { Layouts, Layout, WidthProvider, Responsive } from 'react-grid-layout'
+import { useRouteMatch } from 'react-router'
+import { useLongPress } from 'use-long-press/dist'
+import { Loader } from '@entur/loader'
 
+import { usePrevious, isEqualUnsorted } from '../../utils'
 import DashboardWrapper from '../../containers/DashboardWrapper'
 
 import { DEFAULT_ZOOM } from '../../constants'
 import {
-    useBikeRentalStations,
     useStopPlacesWithDepartures,
     useScooters,
     useWalkInfo,
+    useBikeRentalStations,
 } from '../../logic'
 import { WalkInfo } from '../../logic/useWalkInfo'
+import {
+    getFromLocalStorage,
+    saveToLocalStorage,
+} from '../../settings/LocalStorage'
 
 import { useSettingsContext } from '../../settings'
+
+import RearrangeModal, { Item } from '../../components/RearrangeModal'
+import { LongPressProvider } from '../../logic/longPressContext'
 
 import DepartureTile from './DepartureTile'
 
@@ -20,6 +31,32 @@ import MapTile from './MapTile'
 
 import './styles.scss'
 
+const ResponsiveReactGridLayout = WidthProvider(Responsive)
+
+function getDefaultBreakpoint() {
+    if (window.innerWidth > BREAKPOINTS.lg) {
+        return 'lg'
+    } else if (window.innerWidth > BREAKPOINTS.md) {
+        return 'md'
+    }
+    return 'sm'
+}
+
+const BREAKPOINTS = {
+    lg: 1200,
+    md: 996,
+    sm: 768,
+    xs: 480,
+    xxs: 0,
+}
+
+const COLS: { [key: string]: number } = {
+    lg: 1,
+    md: 1,
+    sm: 1,
+    xs: 1,
+    xxs: 1,
+}
 function getWalkInfoForStopPlace(
     walkInfos: WalkInfo[],
     id: string,
@@ -27,11 +64,54 @@ function getWalkInfoForStopPlace(
     return walkInfos?.find((walkInfo) => walkInfo.stopId === id)
 }
 
-function BusStop({ history }: Props): JSX.Element | null {
+function getDataGrid(
+    index: number,
+    maxWidth: number,
+): { [key: string]: number } {
+    return {
+        w: 1,
+        maxW: maxWidth,
+        minH: 1,
+        h: 6,
+        x: index % maxWidth,
+        y: 0,
+    }
+}
+
+const BusStop = ({ history }: Props): JSX.Element | null => {
     const [settings] = useSettingsContext()
-    const bikeRentalStations = useBikeRentalStations()
+    const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
+    const [isLongPressStarted, setIsLongPressStarted] = useState<boolean>(false)
+    const isCancelled = useRef<NodeJS.Timeout>()
+    const [modalVisible, setModalVisible] = useState(false)
+
+    function clearLongPressTimeout() {
+        setIsLongPressStarted(false)
+        if (isCancelled.current) {
+            clearTimeout(isCancelled.current)
+        }
+    }
+
+    const dashboardKey = history.location.key
+    const boardId =
+        useRouteMatch<{ documentId: string }>('/t/:documentId')?.params
+            ?.documentId
+
+    const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
+        getFromLocalStorage(dashboardKey),
+    )
+
+    const [tileOrder, setTileOrder] = useState<Item[] | undefined>(
+        boardId ? getFromLocalStorage(boardId + '-tile-order') : undefined,
+    )
+
     let stopPlacesWithDepartures = useStopPlacesWithDepartures()
+    const numberOfStopPlaces = stopPlacesWithDepartures
+        ? stopPlacesWithDepartures.length
+        : 0
+    const prevNumberOfStopPlaces = usePrevious(numberOfStopPlaces)
     const scooters = useScooters()
+    const bikeRentalStations = useBikeRentalStations()
 
     if (stopPlacesWithDepartures) {
         stopPlacesWithDepartures = stopPlacesWithDepartures.filter(
@@ -40,51 +120,259 @@ function BusStop({ history }: Props): JSX.Element | null {
     }
 
     const walkInfo = useWalkInfo(stopPlacesWithDepartures)
+    const mapCol = settings?.showMap ? 1 : 0
+    const totalItems = numberOfStopPlaces + mapCol
+    const hasData = Boolean(
+        bikeRentalStations?.length ||
+            scooters?.length ||
+            stopPlacesWithDepartures?.length,
+    )
+    const maxWidthCols = COLS[breakpoint]
+    const stopPlacesHasLoaded = Boolean(
+        stopPlacesWithDepartures ||
+            settings?.hiddenModes?.includes('kollektiv'),
+    )
 
-    const mediumWidth = settings?.showMap ? 8 : 12
+    const bikeHasLoaded = Boolean(
+        bikeRentalStations || settings?.hiddenModes?.includes('bysykkel'),
+    )
+
+    const scooterHasLoaded = Boolean(
+        scooters || settings?.hiddenModes?.includes('sparkesykkel'),
+    )
+
+    const hasFetchedData = Boolean(
+        stopPlacesHasLoaded && bikeHasLoaded && scooterHasLoaded,
+    )
+    useEffect(() => {
+        let defaultTileOrder: Item[] = []
+        if (stopPlacesWithDepartures) {
+            if (stopPlacesWithDepartures.length == prevNumberOfStopPlaces) {
+                return
+            }
+            defaultTileOrder = stopPlacesWithDepartures.map((item) => ({
+                id: item.id,
+                name: item.name,
+            }))
+        }
+        if (mapCol) {
+            defaultTileOrder = [
+                ...defaultTileOrder,
+                { id: 'map', name: 'Kart' },
+            ]
+        }
+        const storedTileOrder: Item[] | undefined = getFromLocalStorage(
+            boardId + '-tile-order',
+        )
+        if (
+            storedTileOrder &&
+            storedTileOrder.length === defaultTileOrder.length &&
+            isEqualUnsorted(
+                defaultTileOrder.map((item) => item.id),
+                storedTileOrder.map((item) => item.id),
+            )
+        ) {
+            setTileOrder(storedTileOrder)
+        } else {
+            setTileOrder(defaultTileOrder)
+        }
+    }, [
+        stopPlacesWithDepartures,
+        prevNumberOfStopPlaces,
+        mapCol,
+        settings?.showMap,
+        boardId,
+    ])
+
+    const longPress = useLongPress(
+        () => {
+            setModalVisible(true)
+        },
+        {
+            threshold: 1000,
+            onStart: () => {
+                isCancelled.current = setTimeout(() => {
+                    setIsLongPressStarted(true)
+                }, 150)
+            },
+            onFinish: () => {
+                clearLongPressTimeout()
+            },
+            onCancel: () => {
+                clearLongPressTimeout()
+            },
+            onMove: () => {
+                clearLongPressTimeout()
+            },
+            cancelOnMovement: true,
+        },
+    )
+    if (window.innerWidth < BREAKPOINTS.md) {
+        const numberOfTileRows = 10
+
+        if (!tileOrder) return null
+
+        return (
+            <DashboardWrapper
+                className="busStop"
+                history={history}
+                bikeRentalStations={bikeRentalStations}
+                stopPlacesWithDepartures={stopPlacesWithDepartures}
+                scooters={scooters}
+            >
+                <LongPressProvider value={isLongPressStarted}>
+                    <div className="busStop__tiles" {...longPress}>
+                        <RearrangeModal
+                            itemOrder={tileOrder}
+                            onTileOrderChanged={(item) => {
+                                setTileOrder(item)
+                                saveToLocalStorage(
+                                    boardId + '-tile-order',
+                                    item,
+                                )
+                            }}
+                            modalVisible={modalVisible}
+                            onDismiss={() => setModalVisible(false)}
+                        />
+                        {tileOrder.map((item) => {
+                            if (item.id == 'map') {
+                                return hasData && mapCol ? (
+                                    <div key={item.id}>
+                                        <MapTile
+                                            scooters={scooters}
+                                            stopPlaces={
+                                                stopPlacesWithDepartures
+                                            }
+                                            bikeRentalStations={
+                                                bikeRentalStations
+                                            }
+                                            walkTimes={null}
+                                            latitude={
+                                                settings?.coordinates
+                                                    ?.latitude ?? 0
+                                            }
+                                            longitude={
+                                                settings?.coordinates
+                                                    ?.longitude ?? 0
+                                            }
+                                            zoom={
+                                                settings?.zoom ?? DEFAULT_ZOOM
+                                            }
+                                        />
+                                    </div>
+                                ) : (
+                                    []
+                                )
+                            } else if (stopPlacesWithDepartures) {
+                                const stopIndex =
+                                    stopPlacesWithDepartures.findIndex(
+                                        (p) => p.id == item.id,
+                                    )
+                                return (
+                                    <div key={item.id}>
+                                        <DepartureTile
+                                            walkInfo={getWalkInfoForStopPlace(
+                                                walkInfo || [],
+                                                item.id,
+                                            )}
+                                            stopPlaceWithDepartures={
+                                                stopPlacesWithDepartures[
+                                                    stopIndex
+                                                ]
+                                            }
+                                            isMobile
+                                            numberOfTileRows={numberOfTileRows}
+                                        />
+                                    </div>
+                                )
+                            }
+                        })}
+                    </div>
+                </LongPressProvider>
+            </DashboardWrapper>
+        )
+    }
     return (
         <DashboardWrapper
             className="busStop"
             history={history}
+            bikeRentalStations={bikeRentalStations}
             stopPlacesWithDepartures={stopPlacesWithDepartures}
+            scooters={scooters}
         >
-            <GridContainer>
-                <GridItem large={mediumWidth} medium={12} small={12}>
-                    <div className="busStop__tiles">
-                        {(stopPlacesWithDepartures || []).map((stop, index) => (
-                            <DepartureTile
-                                key={index.toString()}
-                                stopPlaceWithDepartures={stop}
-                                walkInfo={getWalkInfoForStopPlace(
-                                    walkInfo || [],
-                                    stop.id,
-                                )}
-                            />
-                        ))}
-                    </div>
-                </GridItem>
-                {settings?.showMap ? (
-                    <GridItem
-                        large={4}
-                        medium={12}
-                        small={12}
-                        className="busStop__mapTile"
+            {!hasFetchedData ? (
+                <div className="busStop__loading-screen">
+                    <Loader>Laster inn</Loader>
+                </div>
+            ) : (
+                <div className="busStop__tiles">
+                    <ResponsiveReactGridLayout
+                        key={breakpoint}
+                        breakpoints={BREAKPOINTS}
+                        cols={COLS}
+                        layouts={gridLayouts}
+                        margin={[32, 32]}
+                        onBreakpointChange={(newBreakpoint: string) => {
+                            setBreakpoint(newBreakpoint)
+                        }}
+                        onLayoutChange={(
+                            layout: Layout[],
+                            layouts: Layouts,
+                        ): void => {
+                            if (numberOfStopPlaces > 0) {
+                                setGridLayouts(layouts)
+                                saveToLocalStorage(dashboardKey, layouts)
+                            }
+                        }}
                     >
-                        <MapTile
-                            scooters={scooters}
-                            stopPlaces={stopPlacesWithDepartures}
-                            bikeRentalStations={bikeRentalStations}
-                            walkTimes={null}
-                            latitude={settings?.coordinates?.latitude ?? 0}
-                            longitude={settings?.coordinates?.longitude ?? 0}
-                            zoom={settings?.zoom ?? DEFAULT_ZOOM}
-                        />
-                    </GridItem>
-                ) : null}
-            </GridContainer>
+                        {(stopPlacesWithDepartures || []).map((stop, index) => (
+                            <div
+                                key={stop.id}
+                                data-grid={getDataGrid(index, maxWidthCols)}
+                            >
+                                <DepartureTile
+                                    key={index.toString()}
+                                    stopPlaceWithDepartures={stop}
+                                    walkInfo={getWalkInfoForStopPlace(
+                                        walkInfo || [],
+                                        stop.id,
+                                    )}
+                                />
+                            </div>
+                        ))}
+                        {mapCol ? (
+                            <div
+                                id="busStop-map-tile"
+                                key={totalItems - 1}
+                                data-grid={getDataGrid(
+                                    totalItems - 1,
+                                    maxWidthCols,
+                                )}
+                            >
+                                <MapTile
+                                    scooters={scooters}
+                                    stopPlaces={stopPlacesWithDepartures}
+                                    bikeRentalStations={bikeRentalStations}
+                                    walkTimes={null}
+                                    latitude={
+                                        settings?.coordinates?.latitude ?? 0
+                                    }
+                                    longitude={
+                                        settings?.coordinates?.longitude ?? 0
+                                    }
+                                    zoom={settings?.zoom ?? DEFAULT_ZOOM}
+                                />
+                            </div>
+                        ) : (
+                            []
+                        )}
+                    </ResponsiveReactGridLayout>
+                </div>
+            )}
         </DashboardWrapper>
     )
 }
+
 interface Props {
     history: any
 }

--- a/src/dashboards/BusStop/styles.scss
+++ b/src/dashboards/BusStop/styles.scss
@@ -1,31 +1,60 @@
 @import '../../assets/styles/import.scss';
 
 .busStop {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Old versions of Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently
+                          supported by Chrome, Edge, Opera and Firefox */
     &__tiles {
-        display: flex;
+        display: block;
         flex-direction: column;
         overflow-x: hidden;
+        overflow-y: hidden;
 
         .tile {
-            margin-right: 2rem;
+            width: 100%;
+            padding-top: 2rem;
             margin-bottom: 2rem;
-            max-height: 75vh;
             overflow-y: hidden;
             border-radius: 1rem;
+
+            &__header-icons {
+                font-size: 2rem;
+            }
+        }
+        .maptile {
+            height: inherit;
+            width: 100%;
+            overflow: hidden;
+            border-radius: 1rem;
+            margin-bottom: 1rem;
+            z-index: 1;
         }
     }
-    &__mapTile {
-        height: 75vh;
-        overflow: hidden;
-        border-radius: 1rem;
-        z-index: 1;
+    &__loading-screen {
+        margin: 0;
+        width: 100%;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
     }
-    .eds-table {
-        &__head {
-            justify-content: stretch;
-        }
-        &__header-cell {
-            align-content: center;
+}
+@media (min-width: 996px) {
+    .busStop {
+        &__tiles {
+            /*
+            react-grid-layout uses a margin of 32px between all grid-items.
+            This makes the tiles not lign up with the header, so to counteract
+            these margins on the sides, this styling is needed. 
+            */
+
+            margin-left: -2rem;
+            margin-right: -2rem;
         }
     }
 }
@@ -45,14 +74,15 @@
             width: 100%;
             overflow-y: scroll;
         }
-        &__mapTile {
-            max-height: 60vh;
-            margin-bottom: 1rem;
+        .maptile {
+            height: 487px;
+            max-height: unset;
+            width: 100%;
         }
         .eds-table--small {
             .eds-table__data-cell {
                 padding: 0;
-                justify-content: left;
+                justify-content: center;
             }
         }
     }

--- a/src/dashboards/BusStop/styles.scss
+++ b/src/dashboards/BusStop/styles.scss
@@ -11,14 +11,13 @@
     &__tiles {
         display: block;
         flex-direction: column;
-        overflow-x: hidden;
-        overflow-y: hidden;
+        overflow: hidden;
 
         .tile {
             width: 100%;
             padding-top: 2rem;
             margin-bottom: 2rem;
-            overflow-y: hidden;
+            overflow: hidden;
             border-radius: 1rem;
 
             &__header-icons {
@@ -52,9 +51,7 @@
             This makes the tiles not lign up with the header, so to counteract
             these margins on the sides, this styling is needed. 
             */
-
-            margin-left: -2rem;
-            margin-right: -2rem;
+            margin: -2rem;
         }
     }
 }

--- a/src/dashboards/Chrono/styles.scss
+++ b/src/dashboards/Chrono/styles.scss
@@ -18,12 +18,11 @@
             width: 100%;
             height: 100%;
             overflow-y: scroll;
+            border-radius: 1rem;
 
             &__header-icons {
                 font-size: 2rem;
             }
-
-            border-radius: 1rem;
         }
 
         .maptile {


### PR DESCRIPTION
Busstop now got similar grid, tile and tilerow system like compact and chrono. Layout improvements on mobile and desktop. Longpress functionality added.

![Screenshot 2021-07-23 at 13 20 59](https://user-images.githubusercontent.com/32451773/126775507-f1ac02f7-c2e1-4792-bcaf-0e718331705f.png)
![Screenshot 2021-07-23 at 13 20 38](https://user-images.githubusercontent.com/32451773/126775513-bbdfbb7e-9355-4f5a-8ea6-7db307b6c182.png)

Map is now at the bottom of the for both desktop and mobile. Can possibly change this at a later time, if having the map to the right of the first departure tile would be better. 