### PR TITLE
Visual login error on temporarily deactivated account

### DIFF
--- a/src/components/LoginModal/EmailLogin/index.tsx
+++ b/src/components/LoginModal/EmailLogin/index.tsx
@@ -6,6 +6,7 @@ import { GridContainer, GridItem } from '@entur/grid'
 import { EmailIcon, ClosedLockIcon, BackArrowIcon } from '@entur/icons'
 import { PrimaryButton } from '@entur/button'
 import { Heading3, Link } from '@entur/typography'
+import { SmallExpandableAlertBox } from '@entur/alert'
 
 import { useFormFields } from '../../../utils'
 import sikkerhetBom from '../../../assets/images/sikkerhet_bom.png'
@@ -32,10 +33,12 @@ const EmailLogin = ({ setModalType, onDismiss }: Props): JSX.Element => {
 
     const [emailError, setEmailError] = useState<string>()
     const [passwordError, setPasswordError] = useState<string>()
+    const [userDeactivatedError, setUserDeactivatedError] = useState<string>()
 
     const signIn = (email: string, password: string): void => {
         setEmailError(undefined)
         setPasswordError(undefined)
+        setUserDeactivatedError(undefined)
 
         firebase
             .auth()
@@ -45,6 +48,15 @@ const EmailLogin = ({ setModalType, onDismiss }: Props): JSX.Element => {
                     setEmailError('E-posten er ikke gyldig')
                 } else if (error.code === 'auth/user-disabled') {
                     setEmailError('Brukeren er deaktivert.')
+                } else if (error.code === 'auth/too-many-requests') {
+                    setUserDeactivatedError(
+                        'Tilgang til denne brukerkontoen har blitt ' +
+                            'midlertidig deaktivert på grunn av mange ' +
+                            'mislykkede påloggingsforsøk. Du kan få ' +
+                            'tilgang igjen ved å tilbakestille passordet ' +
+                            'ditt, (følg «Jeg har glemt passord») ' +
+                            'eller du kan prøve igjen senere.',
+                    )
                 } else if (
                     error.code === 'auth/user-not-found' ||
                     error.code === 'auth/wrong-password'
@@ -84,6 +96,16 @@ const EmailLogin = ({ setModalType, onDismiss }: Props): JSX.Element => {
             <Heading3 margin="none">Logg inn med e-post</Heading3>
             <form>
                 <GridContainer spacing="medium">
+                    {userDeactivatedError && (
+                        <GridItem small={12}>
+                            <SmallExpandableAlertBox
+                                title="Konto deaktivert"
+                                variant="error"
+                            >
+                                {userDeactivatedError}
+                            </SmallExpandableAlertBox>
+                        </GridItem>
+                    )}
                     <GridItem small={12}>
                         <InputGroup
                             label="E-post"

--- a/src/components/LoginModal/EmailLogin/index.tsx
+++ b/src/components/LoginModal/EmailLogin/index.tsx
@@ -47,7 +47,7 @@ const EmailLogin = ({ setModalType, onDismiss }: Props): JSX.Element => {
                 if (error.code === 'auth/invalid-email') {
                     setEmailError('E-posten er ikke gyldig')
                 } else if (error.code === 'auth/user-disabled') {
-                    setEmailError('Brukeren er deaktivert.')
+                    setUserDeactivatedError('Brukerkontoen er deaktivert.')
                 } else if (error.code === 'auth/too-many-requests') {
                     setUserDeactivatedError(
                         'Tilgang til denne brukerkontoen har blitt ' +


### PR DESCRIPTION
Changed visual feedback in states of deactivated accounts.

✅ Changes
* Added alert box on temporarily deactivated account (from too many login attempts)
* Changed deactivated account to be a alert box (previously shown on email input field error)

Both looks the same with the alert box collapsed: 
<img width="250" alt="Screenshot 2021-09-02 at 10 09 19" src="https://user-images.githubusercontent.com/32192420/131815847-1f68a2e5-248c-442d-b0c2-1dfc5e9696db.png">

| | Before | After
--- | --- | ---
Temporarily deactivated | <img width="300" alt="før-temp-de" src="https://user-images.githubusercontent.com/32192420/131815782-30c95626-008f-4778-8070-cc19168b919d.png"> | <img width="300" alt="Screenshot 2021-09-02 at 10 10 14" src="https://user-images.githubusercontent.com/32192420/131816260-d0d9e018-4532-45f1-bf55-679f5874f298.png">
Deactivated | <img width="300" alt="før-de" src="https://user-images.githubusercontent.com/32192420/131815924-febc54c2-c4c9-4a21-bc66-9f0d851d3a5e.png"> | <img width="300" alt="Screenshot 2021-09-02 at 10 09 28" src="https://user-images.githubusercontent.com/32192420/131816145-bbb84101-9007-4054-9012-acaab96f3be3.png">


