### PR TITLE
Set correct .env variables

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,9 +75,9 @@ module.exports = (env) => ({
             },
             {
                 test: /\.(svg|png|jpe?g|gif|eot|webp|woff2?)$/,
-                loader: 'file-loader',
-                options: {
-                    outputPath: 'assets/',
+                type: 'asset',
+                generator: {
+                    filename: 'assets/[hash][ext][query]',
                 },
             },
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,8 +12,8 @@ const resolveEnv = (env) => {
     return 'staging'
 }
 
-module.exports = (env) => ({
-    mode: 'development',
+module.exports = (env, args) => ({
+    mode: args.mode === 'production' ? 'production' : 'development',
     entry: './src/main.tsx',
     devtool: 'inline-source-map',
     output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,12 @@ const CopyPlugin = require('copy-webpack-plugin')
 
 const OUTPUT_PATH = path.resolve(__dirname, 'dist')
 
+const resolveEnv = (env) => {
+    if (env.development) return 'development'
+    if (env.prod) return 'prod'
+    return 'staging'
+}
+
 module.exports = (env) => ({
     mode: 'development',
     entry: './src/main.tsx',
@@ -89,10 +95,7 @@ module.exports = (env) => ({
             favicon: 'src/assets/images/logo.png',
         }),
         new Dotenv({
-            path: path.join(
-                __dirname,
-                `.env.${typeof env === 'string' ? env : 'staging'}`,
-            ),
+            path: path.join(__dirname, `.env.${resolveEnv(env)}`),
         }),
         new CopyPlugin({
             patterns: [


### PR DESCRIPTION
God mandag. Slik det sto ble staging alltid valgt, da env som passes inn nå er et objekt. Med andre ord har egentlig ikke prod vært oppe og gått i helgen. Til og med noen som har laget issue på det.  Ble introdusert i forbindelse med oppdateringen av webpack, så min feil. Endringene under burde fikse det.

Commit 2 og 3 skal fikse henholdsvis feil i fontloadingen og at webpack bruker 'development' som mode i alle tilfeller. 