### PR TITLE
Fikse uendelig loop i useeffekten til holdeplass-view

### DIFF
--- a/src/dashboards/BusStop/index.tsx
+++ b/src/dashboards/BusStop/index.tsx
@@ -81,6 +81,14 @@ function getDataGrid(
     }
 }
 
+function removeStopPlacesWithNoDepartures(
+    sPlacesWithDepartures: StopPlaceWithDepartures[],
+): StopPlaceWithDepartures[] {
+    return sPlacesWithDepartures.filter(
+        ({ departures }) => departures.length > 0,
+    )
+}
+
 const BusStop = ({ history }: Props): JSX.Element | null => {
     const [settings] = useSettingsContext()
     const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
@@ -115,14 +123,6 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
         }
     }
 
-    function filterStopPlacesWithDepartures(
-        sPlacesWithDepartures: StopPlaceWithDepartures[],
-    ): StopPlaceWithDepartures[] {
-        return sPlacesWithDepartures.filter(
-            ({ departures }) => departures.length > 0,
-        )
-    }
-
     const mapCol = settings?.showMap ? 1 : 0
     const totalItems = numberOfStopPlaces + mapCol
     const hasData = Boolean(
@@ -150,7 +150,7 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
     useEffect(() => {
         let defaultTileOrder: Item[] = []
         if (stopPlacesWithDepartures) {
-            const filtered = filterStopPlacesWithDepartures(
+            const filtered = removeStopPlacesWithNoDepartures(
                 stopPlacesWithDepartures,
             ).map((item) => ({
                 id: item.id,


### PR DESCRIPTION
Slik jeg har skjønt det fører den if-en fra 118 til 123 til at `stopPlacesWithDepartures` ble forskjellig på hver render. Det førte til at loopen ble uendelig om ikke ifen 152 til 154 kicket inn og hindret at noe state ble satt i useeffecten. Endret derfor til å kjøre filtreringen inni useeffecten. Jeg gjorde noen andre refactoringer her som jeg synes ga mening. Åpen for innspill om det er noe en er uenig i. 