### PR TITLE
Fix/divider color for dark theme

### DIFF
--- a/src/dashboards/BusStop/components/TileRows/index.tsx
+++ b/src/dashboards/BusStop/components/TileRows/index.tsx
@@ -26,7 +26,7 @@ export function TileRows({
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
                 return (
-                    <TableRow key={data.id} className="busStop tilerow">
+                    <TableRow key={data.id} className="tilerow">
                         <DataCell>
                             <div className="tilerow__icon">{icon}</div>
                         </DataCell>

--- a/src/dashboards/BusStop/components/TileRows/index.tsx
+++ b/src/dashboards/BusStop/components/TileRows/index.tsx
@@ -26,7 +26,7 @@ export function TileRows({
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
                 return (
-                    <TableRow key={data.id}>
+                    <TableRow key={data.id} className="busStop tilerow">
                         <DataCell>
                             <div className="tilerow__icon">{icon}</div>
                         </DataCell>

--- a/src/dashboards/BusStop/components/TileRows/styles.scss
+++ b/src/dashboards/BusStop/components/TileRows/styles.scss
@@ -2,7 +2,7 @@
 @import '../../../../variables.scss';
 
 .busStop .tilerow {
-    border-bottom: 2px solid var(--tavla-border-color);
+    border-bottom: 2px solid var(--tavla-border-color) !important;
     padding: 1rem;
 
     &__icon {

--- a/src/dashboards/Chrono/components/TileRows/index.tsx
+++ b/src/dashboards/Chrono/components/TileRows/index.tsx
@@ -27,7 +27,7 @@ export function TileRows({
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
                 return (
-                    <TableRow key={data.id}>
+                    <TableRow key={data.id} className="tilerows">
                         <DataCell>
                             <div className="tilerows__icon">{icon}</div>
                         </DataCell>

--- a/src/dashboards/Chrono/components/TileRows/styles.scss
+++ b/src/dashboards/Chrono/components/TileRows/styles.scss
@@ -2,7 +2,7 @@
 @import '../../../../variables.scss';
 
 .chrono .tilerows {
-    border-bottom: 2px solid var(--tavla-border-color);
+    border-bottom: 2px solid var(--tavla-border-color) !important;
     padding: 1rem;
 
     &__icon {


### PR DESCRIPTION
Denne PRen fikser fargen på skillelinjen mellom avganger i Kronologisk- og Holdeplassvisningen. Løsningen føltes litt hacky så hvis en av dere erfarne mener dette ikke er en god måte å gjøre det på, eller vet om en bedre måte, si gjerne ifra:)) 

Løsningen ble å sikre at css-regelen som skal påføre riktig farge ikke blir overskrevet av en annen regel ved å sette på `!important` på riktig css-regel. 

Før            |  Etter
:-------------------------:|:-------------------------:
<img width="921" alt="Screenshot 2021-08-20 at 12 40 46" src="https://user-images.githubusercontent.com/22789935/130222029-56740423-2d0b-4bb8-a439-6b09b659acb9.png">  |  <img width="921" alt="Screenshot 2021-08-20 at 12 40 54" src="https://user-images.githubusercontent.com/22789935/130222037-ba8afcf2-8e34-4872-9ca9-dfd81605c8d7.png">

