### PR TITLE
Scooters are hidden by default

### DIFF
--- a/src/settings/UrlStorage.ts
+++ b/src/settings/UrlStorage.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SETTINGS: Settings = {
     hiddenStops: [],
     hiddenRoutes: {},
     distance: DEFAULT_DISTANCE,
-    hiddenModes: [],
+    hiddenModes: ['sparkesykkel'],
     hiddenStopModes: {},
     newStations: [],
     newStops: [],


### PR DESCRIPTION
The map is hidden by default and the map is the only place to see where the scooters are, so it makes more sense that scooters also are defaulted to hidden.