### PR TITLE
Add function to update multiple fields at once

### DIFF
--- a/src/containers/MyBoards/BoardCard/index.tsx
+++ b/src/containers/MyBoards/BoardCard/index.tsx
@@ -6,7 +6,7 @@ import { Heading3 } from '@entur/typography'
 import { LinkIcon, ClockIcon } from '@entur/icons'
 
 import { ThemeDashboardPreview } from '../../../assets/icons/ThemeDashboardPreview'
-import { persist } from '../../../settings/FirestoreStorage'
+import { persistSingleField } from '../../../settings/FirestoreStorage'
 import { Settings } from '../../../settings'
 
 import BoardOverflowMenu from './OverflowMenu'
@@ -77,7 +77,7 @@ function BoardCard({
             if (newTitle == settings.boardName) return
 
             setBoardTitle(newTitle)
-            persist(id, 'boardName', newTitle)
+            persistSingleField(id, 'boardName', newTitle)
         },
         [id, settings.boardName],
     )

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -29,7 +29,7 @@ export const getBoardsOnSnapshot = (
         .onSnapshot(observer)
 }
 
-export const updateSettingField = async (
+export const updateSingleSettingsField = async (
     docId: string,
     fieldId: string,
     fieldValue: FieldTypes,
@@ -40,6 +40,19 @@ export const updateSettingField = async (
         .doc(docId)
         .update({
             [fieldId]: fieldValue,
+            lastmodified: firebase.firestore.FieldValue.serverTimestamp(),
+        })
+
+export const updateMultipleSettingsFields = async (
+    docId: string,
+    settings: Settings,
+): Promise<void> =>
+    firebase
+        .firestore()
+        .collection(SETTINGS_COLLECTION)
+        .doc(docId)
+        .update({
+            ...settings,
             lastmodified: firebase.firestore.FieldValue.serverTimestamp(),
         })
 

--- a/src/settings/FirestoreStorage.ts
+++ b/src/settings/FirestoreStorage.ts
@@ -1,4 +1,3 @@
-import { Settings } from './index'
 import firebase from 'firebase/app'
 
 import {
@@ -7,6 +6,8 @@ import {
     deleteDocument,
     updateMultipleSettingsFields,
 } from '../services/firebase'
+
+import { Settings } from './index'
 
 export type FieldTypes =
     | string

--- a/src/settings/FirestoreStorage.ts
+++ b/src/settings/FirestoreStorage.ts
@@ -1,9 +1,11 @@
+import { Settings } from './index'
 import firebase from 'firebase/app'
 
 import {
-    updateSettingField,
+    updateSingleSettingsField,
     removeFromArray,
     deleteDocument,
+    updateMultipleSettingsFields,
 } from '../services/firebase'
 
 export type FieldTypes =
@@ -15,16 +17,20 @@ export type FieldTypes =
     | { [key: string]: string[] }
     | null
 
-export function persist(
+export function persistSingleField(
     docId: string,
     fieldId: string,
     fieldValue: FieldTypes,
 ): void {
-    updateSettingField(docId, fieldId, fieldValue)
+    updateSingleSettingsField(docId, fieldId, fieldValue)
+}
+
+export function persistMultipleFields(docId: string, settings: Settings): void {
+    updateMultipleSettingsFields(docId, settings)
 }
 
 export function removeOwners(docId: string): void {
-    persist(docId, 'owners', [])
+    persistSingleField(docId, 'owners', [])
 }
 
 export function removeFromOwners(docId: string, uid: string): void {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -17,7 +17,11 @@ import {
     persist as persistToUrl,
     restore as restoreFromUrl,
 } from './UrlStorage'
-import { persist as persistToFirebase, FieldTypes } from './FirestoreStorage'
+import {
+    persistSingleField as persistSingleFieldToFirebase,
+    persistMultipleFields as persistMultipleFieldsToFirebase,
+    FieldTypes,
+} from './FirestoreStorage'
 
 export type Mode = 'bysykkel' | 'kollektiv' | 'sparkesykkel'
 
@@ -112,7 +116,11 @@ export function useSettings(): [Settings | null, Setter] {
                 if (editAccess) {
                     Object.entries(DEFAULT_SETTINGS).forEach(([key, value]) => {
                         if (data[key as keyof Settings] === undefined) {
-                            persistToFirebase(id, key, value as FieldTypes)
+                            persistSingleFieldToFirebase(
+                                id,
+                                key,
+                                value as FieldTypes,
+                            )
                         }
                     })
                 }
@@ -155,9 +163,7 @@ export function useSettings(): [Settings | null, Setter] {
 
             const id = getDocumentId()
             if (id) {
-                Object.entries(mergedSettings).map(([key, value]) => {
-                    persistToFirebase(id, key, value)
-                })
+                persistMultipleFieldsToFirebase(id, mergedSettings)
                 return
             }
 


### PR DESCRIPTION
Alsorefactor previous function to be more descriptive. Update function-names in relevant files.

Introduserer en ny funksjon som oppdaterer flere felter på en gang. Hensikten er å ikke trigge unødvendig mange update-jobber. I tillegg virket det litt rart at man skulle gjøre et nytt kall for hvert felt man ønsker å oppdatere hvis man egentlig bare ville oppdatere x antall felter samtidig. Vurderte å endre på den eksisterende funksjonen, men den brukes også andre steder, så løsningen var å lage en egen funksjon for å oppdatere flere på en gang.

Sjekket loggene i firebase konsoll, og det fungerer tilsynelatende som tiltenkt ved at antall ganger `deleteImageFromStorage` blir kalt reduseres betraktelig. Bildet under viser loggene fra en opplastning og sletting (pluss et separat kall nederst).

![image](https://user-images.githubusercontent.com/32391231/130604163-9847168c-315b-4959-93ea-6e3efe82bb61.png)