### PR TITLE
Fix visual error on overflow menu in MyBoards

### DIFF
--- a/src/containers/MyBoards/BoardCard/index.tsx
+++ b/src/containers/MyBoards/BoardCard/index.tsx
@@ -123,9 +123,17 @@ function BoardCard({
             </Link>
 
             <div className="board-card__text-container">
-                <div className="board-card__text-container__top-wrapper">
-                    {boardTitleElement}
-                    <BoardOverflowMenu id={id} uid={uid} history={history} />
+                <div className="board-card__text-container__header-container">
+                    <div className="board-card__text-container__top-wrapper">
+                        {boardTitleElement}
+                    </div>
+                    <div>
+                        <BoardOverflowMenu
+                            id={id}
+                            uid={uid}
+                            history={history}
+                        />
+                    </div>
                 </div>
 
                 <div className="board-card__text-container__text">

--- a/src/containers/MyBoards/BoardCard/styles.scss
+++ b/src/containers/MyBoards/BoardCard/styles.scss
@@ -31,18 +31,19 @@
     }
 
     &__text-container {
+        &__header-container {
+            display: flex;
+        }
+
         &__top-wrapper {
-            display: inline;
+            margin-left: auto;
+            flex: 1;
 
             &__title {
                 color: var(--tavla-font-color);
                 width: fit-content;
                 max-width: 80%;
                 word-break: break-word;
-            }
-
-            &__overflow {
-                float: right;
             }
         }
 


### PR DESCRIPTION
Denne PRen, i motsetning til PR #451, fikser feilen ved hjelp av css. Hovedproblemet lå i at posisjonell styling på knappen `OverflowMenu` ikke medførte at menyen fulgte med. Innholdet ble derfor lagt i parent-divs og disse er satt til å plasseres med flexbox. 

Før | Etter
:----------|----------:
<img width="663" alt="Screenshot 2021-09-02 at 09 29 22" src="https://user-images.githubusercontent.com/22789935/131801691-456b696c-134e-4137-9559-ff85bb6ca056.png"> | <img width="690" alt="Screenshot 2021-09-02 at 09 29 06" src="https://user-images.githubusercontent.com/22789935/131801766-c3680523-9127-433a-91f9-04c2bdc17aee.png"> 