### PR TITLE
Dynamic tile height in edit-tab

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -196,6 +196,10 @@ const EditTab = (): JSX.Element => {
         </div>
     )
 
+    // height of tile is set to default value + a value times number of rows
+    const tileHeight = (items: number, rowHeight: number, padding: number) =>
+        items > 0 ? items * rowHeight + padding : 0
+
     const LAYOUT = {
         lg: [
             {
@@ -203,18 +207,14 @@ const EditTab = (): JSX.Element => {
                 x: 0,
                 y: 0,
                 w: 1.5,
-                h:
-                    2.35 +
-                    (stopPlaces.length > 0
-                        ? 0.44 * stopPlaces.length + 0.32
-                        : 0),
+                h: 2.35 + tileHeight(stopPlaces.length, 0.44, 0.32),
             },
             {
                 i: 'bikePanel',
                 x: 1.5,
                 y: 0,
                 w: 1.5,
-                h: 1.55 + 0.24 * stations.length,
+                h: 1.55 + tileHeight(stations.length, 0.24, 0),
             },
             { i: 'scooterPanel', x: 3, y: 3.2, w: 1.5, h: 1.4 },
             { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 3.2 },
@@ -225,18 +225,14 @@ const EditTab = (): JSX.Element => {
                 x: 0,
                 y: 0,
                 w: 2,
-                h:
-                    2.35 +
-                    (stopPlaces.length > 0
-                        ? 0.44 * stopPlaces.length + 0.32
-                        : 0),
+                h: 2.35 + tileHeight(stopPlaces.length, 0.44, 0.32),
             },
             {
                 i: 'bikePanel',
                 x: 2,
                 y: 0,
                 w: 1,
-                h: 1.55 + 0.24 * stations.length,
+                h: 1.55 + tileHeight(stations.length, 0.24, 0),
             },
             { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.75 },
             { i: 'mapPanel', x: 0, y: 4.5, w: 2, h: 3 },
@@ -247,18 +243,14 @@ const EditTab = (): JSX.Element => {
                 x: 0,
                 y: 0,
                 w: 1,
-                h:
-                    2.25 +
-                    (stopPlaces.length > 0
-                        ? 0.6 * stopPlaces.length + 0.32
-                        : 0),
+                h: 2.25 + tileHeight(stopPlaces.length, 0.6, 0.32),
             },
             {
                 i: 'bikePanel',
                 x: 0,
                 y: 3,
                 w: 1,
-                h: 1.4 + 0.24 * stations.length,
+                h: 1.4 + tileHeight(stations.length, 0.24, 0),
             },
             { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.2 },
             { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },
@@ -269,18 +261,14 @@ const EditTab = (): JSX.Element => {
                 x: 0,
                 y: 0,
                 w: 1,
-                h:
-                    2.5 +
-                    (stopPlaces.length > 0
-                        ? 0.75 * stopPlaces.length + 0.25
-                        : 0),
+                h: 2.5 + tileHeight(stopPlaces.length, 0.75, 0.25),
             },
             {
                 i: 'bikePanel',
                 x: 0,
                 y: 3,
                 w: 1,
-                h: 1.4 + 0.265 * stations.length,
+                h: 1.4 + tileHeight(stations.length, 0.265, 0),
             },
             { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.6 },
             { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -205,8 +205,9 @@ const EditTab = (): JSX.Element => {
                 w: 1.5,
                 h:
                     2.35 +
-                    0.48 * stopPlaces.length +
-                    (stopPlaces.length > 0 ? 0.32 : 0),
+                    (stopPlaces.length > 0
+                        ? 0.44 * stopPlaces.length + 0.32
+                        : 0),
             },
             {
                 i: 'bikePanel',
@@ -226,8 +227,9 @@ const EditTab = (): JSX.Element => {
                 w: 2,
                 h:
                     2.35 +
-                    0.44 * stopPlaces.length +
-                    (stopPlaces.length > 0 ? 0.32 : 0),
+                    (stopPlaces.length > 0
+                        ? 0.44 * stopPlaces.length + 0.32
+                        : 0),
             },
             {
                 i: 'bikePanel',
@@ -247,8 +249,9 @@ const EditTab = (): JSX.Element => {
                 w: 1,
                 h:
                     2.25 +
-                    0.6 * stopPlaces.length +
-                    (stopPlaces.length > 0 ? 0.32 : 0),
+                    (stopPlaces.length > 0
+                        ? 0.6 * stopPlaces.length + 0.32
+                        : 0),
             },
             {
                 i: 'bikePanel',
@@ -268,8 +271,9 @@ const EditTab = (): JSX.Element => {
                 w: 1,
                 h:
                     2.5 +
-                    0.75 * stopPlaces.length +
-                    (stopPlaces.length > 0 ? 0.25 : 0),
+                    (stopPlaces.length > 0
+                        ? 0.75 * stopPlaces.length + 0.25
+                        : 0),
             },
             {
                 i: 'bikePanel',

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -50,27 +50,6 @@ const COLS: { [key: string]: number } = {
     xxs: 1,
 }
 
-const LAYOUT = {
-    lg: [
-        { i: 'busStopPanel', x: 0, y: 0, w: 1.5, h: 4.3 },
-        { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
-        { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.3 },
-        { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 3.3 },
-    ],
-    md: [
-        { i: 'busStopPanel', x: 0, y: 0, w: 2, h: 4.7 },
-        { i: 'bikePanel', x: 2, y: 0, w: 1, h: 3 },
-        { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.7 },
-        { i: 'mapPanel', x: 0, y: 4.5, w: 3, h: 3 },
-    ],
-    sm: [
-        { i: 'busStopPanel', x: 0, y: 0, w: 1, h: 3 },
-        { i: 'bikePanel', x: 0, y: 3, w: 1, h: 2 },
-        { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.5 },
-        { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },
-    ],
-}
-
 const EditTab = (): JSX.Element => {
     const [breakpoint, setBreakpoint] = useState<string>('lg')
     const [settings, settingsSetters] = useSettingsContext()
@@ -216,6 +195,36 @@ const EditTab = (): JSX.Element => {
             <SubParagraph margin="none">{props.text}</SubParagraph>
         </div>
     )
+
+    const LAYOUT = {
+        lg: [
+            {
+                i: 'busStopPanel',
+                x: 0,
+                y: 0,
+                w: 1.5,
+                h:
+                    2.35 +
+                    0.45 * stopPlaces.length +
+                    (stopPlaces.length > 0 ? 0.35 : 0),
+            },
+            { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
+            { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.4 },
+            { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 3 },
+        ],
+        md: [
+            { i: 'busStopPanel', x: 0, y: 0, w: 2, h: 4.7 },
+            { i: 'bikePanel', x: 2, y: 0, w: 1, h: 3 },
+            { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.7 },
+            { i: 'mapPanel', x: 0, y: 4.5, w: 3, h: 3 },
+        ],
+        sm: [
+            { i: 'busStopPanel', x: 0, y: 0, w: 1, h: 3 },
+            { i: 'bikePanel', x: 0, y: 3, w: 1, h: 2 },
+            { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.5 },
+            { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },
+        ],
+    }
 
     return (
         <div className="edit-tab">

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -205,23 +205,80 @@ const EditTab = (): JSX.Element => {
                 w: 1.5,
                 h:
                     2.35 +
-                    0.45 * stopPlaces.length +
-                    (stopPlaces.length > 0 ? 0.35 : 0),
+                    0.48 * stopPlaces.length +
+                    (stopPlaces.length > 0 ? 0.32 : 0),
             },
-            { i: 'bikePanel', x: 1.5, y: 0, w: 1.5, h: 3 },
-            { i: 'scooterPanel', x: 1.5, y: 1.5, w: 1.5, h: 1.4 },
-            { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 3 },
+            {
+                i: 'bikePanel',
+                x: 1.5,
+                y: 0,
+                w: 1.5,
+                h: 1.55 + 0.24 * stations.length,
+            },
+            { i: 'scooterPanel', x: 3, y: 3.2, w: 1.5, h: 1.4 },
+            { i: 'mapPanel', x: 3, y: 0, w: 1.5, h: 3.2 },
         ],
         md: [
-            { i: 'busStopPanel', x: 0, y: 0, w: 2, h: 4.7 },
-            { i: 'bikePanel', x: 2, y: 0, w: 1, h: 3 },
-            { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.7 },
-            { i: 'mapPanel', x: 0, y: 4.5, w: 3, h: 3 },
+            {
+                i: 'busStopPanel',
+                x: 0,
+                y: 0,
+                w: 2,
+                h:
+                    2.35 +
+                    0.44 * stopPlaces.length +
+                    (stopPlaces.length > 0 ? 0.32 : 0),
+            },
+            {
+                i: 'bikePanel',
+                x: 2,
+                y: 0,
+                w: 1,
+                h: 1.55 + 0.24 * stations.length,
+            },
+            { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.75 },
+            { i: 'mapPanel', x: 0, y: 4.5, w: 2, h: 3 },
         ],
         sm: [
-            { i: 'busStopPanel', x: 0, y: 0, w: 1, h: 3 },
-            { i: 'bikePanel', x: 0, y: 3, w: 1, h: 2 },
-            { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.5 },
+            {
+                i: 'busStopPanel',
+                x: 0,
+                y: 0,
+                w: 1,
+                h:
+                    2.25 +
+                    0.6 * stopPlaces.length +
+                    (stopPlaces.length > 0 ? 0.32 : 0),
+            },
+            {
+                i: 'bikePanel',
+                x: 0,
+                y: 3,
+                w: 1,
+                h: 1.4 + 0.24 * stations.length,
+            },
+            { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.2 },
+            { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },
+        ],
+        xs: [
+            {
+                i: 'busStopPanel',
+                x: 0,
+                y: 0,
+                w: 1,
+                h:
+                    2.5 +
+                    0.75 * stopPlaces.length +
+                    (stopPlaces.length > 0 ? 0.25 : 0),
+            },
+            {
+                i: 'bikePanel',
+                x: 0,
+                y: 3,
+                w: 1,
+                h: 1.4 + 0.265 * stations.length,
+            },
+            { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.6 },
             { i: 'mapPanel', x: 0, y: 8, w: 1, h: 3 },
         ],
     }


### PR DESCRIPTION
Dynamic height of tiles in edit-panel. Scaling factor is set based on the content of the tile.

Before:
<img width="1860" alt="Screenshot 2021-07-26 at 12 10 05" src="https://user-images.githubusercontent.com/67413374/126972545-ea9abf3b-4ad6-4869-aa77-390e76157c63.png">


After:
<img width="1863" alt="Screenshot 2021-07-26 at 12 11 41" src="https://user-images.githubusercontent.com/67413374/126972558-952111e9-b49b-4634-a6a2-cb4525966ee1.png">
