### PR TITLE
pwa is now only shown on iOS

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -103,37 +103,38 @@ function updateManifest(pathName: string): void {
     }
 }
 
+const hidePWA = (pathName: string) =>
+    pathName === '/' ||
+    pathName.includes('admin') ||
+    window.matchMedia('(display-mode: standalone)').matches ||
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window.navigator.standalone ||
+    document.referrer.includes('android-app://') ||
+    getFromLocalStorage('pwaPromptShown') ||
+    numberOfVisits < 3 ||
+    ![
+        'iPad Simulator',
+        'iPhone Simulator',
+        'iPod Simulator',
+        'iPad',
+        'iPhone',
+        'iPod',
+    ].includes(navigator.platform)
+
 function ProgressiveWebAppPrompt(pathName: string): JSX.Element | null {
     useEffect(() => {
         saveToLocalStorage('numberOfVisits', numberOfVisits + 1)
     }, [])
 
-    if (
-        pathName === '/' ||
-        pathName.includes('admin') ||
-        window.matchMedia('(display-mode: standalone)').matches ||
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        window.navigator.standalone ||
-        document.referrer.includes('android-app://') ||
-        getFromLocalStorage('pwaPromptShown') ||
-        numberOfVisits < 3 ||
-        ![
-            'iPad Simulator',
-            'iPhone Simulator',
-            'iPod Simulator',
-            'iPad',
-            'iPhone',
-            'iPod',
-        ].includes(navigator.platform)
-    ) {
+    if (hidePWA(pathName)) {
         return null
     }
 
     return (
         <div className="pwa-prompt">
             <PWAPrompt
-                debug
+                debug // forcing prompt to show
                 copyTitle="Legg til Tavla på hjemskjermen"
                 copyShareButtonLabel="1) I Safari, trykk på 'Del'-knappen på menyen under."
                 copyAddHomeButtonLabel="2) Trykk 'Legg til på hjemskjerm'."

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -117,7 +117,15 @@ function ProgressiveWebAppPrompt(pathName: string): JSX.Element | null {
         window.navigator.standalone ||
         document.referrer.includes('android-app://') ||
         getFromLocalStorage('pwaPromptShown') ||
-        numberOfVisits < 3
+        numberOfVisits < 3 ||
+        ![
+            'iPad Simulator',
+            'iPhone Simulator',
+            'iPod Simulator',
+            'iPad',
+            'iPhone',
+            'iPod',
+        ].includes(navigator.platform)
     ) {
         return null
     }
@@ -125,9 +133,9 @@ function ProgressiveWebAppPrompt(pathName: string): JSX.Element | null {
     return (
         <div className="pwa-prompt">
             <PWAPrompt
-                debug={1} // forcing prompt to show
+                debug
                 copyTitle="Legg til Tavla på hjemskjermen"
-                copyShareButtonLabel="1) Trykk på 'Del'-knappen på menyen under."
+                copyShareButtonLabel="1) I Safari, trykk på 'Del'-knappen på menyen under."
                 copyAddHomeButtonLabel="2) Trykk 'Legg til på hjemskjerm'."
                 copyClosePrompt="Lukk"
                 onClose={() => saveToLocalStorage('pwaPromptShown', true)}


### PR DESCRIPTION
The PWA prompt is now only shown on iOS devices, because Chrome on Android is promoting "Add to Home Screen" automatically if a valid manifest and service worker is provided with a website.

Also, added a note that the user has to be in Safari to create a PWA.

Before:
<img width="385" alt="Screenshot 2021-07-26 at 09 43 36" src="https://user-images.githubusercontent.com/31273371/126951795-6cefbe96-a269-4ac3-ac2e-8310b9a62faa.png">

After:
<img width="384" alt="Screenshot 2021-07-26 at 09 42 25" src="https://user-images.githubusercontent.com/31273371/126951804-0ee94455-5369-4872-a328-51cde40f16df.png">
