### PR TITLE
🚲 Bike station migration 🚲 : Moving to mobility API (v2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@entur/loader": "^0.4.1",
                 "@entur/menu": "^4.0.0",
                 "@entur/modal": "^1.5.4",
-                "@entur/sdk": "^4.0.0",
+                "@entur/sdk": "^4.2.0",
                 "@entur/tab": "^0.4.24",
                 "@entur/table": "^4.3.15",
                 "@entur/tokens": "^3.1.0",
@@ -2780,9 +2780,9 @@
             }
         },
         "node_modules/@entur/sdk": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@entur/sdk/-/sdk-4.1.1.tgz",
-            "integrity": "sha512-6U9jB/SN77lJpRzg37sKtNk7vKkMRa7pSnC+nOZ7P1hmuCe8ZSqHgGppIp7nGCdvzMYmG9bEGZONUEzdBCqD+Q==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@entur/sdk/-/sdk-4.2.0.tgz",
+            "integrity": "sha512-OpuJfUSuPl39A6m7bu407OoPoG9+MSvaO+IqGnsSohn9CBv9wNVqTtJZ8++FsywC0KLuO5UldHyfZwlqcJvrtQ==",
             "dependencies": {
                 "@babel/polyfill": "^7.12.1",
                 "@turf/bbox": "^6.3.0",
@@ -26217,9 +26217,9 @@
             }
         },
         "@entur/sdk": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@entur/sdk/-/sdk-4.1.1.tgz",
