### PR TITLE
tweaked styling for tilerows in chrono view

### DIFF
--- a/src/dashboards/Chrono/components/TileRows/index.tsx
+++ b/src/dashboards/Chrono/components/TileRows/index.tsx
@@ -29,28 +29,28 @@ export function TileRows({
                 return (
                     <TableRow key={data.id}>
                         <DataCell>
-                            <div className="tilerow__icon">{icon}</div>
+                            <div className="tilerows__icon">{icon}</div>
                         </DataCell>
                         <DataCell>
-                            <Heading3 className="tilerow__label">
+                            <Heading3 className="tilerows__label">
                                 {data.route}
                             </Heading3>
                         </DataCell>
                         <DataCell>
-                            <div className="tilerow__sublabel">
+                            <div className="tilerows__sublabel">
                                 {subLabel.time}
                             </div>
                         </DataCell>
                         {!hideTracks ? (
                             <DataCell>
-                                <div className="tilerow__sublabel">
+                                <div className="tilerows__sublabel">
                                     {data.quay?.publicCode || '-'}
                                 </div>
                             </DataCell>
                         ) : null}
                         {!hideSituations ? (
                             <DataCell>
-                                <div className="tilerow__sublabel">
+                                <div className="tilerows__sublabel">
                                     <SubLabelIcon
                                         hideSituations={hideSituations}
                                         subLabel={subLabel}

--- a/src/dashboards/Chrono/components/TileRows/styles.scss
+++ b/src/dashboards/Chrono/components/TileRows/styles.scss
@@ -1,7 +1,7 @@
 @import '../../../../assets/styles/import.scss';
 @import '../../../../variables.scss';
 
-.chrono .tilerow {
+.chrono .tilerows {
     border-bottom: 2px solid var(--tavla-border-color);
     padding: 1rem;
 
@@ -13,19 +13,22 @@
 
     &__label {
         margin: 0;
-        margin-top: 0.25rem;
+        padding-right: 0.25rem;
+        vertical-align: middle;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+    }
+    .eds-table__data-cell {
+        vertical-align: middle;
     }
 
     &__sublabel {
         align-items: center;
         display: flex;
-        font-size: 1.25rem;
-        font-weight: 400;
+        font-size: $font-sizes-extra-large2;
+        font-weight: $font-weights-body;
         margin: 0;
-        margin-top: 7px;
         min-width: 5rem;
         text-align: right;
 
@@ -52,6 +55,9 @@
     }
 
     @media (max-width: 480px) {
+        &__sublabel {
+            font-size: $font-sizes-large;
+        }
         &__icon {
             min-width: 1.5rem;
             font-size: 1.5rem;

--- a/src/dashboards/Chrono/components/TileRows/styles.scss
+++ b/src/dashboards/Chrono/components/TileRows/styles.scss
@@ -14,13 +14,9 @@
     &__label {
         margin: 0;
         padding-right: 0.25rem;
-        vertical-align: middle;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
-    }
-    .eds-table__data-cell {
-        vertical-align: middle;
     }
 
     &__sublabel {
@@ -43,13 +39,8 @@
             overflow: visible;
             width: 0.875rem;
         }
-
-        &__situation {
-            font-size: 1.125rem;
-            height: 1.25rem;
-            margin-left: 1rem;
-        }
     }
+
     @media (max-width: 1000px) {
         padding: 0.5rem;
     }


### PR DESCRIPTION
Updated styling for TileRows in Chrono, with improvements in vertical alignment and font-sizing.

Before/after:
<img src="https://user-images.githubusercontent.com/31273371/126772238-69fd2696-ce4f-41bd-a7e3-e55ac05e6203.png" alt="Tavla Staging Chrono TileRows example image" height=500> <img src="https://user-images.githubusercontent.com/31273371/126772242-8aac57f5-2c9e-4649-ac08-5d29b0d66ef4.png" height=500>

