### PR TITLE
Fix font color in header cell in chrono view

### DIFF
--- a/src/dashboards/Chrono/components/Tile/styles.scss
+++ b/src/dashboards/Chrono/components/Tile/styles.scss
@@ -5,7 +5,6 @@
     height: 100%;
     width: 100%;
     background-color: var(--tavla-box-background-color);
-    color: var(--tavla-font-color);
     flex: none;
     padding: 2rem;
     overflow-x: hidden;
@@ -21,6 +20,7 @@
 
     .eds-table__header-cell {
         text-align: left;
+        color: var(--tavla-label-font-color);
     }
 
     .eds-table__data-cell:not(:first-child),
@@ -36,6 +36,7 @@
 
         h2 {
             margin: 0;
+            color: var(--tavla-font-color);
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;


### PR DESCRIPTION
In dark mode the color in header cell in chrono view was of wrong color.

Before:
<img width="642" alt="Screenshot 2021-07-28 at 09 55 28" src="https://user-images.githubusercontent.com/67413374/127285873-28c29215-d370-4013-b85c-6a7a9211d569.png">


After:
<img width="575" alt="Screenshot 2021-07-28 at 09 54 28" src="https://user-images.githubusercontent.com/67413374/127285835-8fe56789-5162-4d8f-9ba7-92064a62fa49.png">
