### PR TITLE
Fikse feilmelding om src URL in Manifest invalid 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "description": "Lag din egen sanntidstavle.",
     "orientation": "portrait",
     "lang": "no",
-    "images": [
+    "icons": [
         {
             "src": "images/logo/logo-72x72.png",
             "sizes": "72x72",
@@ -57,6 +57,13 @@
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "any maskable"
+        }
+    ],
+    "splash_screen": [
+        {
+            "src": "images/splash/startup-image-1284x2778.png",
+            "sizes": "1284x2778",
+            "type": "image/png"
         }
     ]
 }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -75,13 +75,49 @@ function updateManifest(pathName: string): void {
             lang: 'no',
             icons: [
                 {
-                    src: '/images/logo/logo-192x192.png',
+                    src: `${pathName}/images/logo/logo-72x72.png`,
+                    sizes: '72x72',
+                    type: 'image/png',
+                    purpose: 'any maskable',
+                },
+                {
+                    src: `${pathName}images/logo/logo-96x96.png`,
+                    sizes: '96x96',
+                    type: 'image/png',
+                    purpose: 'any maskable',
+                },
+                {
+                    src: `${pathName}images/logo/logo-128x128.png`,
+                    sizes: '128x128',
+                    type: 'image/png',
+                    purpose: 'any maskable',
+                },
+                {
+                    src: `${pathName}images/logo/logo-144x144.png`,
+                    sizes: '144x144',
+                    type: 'image/png',
+                    purpose: 'any maskable',
+                },
+                {
+                    src: `${pathName}images/logo/logo-152x152.png`,
+                    sizes: '152x152',
+                    type: 'image/png',
+                    purpose: 'any maskable',
+                },
+                {
+                    src: `${pathName}images/logo/logo-192x192.png`,
                     sizes: '192x192',
                     type: 'image/png',
                     purpose: 'any maskable',
                 },
                 {
-                    src: '/images/logo/logo-512x512.png',
+                    src: `${pathName}images/logo/logo-384x384.png`,
+                    sizes: '384x384',
+                    type: 'image/png',
+                    purpose: 'any maskable',
+                },
+                {
+                    src: `${pathName}images/logo/logo-512x512.png`,
                     sizes: '512x512',
                     type: 'image/png',
                     purpose: 'any maskable',
@@ -89,7 +125,7 @@ function updateManifest(pathName: string): void {
             ],
             splash_screen: [
                 {
-                    src: '/images/splash/startup-image-1284x2778.png',
+                    src: `${pathName}/images/splash/startup-image-1284x2778.png`,
                     sizes: '1284x2778',
                     type: 'image/png',
                 },


### PR DESCRIPTION
Denne PRen oppdaterer noen verdier i Manifest-filene som lages som gjør at `src` for URL-en ikke lenger er invalid. Er en god del ekstra som kan og sikkert burde gjøres med PWA-delen av web appen, men det tar ikke denne PRen for seg