### PR TITLE
Upgrade typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
                 "stylelint-config-prettier": "^8.0.2",
                 "stylelint-config-standard": "^22.0.0",
                 "ts-loader": "^9.2.5",
-                "typescript": "^3.9.9",
+                "typescript": "^4.4.2",
                 "webpack": "^5.51.2",
                 "webpack-cli": "^4.8.0",
                 "webpack-dev-server": "^4.1.0"
@@ -23108,9 +23108,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+            "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -42641,9 +42641,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+            "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "stylelint-config-prettier": "^8.0.2",
         "stylelint-config-standard": "^22.0.0",
         "ts-loader": "^9.2.5",
-        "typescript": "^3.9.9",
+        "typescript": "^4.4.2",
         "webpack": "^5.51.2",
         "webpack-cli": "^4.8.0",
         "webpack-dev-server": "^4.1.0"

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -101,8 +101,9 @@ const EditTab = (): JSX.Element => {
 
     useEffect(() => {
         let ignoreResponse = false
-
-        const ids = [...newStops, ...nearestStopPlaceIds]
+        const ids = newStops
+            ? [...newStops, ...nearestStopPlaceIds]
+            : nearestStopPlaceIds
 
         getStopPlacesWithLines(
             ids.map((id: string) => id.replace(/-\d+$/, '')),
@@ -129,7 +130,9 @@ const EditTab = (): JSX.Element => {
             .filter(({ type }) => type === 'BikeRentalStation')
             .map(({ id }) => id)
 
-        const ids = [...newStations, ...nearestBikeRentalStationIds]
+        const ids = newStations
+            ? [...newStations, ...nearestBikeRentalStationIds]
+            : nearestBikeRentalStationIds
 
         service.getBikeRentalStations(ids).then((freshStations) => {
             if (ignoreResponse) return
@@ -149,7 +152,11 @@ const EditTab = (): JSX.Element => {
 
     const addNewStop = useCallback(
         (stopId: string) => {
-            const numberOfDuplicates = [...nearestStopPlaceIds, ...newStops]
+            const numberOfDuplicates = (
+                newStops
+                    ? [...nearestStopPlaceIds, ...newStops]
+                    : nearestStopPlaceIds
+            )
                 .map((id) => id.replace(/-\d+$/, ''))
                 .filter((id) => id === stopId).length
 
@@ -158,7 +165,7 @@ const EditTab = (): JSX.Element => {
                 : `${stopId}-${numberOfDuplicates}`
 
             setSettings({
-                newStops: [...newStops, id],
+                newStops: newStops ? [...newStops, id] : [id],
             })
         },
         [nearestStopPlaceIds, newStops, setSettings],
@@ -167,7 +174,9 @@ const EditTab = (): JSX.Element => {
     const addNewStation = useCallback(
         (stationId: string) => {
             setSettings({
-                newStations: [...newStations, stationId],
+                newStations: newStations
+                    ? [...newStations, stationId]
+                    : [stationId],
             })
         },
         [newStations, setSettings],

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -55,7 +55,12 @@ const COLS: { [key: string]: number } = {
 const EditTab = (): JSX.Element => {
     const [breakpoint, setBreakpoint] = useState<string>('lg')
     const [settings, setSettings] = useSettingsContext()
-    const { newStops, newStations, hiddenModes, showMap } = settings || {}
+    const {
+        newStops = [],
+        newStations = [],
+        hiddenModes,
+        showMap,
+    } = settings || {}
     const [distance, setDistance] = useState<number>(
         settings?.distance || DEFAULT_DISTANCE,
     )
@@ -101,9 +106,7 @@ const EditTab = (): JSX.Element => {
 
     useEffect(() => {
         let ignoreResponse = false
-        const ids = newStops
-            ? [...newStops, ...nearestStopPlaceIds]
-            : nearestStopPlaceIds
+        const ids = [...newStops, ...nearestStopPlaceIds]
 
         getStopPlacesWithLines(
             ids.map((id: string) => id.replace(/-\d+$/, '')),
@@ -130,9 +133,7 @@ const EditTab = (): JSX.Element => {
             .filter(({ type }) => type === 'BikeRentalStation')
             .map(({ id }) => id)
 
-        const ids = newStations
-            ? [...newStations, ...nearestBikeRentalStationIds]
-            : nearestBikeRentalStationIds
+        const ids = [...newStations, ...nearestBikeRentalStationIds]
 
         service.getBikeRentalStations(ids).then((freshStations) => {
             if (ignoreResponse) return
@@ -152,11 +153,7 @@ const EditTab = (): JSX.Element => {
 
     const addNewStop = useCallback(
         (stopId: string) => {
-            const numberOfDuplicates = (
-                newStops
-                    ? [...nearestStopPlaceIds, ...newStops]
-                    : nearestStopPlaceIds
-            )
+            const numberOfDuplicates = [...nearestStopPlaceIds, ...newStops]
                 .map((id) => id.replace(/-\d+$/, ''))
                 .filter((id) => id === stopId).length
 
@@ -165,7 +162,7 @@ const EditTab = (): JSX.Element => {
                 : `${stopId}-${numberOfDuplicates}`
 
             setSettings({
-                newStops: newStops ? [...newStops, id] : [id],
+                newStops: [...newStops, id],
             })
         },
         [nearestStopPlaceIds, newStops, setSettings],
@@ -174,9 +171,7 @@ const EditTab = (): JSX.Element => {
     const addNewStation = useCallback(
         (stationId: string) => {
             setSettings({
-                newStations: newStations
-                    ? [...newStations, stationId]
-                    : [stationId],
+                newStations: [...newStations, stationId],
             })
         },
         [newStations, setSettings],

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -41,7 +41,7 @@ function BottomMenu({ className, history }: Props): JSX.Element {
 
     const { addToast } = useToast()
 
-    const { documentId } = useParams()
+    const { documentId } = useParams<{ documentId: string }>()
 
     const onSettingsButtonClick = useCallback(
         (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/src/containers/LandingPage/SearchPanel/index.tsx
+++ b/src/containers/LandingPage/SearchPanel/index.tsx
@@ -37,7 +37,7 @@ function mapFeaturesToItems(features: Feature[]): Item[] {
     }))
 }
 
-function getErrorMessage(error: PositionError): string {
+function getErrorMessage(error: GeolocationPositionError): string {
     switch (error.code) {
         case error.PERMISSION_DENIED:
             return 'Du må godta bruk av posisjon i nettleseren før vi kan hente den.'
@@ -83,7 +83,7 @@ const SearchPanel = ({ handleCoordinatesSelected }: Props): JSX.Element => {
         })
     }
 
-    const handleSuccessLocation = (data: Position): void => {
+    const handleSuccessLocation = (data: GeolocationPosition): void => {
         refreshLocationPermission()
         const position = {
             latitude: data.coords.latitude,
@@ -92,7 +92,7 @@ const SearchPanel = ({ handleCoordinatesSelected }: Props): JSX.Element => {
         getAddressFromPosition(position)
     }
 
-    const handleDeniedLocation = (error: PositionError): void => {
+    const handleDeniedLocation = (error: GeolocationPositionError): void => {
         refreshLocationPermission()
         setErrorMessage(getErrorMessage(error))
         setLocation({

--- a/src/containers/MineTavlerModal/index.tsx
+++ b/src/containers/MineTavlerModal/index.tsx
@@ -61,7 +61,9 @@ const MineTavlerModal = ({ open, onDismiss }: Props): JSX.Element | null => {
             !settings.owners?.includes(user.uid) &&
             open
         ) {
-            const newOwnersList = [...settings.owners, user.uid]
+            const newOwnersList = settings.owners
+                ? [...settings.owners, user.uid]
+                : [user.uid]
             setSettings({
                 owners: newOwnersList,
             })

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -26,7 +26,7 @@ export default function useBikeRentalStations(): BikeRentalStation[] | null {
         settings?.distance,
     )
 
-    const { newStations, hiddenStations, hiddenModes } = settings || {}
+    const { newStations = [], hiddenStations, hiddenModes } = settings || {}
 
     const nearestBikeRentalStations = useMemo(
         () =>
@@ -36,11 +36,7 @@ export default function useBikeRentalStations(): BikeRentalStation[] | null {
         [nearestPlaces],
     )
 
-    const allStationIds = (
-        newStations
-            ? [...newStations, ...nearestBikeRentalStations]
-            : nearestBikeRentalStations
-    )
+    const allStationIds = [...newStations, ...nearestBikeRentalStations]
         .filter((id) => !hiddenStations?.includes(id))
         .filter((id, index, ids) => ids.indexOf(id) === index)
 

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -36,7 +36,11 @@ export default function useBikeRentalStations(): BikeRentalStation[] | null {
         [nearestPlaces],
     )
 
-    const allStationIds = [...newStations, ...nearestBikeRentalStations]
+    const allStationIds = (
+        newStations
+            ? [...newStations, ...nearestBikeRentalStations]
+            : nearestBikeRentalStations
+    )
         .filter((id) => !hiddenStations?.includes(id))
         .filter((id, index, ids) => ids.indexOf(id) === index)
 

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -54,7 +54,7 @@ export default function useStopPlacesWithDepartures():
     >(null)
 
     const {
-        newStops,
+        newStops = [],
         hiddenStops,
         hiddenStopModes,
         hiddenRoutes,
@@ -71,9 +71,9 @@ export default function useStopPlacesWithDepartures():
 
     const isDisabled = Boolean(hiddenModes?.includes('kollektiv'))
 
-    const allStopPlaceIds = unique(
-        newStops ? [...newStops, ...nearestStopPlaces] : nearestStopPlaces,
-    ).filter((id) => !hiddenStops?.includes(id))
+    const allStopPlaceIds = unique([...newStops, ...nearestStopPlaces]).filter(
+        (id) => !hiddenStops?.includes(id),
+    )
 
     const allStopPlaceIdsWithoutDuplicateNumber = allStopPlaceIds.map((id) =>
         id.replace(/-\d+$/, ''),

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -71,9 +71,9 @@ export default function useStopPlacesWithDepartures():
 
     const isDisabled = Boolean(hiddenModes?.includes('kollektiv'))
 
-    const allStopPlaceIds = unique([...newStops, ...nearestStopPlaces]).filter(
-        (id) => !hiddenStops?.includes(id),
-    )
+    const allStopPlaceIds = unique(
+        newStops ? [...newStops, ...nearestStopPlaces] : nearestStopPlaces,
+    ).filter((id) => !hiddenStops?.includes(id))
 
     const allStopPlaceIdsWithoutDuplicateNumber = allStopPlaceIds.map((id) =>
         id.replace(/-\d+$/, ''),

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -121,6 +121,7 @@ export default function useStopPlacesWithDepartures():
                             )
                     return {
                         ...stop,
+                        id: stopId,
                         departures: mappedAndFilteredDepartures,
                     }
                 },


### PR DESCRIPTION
Denne er bak i køen for #457 da den har med de samme commitsene. 

Her oppgraderes ts og koden refaktoreres til å håndtere feil ts påpeker i den gamle koden. Det er også med en fiks for logikken bak å kunne ha samme stoppested to ganger. Slik koden var ble den unike id-en som ble satt for to entries av samme stoppesteder borte i filtreringsprosessen når man henter stoppesteder med avganger. Dette skal nå ha blitt riktig med siste commit på denne PR-en. 