### PR TITLE
Fixed font size variations in StopPlacePanel

### DIFF
--- a/src/containers/Admin/EditTab/StopPlacePanel/styles.scss
+++ b/src/containers/Admin/EditTab/StopPlacePanel/styles.scss
@@ -46,6 +46,7 @@
                 font-weight: 600;
                 -webkit-font-smoothing: antialiased;
                 align-items: center;
+                font-size: $font-sizes-large;
             }
         }
 


### PR DESCRIPTION
Font size were changing when a stop was toggled, this is now fixed.

Before | After:
<img width="300" alt="Screenshot 2021-07-28 at 08 56 18" src="https://user-images.githubusercontent.com/31273371/127277942-c1d78d64-8f27-458f-abd1-639e06202f97.png"> <img width="300" alt="Screenshot 2021-07-28 at 08 56 30" src="https://user-images.githubusercontent.com/31273371/127277930-a1f827cf-586f-4339-9c1c-275d9d612bd2.png">

