### PR TITLE
Generalisert tilbakemelding ved feil brukernavn eller passord

### DIFF
--- a/src/components/LoginModal/EmailLogin/index.tsx
+++ b/src/components/LoginModal/EmailLogin/index.tsx
@@ -45,10 +45,12 @@ const EmailLogin = ({ setModalType, onDismiss }: Props): JSX.Element => {
                     setEmailError('E-posten er ikke gyldig')
                 } else if (error.code === 'auth/user-disabled') {
                     setEmailError('Brukeren er deaktivert.')
-                } else if (error.code === 'auth/user-not-found') {
-                    setEmailError('Vi finner ingen konto med denne e-posten.')
-                } else if (error.code === 'auth/wrong-password') {
-                    setPasswordError('Feil passord.')
+                } else if (
+                    error.code === 'auth/user-not-found' ||
+                    error.code === 'auth/wrong-password'
+                ) {
+                    setEmailError('Feil brukernavn eller passord.')
+                    setPasswordError('Feil brukernavn eller passord.')
                 } else {
                     // eslint-disable-next-line no-console
                     console.error(error)


### PR DESCRIPTION
🔐 
Tilbakemeldingene til brukeren ved login burde være generelle slik at man ikke kan gjette seg frem til brukernavn/e-poster. 
Med denne oppdateringen vil tilbakemeldingen se lik ut ved feil brukernavn eller feil passord.

Før | etter
--- | ---
<img width="200" alt="Screenshot 2021-08-31 at 13 09 54" src="https://user-images.githubusercontent.com/32192420/131492705-6afad8ed-01e4-4197-b912-686d09918ad4.png"> <img width="200" alt="Screenshot 2021-08-31 at 13 20 14" src="https://user-images.githubusercontent.com/32192420/131493933-df4fabcf-6a06-4d8c-8618-feaeeb8846bf.png"> | <img width="300" alt="Screenshot 2021-08-31 at 11 09 13" src="https://user-images.githubusercontent.com/32192420/131492720-36470e66-b98d-4202-91a4-0092315bff5c.png">
