### PR TITLE
Fiks «A component is changing an uncontrolled input of type checkbox to be controlled.»-feil i Admin-panelet

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -67,8 +67,8 @@ const EditTab = (): JSX.Element => {
         newStops = [],
         newStations = [],
         hiddenModes,
-        showMap,
-        showWeather,
+        showMap = false,
+        showWeather = false,
     } = settings || {}
     const [distance, setDistance] = useState<number>(
         settings?.distance || DEFAULT_DISTANCE,


### PR DESCRIPTION
Denne PRen fikser en feil i Admin-panelet der innstillings-tilen for vær og kart ikke har en satt startverdi når de hentes fra `settings`. Dette gjør at `form`-komponenten starter som _uncontrolled_ for så å bli _controlled_., noe React ikke liker (https://reactjs.org/docs/forms.html#controlled-components). Fiksen er så enkel som at showMap og showWeather settes default til `false` hvis verdien deres ikke er satt i `settings`.