-            "integrity": "sha512-6U9jB/SN77lJpRzg37sKtNk7vKkMRa7pSnC+nOZ7P1hmuCe8ZSqHgGppIp7nGCdvzMYmG9bEGZONUEzdBCqD+Q==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@entur/sdk/-/sdk-4.2.0.tgz",
+            "integrity": "sha512-OpuJfUSuPl39A6m7bu407OoPoG9+MSvaO+IqGnsSohn9CBv9wNVqTtJZ8++FsywC0KLuO5UldHyfZwlqcJvrtQ==",
             "requires": {
                 "@babel/polyfill": "^7.12.1",
                 "@turf/bbox": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@entur/loader": "^0.4.1",
         "@entur/menu": "^4.0.0",
         "@entur/modal": "^1.5.4",
-        "@entur/sdk": "^4.0.0",
+        "@entur/sdk": "^4.2.0",
         "@entur/tab": "^0.4.24",
         "@entur/table": "^4.3.15",
         "@entur/tokens": "^3.1.0",

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,4 +1,3 @@
-import { BikeRentalStation } from '@entur/sdk'
 import React, { useState, memo, useRef } from 'react'
 
 import { InteractiveMap, Marker } from 'react-map-gl'
@@ -7,7 +6,7 @@ import useSupercluster from 'use-supercluster'
 
 import type { ClusterProperties } from 'supercluster'
 
-import { Vehicle } from '@entur/sdk/lib/mobility/types'
+import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import PositionPin from '../../assets/icons/positionPin'
 
@@ -51,20 +50,17 @@ const Map = ({
         },
     }))
     const bikeRentalStationPoints = bikeRentalStations?.map(
-        (bikeRentalStation: BikeRentalStation) => ({
+        (bikeRentalStation: Station) => ({
             type: 'Feature' as const,
             properties: {
                 cluster: false,
                 stationId: bikeRentalStation.id,
-                bikesAvailable: bikeRentalStation.bikesAvailable,
-                spacesAvailable: bikeRentalStation.spacesAvailable,
+                bikesAvailable: bikeRentalStation.numBikesAvailable,
+                spacesAvailable: bikeRentalStation.numDocksAvailable,
             },
             geometry: {
                 type: 'Point' as const,
-                coordinates: [
-                    bikeRentalStation.longitude,
-                    bikeRentalStation.latitude,
-                ],
+                coordinates: [bikeRentalStation.lon, bikeRentalStation.lat],
             },
         }),
     )
@@ -224,7 +220,7 @@ const Map = ({
 
 interface Props {
     stopPlaces?: StopPlaceWithDepartures[] | null
-    bikeRentalStations?: BikeRentalStation[] | null
+    bikeRentalStations?: Station[] | null
     scooters?: Vehicle[] | null
     walkTimes?: Array<{ stopId: string; walkTime: number }> | null
     interactive: boolean

--- a/src/containers/Admin/EditTab/BikePanel/index.tsx
+++ b/src/containers/Admin/EditTab/BikePanel/index.tsx
@@ -59,12 +59,12 @@ function BikePanel(props: Props): JSX.Element {
                 <Checkbox
                     key={id}
                     id={id}
-                    name={getTranslation(name) || id}
+                    name={getTranslation(name) || ''}
                     checked={!hiddenStations.includes(id)}
                     onChange={onToggleStation}
                 >
                     <span className="bike-panel__eds-paragraph">
-                        {getTranslation(name) || id}
+                        {getTranslation(name) || ''}
                     </span>
                 </Checkbox>
             ))}

--- a/src/containers/Admin/EditTab/BikePanel/index.tsx
+++ b/src/containers/Admin/EditTab/BikePanel/index.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from 'react'
 
-import { BikeRentalStation } from '@entur/sdk'
+import { Station } from '@entur/sdk/lib/mobility/types'
 import { Checkbox, Fieldset } from '@entur/form'
 import { Paragraph } from '@entur/typography'
 
-import { toggleValueInList } from '../../../../utils'
+import { getTranslation, toggleValueInList } from '../../../../utils'
 import { useSettingsContext } from '../../../../settings'
 
 import './styles.scss'
@@ -59,11 +59,13 @@ function BikePanel(props: Props): JSX.Element {
                 <Checkbox
                     key={id}
                     id={id}
-                    name={name}
+                    name={getTranslation(name) || id}
                     checked={!hiddenStations.includes(id)}
                     onChange={onToggleStation}
                 >
-                    <span className="bike-panel__eds-paragraph">{name}</span>
+                    <span className="bike-panel__eds-paragraph">
+                        {getTranslation(name) || id}
+                    </span>
                 </Checkbox>
             ))}
         </Fieldset>
@@ -71,7 +73,7 @@ function BikePanel(props: Props): JSX.Element {
 }
 
 interface Props {
-    stations: BikeRentalStation[]
+    stations: Station[]
 }
 
 export default BikePanel

--- a/src/containers/Admin/EditTab/BikeSearch/index.tsx
+++ b/src/containers/Admin/EditTab/BikeSearch/index.tsx
@@ -19,7 +19,7 @@ interface Item {
 function mapFeaturesToItems(features: Station[]): Item[] {
     return features.map(({ id, name }) => ({
         value: id,
-        label: getTranslation(name) || id,
+        label: getTranslation(name) || '',
     }))
 }
 

--- a/src/containers/Admin/EditTab/BikeSearch/index.tsx
+++ b/src/containers/Admin/EditTab/BikeSearch/index.tsx
@@ -27,22 +27,30 @@ const BikePanelSearch = ({ onSelected, position }: Props): JSX.Element => {
     const [stations, setStations] = useState<Station[]>([])
 
     useEffect(() => {
-        let isMounted = true
+        const controller = new AbortController()
         if (position) {
             service.mobility
-                .getStations({
-                    lat: position.latitude,
-                    lon: position.longitude,
-                    range: MAX_SEARCH_RANGE,
-                })
+                .getStations(
+                    {
+                        lat: position.latitude,
+                        lon: position.longitude,
+                        range: MAX_SEARCH_RANGE,
+                    },
+                    {
+                        signal: controller.signal,
+                    },
+                )
                 .then((data) => {
-                    if (isMounted) {
-                        setStations(data)
+                    setStations(data)
+                })
+                .catch((err) => {
+                    if (!controller.signal.aborted) {
+                        throw err
                     }
                 })
         }
         return () => {
-            isMounted = false
+            controller.abort()
         }
     }, [position])
 

--- a/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
@@ -33,7 +33,7 @@ async function getItems(query: string): Promise<Item[]> {
     return mapFeaturesToItems(featuresData)
 }
 
-const SelectionPanelSearch = ({ handleAddNewStop }: Props): JSX.Element => {
+const StopPlaceSearch = ({ handleAddNewStop }: Props): JSX.Element => {
     const onItemSelected = (item: Item | null): void => {
         if (item) {
             handleAddNewStop(item.value)
@@ -59,4 +59,4 @@ interface Props {
     handleAddNewStop: (stopId: string) => void
 }
 
-export default SelectionPanelSearch
+export default StopPlaceSearch

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -90,7 +90,7 @@ const EditTab = (): JSX.Element => {
     }, [debouncedDistance, setSettings, settings])
 
     const [stopPlaces, setStopPlaces] = useState<StopPlaceWithLines[]>([])
-    const bikeRentalStations: Station[] | null = useBikeRentalStations()
+    const bikeRentalStations: Station[] | null = useBikeRentalStations(false)
     const [sortedBikeRentalStations, setSortedBikeRentalStations] = useState<
         Station[]
     >([])

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -183,6 +183,7 @@ const EditTab = (): JSX.Element => {
 
     const addNewStation = useCallback(
         (stationId: string) => {
+            if (newStations.includes(stationId)) return
             setSettings({
                 newStations: [...newStations, stationId],
             })

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -121,13 +121,13 @@ const EditTab = (): JSX.Element => {
     const scooters = useMobility(FormFactor.SCOOTER)
 
     useEffect(() => {
-        let ignoreResponse = false
+        const controller = new AbortController()
         const ids = [...newStops, ...nearestStopPlaceIds]
 
         getStopPlacesWithLines(
             ids.map((id: string) => id.replace(/-\d+$/, '')),
         ).then((resultingStopPlaces) => {
-            if (ignoreResponse) return
+            if (controller.signal.aborted) return
 
             setStopPlaces(
                 resultingStopPlaces.map((s, index) => ({
@@ -138,12 +138,12 @@ const EditTab = (): JSX.Element => {
         })
 
         return (): void => {
-            ignoreResponse = true
+            controller.abort()
         }
     }, [nearestPlaces, nearestStopPlaceIds, newStops])
 
     useEffect(() => {
-        let ignoreResponse = false
+        const controller = new AbortController()
 
         if (bikeRentalStations) {
             const sortedStations = bikeRentalStations
@@ -154,13 +154,12 @@ const EditTab = (): JSX.Element => {
                         'no',
                     ),
                 )
-            if (!ignoreResponse) {
-                setSortedBikeRentalStations(sortedStations)
-            }
+            if (controller.signal.aborted) return
+            setSortedBikeRentalStations(sortedStations)
         }
 
         return (): void => {
-            ignoreResponse = true
+            controller.abort()
         }
     }, [bikeRentalStations])
 

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -148,12 +148,13 @@ const EditTab = (): JSX.Element => {
         if (bikeRentalStations) {
             const sortedStations = bikeRentalStations
                 .filter(isNotNullOrUndefined)
-                .sort((a: Station, b: Station) =>
-                    (getTranslation(a.name) || a.id).localeCompare(
-                        getTranslation(b.name) || b.id,
-                        'no',
-                    ),
-                )
+                .sort((a: Station, b: Station) => {
+                    const aName = getTranslation(a.name)
+                    const bName = getTranslation(b.name)
+                    if (!aName) return 1
+                    if (!bName) return -1
+                    return aName.localeCompare(bName, 'no')
+                })
             if (controller.signal.aborted) return
             setSortedBikeRentalStations(sortedStations)
         }

--- a/src/containers/DashboardWrapper/index.tsx
+++ b/src/containers/DashboardWrapper/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { BikeRentalStation } from '@entur/sdk'
 import { Loader } from '@entur/loader'
 
-import { Vehicle } from '@entur/sdk/lib/mobility/types'
+import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import { useCounter, isDarkOrDefaultTheme } from '../../utils'
 import { useSettingsContext } from '../../settings'
@@ -80,7 +79,7 @@ function DashboardWrapper(props: Props): JSX.Element {
 
 interface Props {
     stopPlacesWithDepartures?: StopPlaceWithDepartures[] | null
-    bikeRentalStations?: BikeRentalStation[] | null
+    bikeRentalStations?: Station[] | null
     scooters?: Vehicle[] | null
     className: string
     children: JSX.Element | JSX.Element[]

--- a/src/dashboards/BusStop/MapTile/index.tsx
+++ b/src/dashboards/BusStop/MapTile/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import { BikeRentalStation } from '@entur/sdk'
 
-import { Vehicle } from '@entur/sdk/lib/mobility/types'
+import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import MapView from '../../../components/Map'
 
@@ -21,7 +20,7 @@ function MapTile(data: Props): JSX.Element {
 
 interface Props {
     stopPlaces: StopPlaceWithDepartures[] | null
-    bikeRentalStations: BikeRentalStation[] | null
+    bikeRentalStations: Station[] | null
     scooters: Vehicle[] | null
     walkTimes: Array<{ stopId: string; walkTime: number }> | null
     latitude: number

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -8,7 +8,7 @@ import Tile from '../components/Tile'
 import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { IconColorType } from '../../../types'
-import { getIconColorType } from '../../../utils'
+import { getIconColorType, getTranslation } from '../../../utils'
 import useWalkInfoBike, { WalkInfoBike } from '../../../logic/useWalkInfoBike'
 import TileRow from '../components/TileRow'
 
@@ -57,7 +57,7 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                             ? getWalkInfoBike(walkInfoBike || [], station.id)
                             : undefined
                     }
-                    label={station.system.name.translation[0].value}
+                    label={getTranslation(station.name) || ''}
                     subLabels={[
                         {
                             time:

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import { BikeRentalStation } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 import { BicycleIcon } from '@entur/icons'
+import { Station } from '@entur/sdk/lib/mobility/types'
 
 import Tile from '../components/Tile'
 
@@ -57,19 +57,19 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                             ? getWalkInfoBike(walkInfoBike || [], station.id)
                             : undefined
                     }
-                    label={station.name}
+                    label={station.system.name.translation[0].value}
                     subLabels={[
                         {
                             time:
-                                station.bikesAvailable === 1
+                                station.numBikesAvailable === 1
                                     ? '1 sykkel'
-                                    : `${station.bikesAvailable} sykler`,
+                                    : `${station.numBikesAvailable} sykler`,
                         },
                         {
                             time:
-                                station.spacesAvailable === 1
+                                station.numDocksAvailable === 1
                                     ? '1 lås'
-                                    : `${station.spacesAvailable} låser`,
+                                    : `${station.numBikesAvailable} låser`,
                         },
                     ]}
                 />
@@ -79,7 +79,7 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
 }
 
 interface Props {
-    stations: BikeRentalStation[]
+    stations: Station[]
 }
 
 export default BikeTile

--- a/src/dashboards/Chrono/MapTile/index.tsx
+++ b/src/dashboards/Chrono/MapTile/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
-import { BikeRentalStation } from '@entur/sdk'
-
-import { Vehicle } from '@entur/sdk/lib/mobility/types'
+import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import MapView from '../../../components/Map'
 
@@ -21,7 +19,7 @@ function MapTile(data: Props): JSX.Element {
 
 interface Props {
     stopPlaces: StopPlaceWithDepartures[] | null
-    bikeRentalStations: BikeRentalStation[] | null
+    bikeRentalStations: Station[] | null
     scooters: Vehicle[] | null
     walkTimes: Array<{ stopId: string; walkTime: number }> | null
     latitude: number

--- a/src/dashboards/Compact/BikeTile/index.tsx
+++ b/src/dashboards/Compact/BikeTile/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import { BikeRentalStation } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 import { BicycleIcon } from '@entur/icons'
+import { Station } from '@entur/sdk/lib/mobility/types'
 
 import Tile from '../components/Tile'
 import TileRow from '../components/TileRow'
@@ -54,19 +54,19 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                             ? getWalkInfoBike(walkInfoBike || [], station.id)
                             : undefined
                     }
-                    label={station.name}
+                    label={station.system.name.translation[0].value}
                     subLabels={[
                         {
                             time:
-                                station.bikesAvailable === 1
+                                station.numBikesAvailable === 1
                                     ? '1 sykkel'
-                                    : `${station.bikesAvailable} sykler`,
+                                    : `${station.numBikesAvailable} sykler`,
                         },
                         {
                             time:
-                                station.spacesAvailable === 1
+                                station.numDocksAvailable === 1
                                     ? '1 lås'
-                                    : `${station.spacesAvailable} låser`,
+                                    : `${station.numDocksAvailable} låser`,
                         },
                     ]}
                 />
@@ -76,7 +76,7 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
 }
 
 interface Props {
-    stations: BikeRentalStation[]
+    stations: Station[]
 }
 
 export default BikeTile

--- a/src/dashboards/Compact/BikeTile/index.tsx
+++ b/src/dashboards/Compact/BikeTile/index.tsx
@@ -7,7 +7,7 @@ import Tile from '../components/Tile'
 import TileRow from '../components/TileRow'
 import { useSettingsContext } from '../../../settings'
 import { IconColorType } from '../../../types'
-import { getIconColorType } from '../../../utils'
+import { getIconColorType, getTranslation } from '../../../utils'
 import useWalkInfoBike, { WalkInfoBike } from '../../../logic/useWalkInfoBike'
 
 function getWalkInfoBike(
@@ -54,7 +54,7 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                             ? getWalkInfoBike(walkInfoBike || [], station.id)
                             : undefined
                     }
-                    label={station.system.name.translation[0].value}
+                    label={getTranslation(station.name) || ''}
                     subLabels={[
                         {
                             time:

--- a/src/dashboards/Compact/MapTile/index.tsx
+++ b/src/dashboards/Compact/MapTile/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
-import { BikeRentalStation } from '@entur/sdk'
-
-import { Vehicle } from '@entur/sdk/lib/mobility/types'
+import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import MapView from '../../../components/Map'
 
@@ -21,7 +19,7 @@ function MapTile(data: Props): JSX.Element {
 
 interface Props {
     stopPlaces: StopPlaceWithDepartures[] | null
-    bikeRentalStations: BikeRentalStation[] | null
+    bikeRentalStations: Station[] | null
     scooters: Vehicle[] | null
     walkTimes: Array<{ stopId: string; walkTime: number }> | null
     latitude: number

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -26,13 +26,24 @@ async function fetchBikeRentalStationsNearby(
     return allStations
 }
 
-export default function useBikeRentalStations(): Station[] | null {
+function includesStation(stations: Station[], station: Station) {
+    for (let index = 0; index < stations.length; index++) {
+        if (station.id === stations[index].id) return true
+    }
+    return false
+}
+
+export default function useBikeRentalStations(
+    removeHiddenStations = true,
+): Station[] | null {
     const [settings] = useSettingsContext()
     const [bikeRentalStations, setBikeRentalStations] = useState<
         Station[] | null
     >(null)
     const [nearbyStations, setNearbyStations] = useState<Station[]>([])
-    const [additionalStations, setAdditionalStations] = useState<Station[]>([])
+    const [userSelectedStations, setUserSelectedStations] = useState<Station[]>(
+        [],
+    )
 
     const {
         coordinates,
@@ -58,7 +69,7 @@ export default function useBikeRentalStations(): Station[] | null {
             return setBikeRentalStations(null)
         }
         fetchBikeRentalStationsById(newStations).then((stations) =>
-            setAdditionalStations(stations || []),
+            setUserSelectedStations(stations || []),
         )
     }, [newStations, isDisabled])
 
@@ -66,13 +77,17 @@ export default function useBikeRentalStations(): Station[] | null {
         if (isDisabled) {
             return setBikeRentalStations(null)
         }
-        const allStations = [...nearbyStations, ...additionalStations]
-        setBikeRentalStations(
-            allStations.filter(
-                (station) => !hiddenStations.includes(station.id),
-            ),
+        const uniqueUserStations = userSelectedStations.filter(
+            (station) => !includesStation(nearbyStations, station),
         )
-    }, [nearbyStations, additionalStations, hiddenStations, isDisabled])
+        setBikeRentalStations([...nearbyStations, ...uniqueUserStations])
+    }, [nearbyStations, userSelectedStations, isDisabled])
+
+    if (removeHiddenStations && bikeRentalStations) {
+        return bikeRentalStations.filter(
+            (station) => !hiddenStations.includes(station.id),
+        )
+    }
 
     return bikeRentalStations
 }

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -1,61 +1,91 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect } from 'react'
 import { isEqual } from 'lodash'
-import { BikeRentalStation } from '@entur/sdk'
+import { Coordinates } from '@entur/sdk'
+import { Station } from '@entur/sdk/lib/mobility/types'
 
-import { usePrevious, isNotNullOrUndefined } from '../utils'
+import { usePrevious } from '../utils'
 import service from '../service'
 import { useSettingsContext } from '../settings'
-import { REFRESH_INTERVAL } from '../constants'
 
-import useNearestPlaces from './useNearestPlaces'
-
-async function fetchBikeRentalStations(
+async function fetchBikeRentalStationsById(
     allStationIds: string[],
-): Promise<BikeRentalStation[] | null> {
-    const allStations = await service.getBikeRentalStations(allStationIds)
-    return allStations.filter(isNotNullOrUndefined)
+): Promise<Station[] | null> {
+    const allStations = await service.mobility.getStationsById({
+        stationIds: allStationIds,
+    })
+    return allStations
 }
 
-export default function useBikeRentalStations(): BikeRentalStation[] | null {
+async function fetchBikeRentalStationsNearby(
+    coordinates: Coordinates,
+    distance: number,
+): Promise<Station[] | null> {
+    const allStations = await service.mobility.getStations({
+        lat: coordinates.latitude,
+        lon: coordinates.longitude,
+        range: distance,
+    })
+    return allStations
+}
+
+export default function useBikeRentalStations(): Station[] | null {
     const [settings] = useSettingsContext()
     const [bikeRentalStations, setBikeRentalStations] = useState<
-        BikeRentalStation[] | null
+        Station[] | null
     >(null)
-    const nearestPlaces = useNearestPlaces(
-        settings?.coordinates,
-        settings?.distance,
-    )
+    const [nearbyStations, setStationsNearby] = useState<Station[]>([])
+    const [additionalStations, setAdditionalStations] = useState<Station[]>([])
 
-    const { newStations = [], hiddenStations, hiddenModes } = settings || {}
+    const {
+        coordinates,
+        distance,
+        newStations = [],
+        hiddenStations = [],
+        hiddenModes,
+    } = settings || {}
 
-    const nearestBikeRentalStations = useMemo(
-        () =>
-            nearestPlaces
-                .filter(({ type }) => type === 'BikeRentalStation')
-                .map(({ id }) => id),
-        [nearestPlaces],
-    )
-
-    const allStationIds = [...newStations, ...nearestBikeRentalStations]
-        .filter((id) => !hiddenStations?.includes(id))
-        .filter((id, index, ids) => ids.indexOf(id) === index)
-
-    const prevStationIds = usePrevious(allStationIds)
+    const prevNewStations = usePrevious(newStations)
+    const prevArea = usePrevious({ coordinates, distance })
 
     const isDisabled = Boolean(hiddenModes?.includes('bysykkel'))
     useEffect(() => {
-        const isStationsEqual = isEqual(allStationIds, prevStationIds)
-        if (isDisabled) {
+        if (!coordinates || !distance || isDisabled) {
             return setBikeRentalStations(null)
         }
-        if (!isStationsEqual) {
-            fetchBikeRentalStations(allStationIds).then(setBikeRentalStations)
+        const isAreaChanged = !isEqual({ coordinates, distance }, prevArea)
+        const isNewStationsAdded = !isEqual(newStations, prevNewStations)
+
+        // 1. Add nearby stations
+        // 2. Add additional stations
+        // 3. Remove hidden stations
+
+        if (isAreaChanged) {
+            fetchBikeRentalStationsNearby(coordinates, distance).then(
+                (stations) => setStationsNearby(stations || []),
+            )
         }
-        const intervalId = setInterval(() => {
-            fetchBikeRentalStations(allStationIds).then(setBikeRentalStations)
-        }, REFRESH_INTERVAL)
-        return (): void => clearInterval(intervalId)
-    }, [allStationIds, isDisabled, prevStationIds])
+        if (isNewStationsAdded) {
+            fetchBikeRentalStationsById(newStations).then((stations) =>
+                setAdditionalStations(stations || []),
+            )
+        }
+        const allStations = [...nearbyStations, ...additionalStations]
+        setBikeRentalStations(
+            allStations.filter(
+                (station) => !hiddenStations.includes(station.id),
+            ),
+        )
+    }, [
+        coordinates,
+        distance,
+        newStations,
+        hiddenStations,
+        nearbyStations,
+        additionalStations,
+        isDisabled,
+        prevArea,
+        prevNewStations,
+    ])
 
     return bikeRentalStations
 }

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -45,14 +45,16 @@ export default function useBikeRentalStations(): Station[] | null {
     } = settings || {}
 
     const prevNewStations = usePrevious(newStations)
-    const prevArea = usePrevious({ coordinates, distance })
+    const prevCoordinates = usePrevious(coordinates)
+    const prevDistance = usePrevious(distance)
 
     const isDisabled = Boolean(hiddenModes?.includes('bysykkel'))
     useEffect(() => {
         if (!coordinates || !distance || isDisabled) {
             return setBikeRentalStations(null)
         }
-        const isAreaChanged = !isEqual({ coordinates, distance }, prevArea)
+        const isAreaChanged =
+            coordinates !== prevCoordinates || distance !== prevDistance
         const isNewStationsAdded = !isEqual(newStations, prevNewStations)
 
         // 1. Add nearby stations
@@ -83,8 +85,9 @@ export default function useBikeRentalStations(): Station[] | null {
         nearbyStations,
         additionalStations,
         isDisabled,
-        prevArea,
         prevNewStations,
+        prevCoordinates,
+        prevDistance,
     ])
 
     return bikeRentalStations

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -4,6 +4,7 @@ import { Station } from '@entur/sdk/lib/mobility/types'
 
 import service from '../service'
 import { useSettingsContext } from '../settings'
+import { includesStation } from '../utils'
 
 async function fetchBikeRentalStationsById(
     allStationIds: string[],
@@ -24,13 +25,6 @@ async function fetchBikeRentalStationsNearby(
         range: distance,
     })
     return allStations
-}
-
-function includesStation(stations: Station[], station: Station) {
-    for (let index = 0; index < stations.length; index++) {
-        if (station.id === stations[index].id) return true
-    }
-    return false
 }
 
 export default function useBikeRentalStations(

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -4,7 +4,6 @@ import { Station } from '@entur/sdk/lib/mobility/types'
 
 import service from '../service'
 import { useSettingsContext } from '../settings'
-import { includesStation } from '../utils'
 
 async function fetchBikeRentalStationsById(
     allStationIds: string[],
@@ -72,7 +71,10 @@ export default function useBikeRentalStations(
             return setBikeRentalStations(null)
         }
         const uniqueUserStations = userSelectedStations.filter(
-            (station) => !includesStation(nearbyStations, station),
+            (userStation) =>
+                !nearbyStations.some(
+                    (nearbyStation) => nearbyStation.id === userStation.id,
+                ),
         )
         setBikeRentalStations([...nearbyStations, ...uniqueUserStations])
     }, [nearbyStations, userSelectedStations, isDisabled])

--- a/src/logic/useWalkInfoBike.ts
+++ b/src/logic/useWalkInfoBike.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
 import { isEqual } from 'lodash'
 
-import { BikeRentalStation, Coordinates, QueryMode } from '@entur/sdk'
+import { Coordinates, QueryMode } from '@entur/sdk'
+import { Station } from '@entur/sdk/lib/mobility/types'
 
 import service from '../service'
 import { useSettingsContext } from '../settings'
@@ -14,7 +15,7 @@ export type WalkInfoBike = {
 }
 
 async function getWalkInfoBike(
-    rentalStations: BikeRentalStation[],
+    rentalStations: Station[],
     from: Coordinates,
     signal: AbortSignal,
 ): Promise<WalkInfoBike[]> {
@@ -29,8 +30,8 @@ async function getWalkInfoBike(
                         },
                         to: {
                             coordinates: {
-                                longitude: stopPlace.longitude,
-                                latitude: stopPlace.latitude,
+                                longitude: stopPlace.lon,
+                                latitude: stopPlace.lat,
                             },
                         },
                         modes: [QueryMode.FOOT],
@@ -59,7 +60,7 @@ async function getWalkInfoBike(
 }
 
 export default function useTravelTime(
-    rentalStations: BikeRentalStation[] | null,
+    rentalStations: Station[] | null,
 ): WalkInfoBike[] | null {
     const [settings] = useSettingsContext()
     const [travelTime, setTravelTime] = useState<WalkInfoBike[] | null>(null)

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -19,7 +19,11 @@ import {
 import { colors } from '@entur/tokens'
 
 import { Departure, LegMode, TransportMode, TransportSubmode } from '@entur/sdk'
-import { TranslatedString, Translation } from '@entur/sdk/lib/mobility/types'
+import {
+    Station,
+    TranslatedString,
+    Translation,
+} from '@entur/sdk/lib/mobility/types'
 
 import { LineData, TileSubLabel, Theme, IconColorType } from './types'
 import { useSettingsContext } from './settings'
@@ -381,4 +385,14 @@ export function getTranslation(
     )
     if (!match) return null
     return match.value
+}
+
+export function includesStation(
+    stations: Station[],
+    searchElement: Station,
+): boolean {
+    for (let index = 0; index < stations.length; index++) {
+        if (searchElement.id === stations[index].id) return true
+    }
+    return false
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -410,13 +410,3 @@ export function getTranslation(
     if (!match) return null
     return match.value
 }
-
-export function includesStation(
-    stations: Station[],
-    searchElement: Station,
-): boolean {
-    for (let index = 0; index < stations.length; index++) {
-        if (searchElement.id === stations[index].id) return true
-    }
-    return false
-}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -19,11 +19,7 @@ import {
 import { colors } from '@entur/tokens'
 
 import { Departure, LegMode, TransportMode, TransportSubmode } from '@entur/sdk'
-import {
-    Station,
-    TranslatedString,
-    Translation,
-} from '@entur/sdk/lib/mobility/types'
+import { TranslatedString, Translation } from '@entur/sdk/lib/mobility/types'
 
 import { LineData, TileSubLabel, Theme, IconColorType } from './types'
 import { useSettingsContext } from './settings'

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -19,6 +19,7 @@ import {
 import { colors } from '@entur/tokens'
 
 import { Departure, LegMode, TransportMode, TransportSubmode } from '@entur/sdk'
+import { TranslatedString, Translation } from '@entur/sdk/lib/mobility/types'
 
 import { LineData, TileSubLabel, Theme, IconColorType } from './types'
 import { useSettingsContext } from './settings'
@@ -368,4 +369,16 @@ export function isDarkOrDefaultTheme(theme?: Theme): boolean {
 export function isEqualUnsorted<T>(array: T[], includes: T[]): boolean {
     if (array.length !== includes.length) return false
     return includes.every((i) => array.includes(i))
+}
+
+export function getTranslation(
+    translationObject: TranslatedString,
+    languageId = 'nb',
+): string | null {
+    const translations: Translation[] = translationObject.translation
+    const match = translations.find(
+        (currentTranslation) => currentTranslation.language === languageId,
+    )
+    if (!match) return null
+    return match.value
 }


### PR DESCRIPTION
🚲 
This PR migrates the part of the app considering bike stations to utilize the mobility v2 API using the entur SDK.
The reason why many files are changed is primarily due to the different format of the returned data using the type `Station`. The primary changes are in the custom hook `useBikeRentalStations()`, the majority of other file changes are adaptations to the new data format. 

The commit-log includes multiple Work-In-Progress commits (due to unknown migration scope) which may be squashed for prettier history. The drawback being a big bulk of changes with less traceability.

Changes:
* Rewrite useBikeRentalStation() to use mobility v2
    * Using SDK-function getStations() to get nearby stations (within user selected radius)
    * ❗Updated entur/sdk package: Using New SDK-function getStationsById() to get user selected stations (from bike station searchfield)
   
* As an effect we move from using BikeRentalStation type to Station type (return type of relevant mobility v2 functions)
* Rewrite EditTab to use mobility v2 where needed
* Different naming system (`getTranslation()` utility function added)
    * Adapting to: `station.name` → `station.name.translation[0].value`
    * created util function getTranslation() which which defaults to returning Norwegian translation with `'nb'` language ID (norsk bokmål)

Other: 
* General refactoring (irrelevant to bike stations): Matched filename with exported component in `StopPlaceSearch`
* Known issues: React warning inherent to `Dropdown` component
* ~~Discovered "bug" (fix incoming): User selected stations (`newStations` in settings) stores duplicates if same stations is searched and selected more than once.~~ Fixed in additional commit