### PR TITLE
Fix/icon color departure header

### DIFF
--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -20,7 +20,10 @@ import { WalkInfo } from '../../../logic/useWalkInfo'
 import Tile from '../components/Tile'
 import TileRows from '../components/TileRows'
 
-function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
+function getTransportHeaderIcons(
+    departures: LineData[],
+    iconColorType: IconColorType,
+): JSX.Element[] {
     const transportModes = unique(
         departures.map(({ type, subType }) => ({ type, subType })),
         (a, b) =>
@@ -29,7 +32,7 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     )
 
     const transportIcons = transportModes.map(({ type, subType }) => ({
-        icon: getIcon(type, undefined, subType),
+        icon: getIcon(type, iconColorType, subType),
     }))
 
     return transportIcons.map(({ icon }) => icon).filter(isNotNullOrUndefined)
@@ -67,7 +70,6 @@ const DepartureTile = ({
     numberOfTileRows = 10,
 }: Props): JSX.Element => {
     const { departures, name } = stopPlaceWithDepartures
-    const headerIcons = getTransportHeaderIcons(departures)
     const [settings] = useSettingsContext()
     const { hideSituations, hideTracks, hideWalkInfo } = settings || {}
     const [iconColorType, setIconColorType] = useState<IconColorType>(
@@ -86,7 +88,7 @@ const DepartureTile = ({
     return (
         <Tile
             title={name}
-            icons={headerIcons}
+            icons={getTransportHeaderIcons(departures, iconColorType)}
             walkInfo={!hideWalkInfo ? walkInfo : undefined}
         >
             <Table spacing="small" fixed>

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -22,7 +22,10 @@ import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { WalkInfo } from '../../../logic/useWalkInfo'
 
-function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
+function getTransportHeaderIcons(
+    departures: LineData[],
+    iconColorType: IconColorType,
+): JSX.Element[] {
     const transportModes = unique(
         departures.map(({ type, subType }) => ({ type, subType })),
         (a, b) =>
@@ -31,7 +34,7 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     )
 
     const transportIcons = transportModes.map(({ type, subType }) => ({
-        icon: getIcon(type, undefined, subType),
+        icon: getIcon(type, iconColorType, subType),
     }))
 
     return transportIcons.map(({ icon }) => icon).filter(isNotNullOrUndefined)
@@ -69,7 +72,6 @@ const DepartureTile = ({
     numberOfTileRows = 7,
 }: Props): JSX.Element => {
     const { departures, name } = stopPlaceWithDepartures
-    const headerIcons = getTransportHeaderIcons(departures)
     const [settings] = useSettingsContext()
     const { hideSituations, hideTracks, hideWalkInfo } = settings || {}
     const [iconColorType, setIconColorType] = useState<IconColorType>(
@@ -88,7 +90,7 @@ const DepartureTile = ({
     return (
         <Tile
             title={name}
-            icons={headerIcons}
+            icons={getTransportHeaderIcons(departures, iconColorType)}
             walkInfo={!hideWalkInfo ? walkInfo : undefined}
         >
             <Table spacing="small" fixed>

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -22,7 +22,10 @@ import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { WalkInfo } from '../../../logic/useWalkInfo'
 
-function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
+function getTransportHeaderIcons(
+    departures: LineData[],
+    iconColorType: IconColorType,
+): JSX.Element[] {
     const transportModes = unique(
         departures.map(({ type, subType }) => ({ type, subType })),
         (a, b) =>
@@ -31,7 +34,7 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
     )
 
     return transportModes
-        .map(({ type, subType }) => getIcon(type, undefined, subType))
+        .map(({ type, subType }) => getIcon(type, iconColorType, subType))
         .filter(isNotNullOrUndefined)
 }
 
@@ -41,7 +44,7 @@ const DepartureTile = ({
 }: Props): JSX.Element => {
     const { departures, name } = stopPlaceWithDepartures
     const groupedDepartures = groupBy<LineData>(departures, 'route')
-    const headerIcons = getTransportHeaderIcons(departures)
+    // const headerIcons = getTransportHeaderIcons(departures)
     const routes = Object.keys(groupedDepartures)
     const [settings] = useSettingsContext()
     const hideSituations = settings?.hideSituations
@@ -60,7 +63,7 @@ const DepartureTile = ({
     return (
         <Tile
             title={name}
-            icons={headerIcons}
+            icons={getTransportHeaderIcons(departures, iconColorType)}
             walkInfo={!hideWalkInfo ? walkInfo : undefined}
         >
             {routes.map((route) => {

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -44,7 +44,6 @@ const DepartureTile = ({
 }: Props): JSX.Element => {
     const { departures, name } = stopPlaceWithDepartures
     const groupedDepartures = groupBy<LineData>(departures, 'route')
-    // const headerIcons = getTransportHeaderIcons(departures)
     const routes = Object.keys(groupedDepartures)
     const [settings] = useSettingsContext()
     const hideSituations = settings?.hideSituations


### PR DESCRIPTION
Denne PRen fikser ikonfargen på ikonene til høyre for holdeplasstittelen (dvs. de ikonene som indikerer hvilke kollektivtilbud som er tilgjengelig på denne holdeplassen) i lyse tema. Disse ikonene tok tidligere ikke hensyn til hvilket fargetema som var valgt, men oppdateres nå på bakgrunn av dette. 

Før             |  Etter
:-------------------------:|:-------------------------:
<img width="567" alt="Screen Shot 2021-08-19 at 1 03 22 PM" src="https://user-images.githubusercontent.com/22789935/130058204-d640261a-a777-40ce-b7d4-f74e271caafa.png">  |  <img width="563" alt="Screen Shot 2021-08-19 at 1 04 26 PM" src="https://user-images.githubusercontent.com/22789935/130058210-60fbb919-22fa-484b-b21c-ffd84fb2f020.png">



