### PR TITLE
EditTab toggle improvements

### DIFF
--- a/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
@@ -69,17 +69,38 @@ function StopPlacePanel(props: Props): JSX.Element {
 
     const onToggleMode = useCallback(
         (stopPlaceId: string, mode: LegMode): void => {
+            const newHiddenModes = {
+                ...hiddenStopModes,
+                [stopPlaceId]: toggleValueInList(
+                    hiddenStopModes[stopPlaceId] || [],
+                    mode,
+                ),
+            }
+            const stopPlace = filteredStopPlaces.find(
+                (item) => item.id === stopPlaceId,
+            )
+
+            const uniqueTransportModes = Array.from(
+                new Set(stopPlace?.lines.map((line) => line.transportMode)),
+            )
+
+            const allModesUnchecked =
+                uniqueTransportModes.length ===
+                newHiddenModes[stopPlaceId].length
+
+            if (allModesUnchecked) {
+                setSettings({
+                    hiddenStops: [...hiddenStops, stopPlaceId],
+                    hiddenStopModes: newHiddenModes,
+                })
+            }
+
             setSettings({
-                hiddenStopModes: {
-                    ...hiddenStopModes,
-                    [stopPlaceId]: toggleValueInList(
-                        hiddenStopModes[stopPlaceId] || [],
-                        mode,
-                    ),
-                },
+                hiddenStops: hiddenStops.filter((id) => id !== stopPlaceId),
+                hiddenStopModes: newHiddenModes,
             })
         },
-        [hiddenStopModes, setSettings],
+        [filteredStopPlaces, hiddenStopModes, hiddenStops, setSettings],
     )
 
     if (!filteredStopPlaces.length) {

--- a/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
@@ -43,12 +43,27 @@ function StopPlacePanel(props: Props): JSX.Element {
 
     const onToggleStop = useCallback(
         (event) => {
+            const checked = event.target.checked
             const stopId = event.target.id
+            const stopPlace = filteredStopPlaces.find(
+                (item) => item.id === stopId,
+            )
+
+            const uniqueTransportModes = Array.from(
+                new Set(
+                    stopPlace?.lines.map(({ transportMode }) => transportMode),
+                ),
+            )
+
             setSettings({
                 hiddenStops: toggleValueInList(hiddenStops, stopId),
+                hiddenStopModes: {
+                    ...hiddenStopModes,
+                    [stopId]: !checked ? uniqueTransportModes : [],
+                },
             })
         },
-        [hiddenStops, setSettings],
+        [filteredStopPlaces, hiddenStopModes, hiddenStops, setSettings],
     )
 
     const onToggleRoute = useCallback(
@@ -81,7 +96,9 @@ function StopPlacePanel(props: Props): JSX.Element {
             )
 
             const uniqueTransportModes = Array.from(
-                new Set(stopPlace?.lines.map((line) => line.transportMode)),
+                new Set(
+                    stopPlace?.lines.map(({ transportMode }) => transportMode),
+                ),
             )
 
             const allModesUnchecked =

--- a/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
@@ -33,13 +33,16 @@ function StopPlacePanel(props: Props): JSX.Element {
         if (hiddenStops.length > 0) {
             setSettings({
                 hiddenStops: [],
+                hiddenStopModes: Object.fromEntries(
+                    Object.keys(hiddenStopModes).map((key) => [key, []]),
+                ),
             })
         } else {
             setSettings({
                 hiddenStops: stops.map(({ id }) => id),
             })
         }
-    }, [hiddenStops.length, setSettings, stops])
+    }, [hiddenStopModes, hiddenStops.length, setSettings, stops])
 
     const onToggleStop = useCallback(
         (event) => {

--- a/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
@@ -93,6 +93,7 @@ function StopPlacePanel(props: Props): JSX.Element {
                     hiddenStops: [...hiddenStops, stopPlaceId],
                     hiddenStopModes: newHiddenModes,
                 })
+                return
             }
 
             setSettings({


### PR DESCRIPTION
If all transport modes for a stop place are toggled off, this deselects the checkbox for the stop place as well, and vice versa.