### PR TITLE
Fix/show board description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "tavla",
             "version": "5.7.0",
             "license": "EUPL-1.2",
             "dependencies": {

--- a/src/components/Header/DashboardHeader.tsx
+++ b/src/components/Header/DashboardHeader.tsx
@@ -20,7 +20,7 @@ export function DashboardHeader(): JSX.Element | null {
             <TavlaLogo className="header__logo-wrapper__logo" />
         </Link>
     )
-        
+
     const showBoardDescription = !isMobileWeb() && logoSize === '32px'
 
     const boardDescription = (

--- a/src/components/Header/DashboardHeader.tsx
+++ b/src/components/Header/DashboardHeader.tsx
@@ -21,13 +21,10 @@ export function DashboardHeader(): JSX.Element | null {
         </Link>
     )
 
-    const logoDescription =
-        logoSize === '32px' &&
-        (description || 'Finn din rute på entur.no eller i Entur-appen')
     const boardDescription = (
         <span className="header__logo-wrapper__description">
-            {logo
-                ? logoDescription
+            {description
+                ? description
                 : 'Finn din rute på entur.no eller i Entur-appen'}
         </span>
     )

--- a/src/components/Header/DashboardHeader.tsx
+++ b/src/components/Header/DashboardHeader.tsx
@@ -20,6 +20,8 @@ export function DashboardHeader(): JSX.Element | null {
             <TavlaLogo className="header__logo-wrapper__logo" />
         </Link>
     )
+        
+    const showBoardDescription = !isMobileWeb() && logoSize === '32px'
 
     const boardDescription = (
         <span className="header__logo-wrapper__description">
@@ -35,7 +37,7 @@ export function DashboardHeader(): JSX.Element | null {
             <div className="header">
                 <div className="header__logo-wrapper">
                     {headerLogo}
-                    {!isMobileWeb() ? boardDescription : null}
+                    {showBoardDescription ? boardDescription : null}
                 </div>
                 <Clock className="header__clock" />
             </div>

--- a/src/containers/Admin/LogoTab/Description/index.tsx
+++ b/src/containers/Admin/LogoTab/Description/index.tsx
@@ -15,7 +15,7 @@ const Description = (): JSX.Element => {
 
     const [value, setValue] = useState(description)
 
-    const debouncedValue = useDebounce(value, 1000)
+    const debouncedValue = useDebounce(value, 300)
 
     useEffect(() => {
         if (debouncedValue && description !== debouncedValue) {


### PR DESCRIPTION
**Problem:** Had to upload custom board logo for board description to be shown
**Solution:** Made displaying description dependent on existing description instead of existing logo

Also: 
Lowered debounce threshold form 1s to 300 ms so quicker changes to board description are kept