### PR TITLE
Disable zoom in map in busStop view on desktop

### DIFF
--- a/src/dashboards/BusStop/MapTile/index.tsx
+++ b/src/dashboards/BusStop/MapTile/index.tsx
@@ -7,11 +7,16 @@ import MapView from '../../../components/Map'
 import './styles.scss'
 
 import { StopPlaceWithDepartures } from '../../../types'
+import { isMobileWeb } from '../../../utils'
 
 function MapTile(data: Props): JSX.Element {
     return (
         <div className="maptile">
-            <MapView {...data} interactive />
+            {isMobileWeb() ? (
+                <MapView {...data} interactive />
+            ) : (
+                <MapView {...data} interactive={false} />
+            )}
         </div>
     )
 }

--- a/src/dashboards/BusStop/MapTile/index.tsx
+++ b/src/dashboards/BusStop/MapTile/index.tsx
@@ -12,11 +12,7 @@ import { isMobileWeb } from '../../../utils'
 function MapTile(data: Props): JSX.Element {
     return (
         <div className="maptile">
-            {isMobileWeb() ? (
-                <MapView {...data} interactive />
-            ) : (
-                <MapView {...data} interactive={false} />
-            )}
+            <MapView {...data} interactive={isMobileWeb()} />
         </div>
     )
 }


### PR DESCRIPTION
Difficult to scroll in busStop view on desktop when zoom in map is activated.