### PR TITLE
added a bit more padding to avoid scroll section in busstop tile

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -207,7 +207,7 @@ const EditTab = (): JSX.Element => {
                 x: 0,
                 y: 0,
                 w: 1.5,
-                h: 2.35 + tileHeight(stopPlaces.length, 0.44, 0.32),
+                h: 2.35 + tileHeight(stopPlaces.length, 0.45, 0.35),
             },
             {
                 i: 'bikePanel',


### PR DESCRIPTION
Height in large mode on smaller screens were a bit too short, so I adjusted the row height a bit to fit most screens perfectly.