### PR TITLE
Whitelist apis.google.com in Content-Security-Policy header

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -22,7 +22,7 @@
                     },
                     {
                         "key": "Content-Security-Policy",
-                        "value": "child-src 'self' blob:;default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com blob:; connect-src 'self' https://stats.g.doubleclick.net https://*.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com https://*.entur.io https://*.entur.org https://*.cloudfunctions.net https://*.googleapis.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:  https://www.google.no  https://www.google.com https://*.googleapis.com https://www.google-analytics.com; object-src 'none'; frame-ancestors https:; manifest-src 'self' blob:"
+                        "value": "child-src 'self' blob:;default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com  https://apis.google.com blob:; connect-src 'self' https://stats.g.doubleclick.net https://*.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com https://*.entur.io https://*.entur.org https://*.cloudfunctions.net https://*.googleapis.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:  https://www.google.no  https://www.google.com https://*.googleapis.com https://www.google-analytics.com; object-src 'none'; frame-ancestors https:; manifest-src 'self' blob:"
                     },
                     {
                         "key": "Permissions-Policy",


### PR DESCRIPTION
Vi fant ut tidligere i dag at prod ikke funket på mobil og klødd oss i hodet et par timer nå. 

Slik vi har skjønt det sjekker firebase hva slags device man er på, og firebase/auth henter script fra apis.google.com om man er på mobil. Denne er ikke whitelistet i content security policy headeren, og blir følgelig ikke kjørt. Før omskrivingen til firebase 9 fikk man samme feilen, men appen fungerte tilsynelatende ok. Etter omskrivingen gjør den ikke det. 

I staging finner man nå nyeste master som altså ikke funker, mens prod er rullet tilbake til før omskrivingen. En kan sjekke oppførselen mellom de to forskjellige der. Litt vanskelig å reprodusere dette lokalt, da alt fungerer fint der (mye mulig pga at localhost ikke setter noe content security policy header på responsen sin?). 

Forsøkt løsning her er å whiteliste apis.google.com og se om det fikser feilen.