### PR TITLE
Gi unike nøkler til alle avganger

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -194,6 +194,7 @@ export function transformDepartureToLineData(
     const {
         date,
         expectedDepartureTime,
+        aimedDepartureTime,
         destinationDisplay,
         serviceJourney,
         situations,
@@ -218,7 +219,7 @@ export function transformDepartureToLineData(
     const subType = departure.serviceJourney?.transportSubmode
 
     return {
-        id: `${date}::${departure.serviceJourney.id}`,
+        id: `${date}::${departure.serviceJourney.id}::${aimedDepartureTime}`,
         expectedDepartureTime,
         type: transportMode,
         subType,

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -219,7 +219,7 @@ export function transformDepartureToLineData(
     const subType = departure.serviceJourney?.transportSubmode
 
     return {
-        id: `${date}::${departure.serviceJourney.id}::${aimedDepartureTime}`,
+        id: `${date}::${aimedDepartureTime}::${departure.serviceJourney.id}`,
         expectedDepartureTime,
         type: transportMode,
         subType,


### PR DESCRIPTION
Utvider nøklene for avganger til å være en kombinasjon av ID hentet gjennom entur/sdk og planlagt avgangstid.