### PR TITLE
Horisontal scrolling av avgangstider

### DIFF
--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -46,7 +46,8 @@
     &__sublabels {
         display: flex;
         flex-wrap: nowrap;
-        overflow-x: auto;
+        overflow-x: scroll;
+        overflow-y: hidden;
         font-size: $font-sizes-extra-large;
 
         &::-webkit-scrollbar {

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -5,8 +5,6 @@
     display: flex;
     border-bottom: 2px solid var(--tavla-border-color);
     padding: 1rem 0;
-    overflow-x: hidden;
-    overflow-y: hidden;
 
     &:last-child {
         border-bottom: 0;
@@ -28,7 +26,8 @@
     &__texts {
         flex-direction: column;
         flex-grow: 1;
-        overflow: hidden;
+        overflow-x: scroll;
+        overflow-y: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
     }
@@ -45,17 +44,21 @@
     }
 
     &__sublabels {
-        display: grid;
-        grid-template-columns: repeat(20, 1fr);
-        justify-content: space-between;
-        min-width: 130rem;
+        display: flex;
+        flex-wrap: nowrap;
+        overflow-x: auto;
         font-size: $font-sizes-extra-large;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
     }
 
     &__sublabel {
         align-items: center;
         display: flex;
         font-weight: 400;
+        min-width: 6.5rem;
 
         &__cancellation {
             align-items: center;


### PR DESCRIPTION
Denne PR'en muliggjør å scrolle horisontalt for å se senere avgangstider i Kompakt visning. Dette skal funke på både desktop og mobil.
Synlig scrollbar er fjernet, mye fordi den overlappet en del med avgangstidene. 

<img src="https://user-images.githubusercontent.com/32192420/132516498-7c68aba0-1c01-46c7-a03f-4ba81839e360.gif" width="400" />
