### PR TITLE
Revert "Fikse feilmelding om src URL in Manifest invalid "

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "description": "Lag din egen sanntidstavle.",
     "orientation": "portrait",
     "lang": "no",
-    "icons": [
+    "images": [
         {
             "src": "images/logo/logo-72x72.png",
             "sizes": "72x72",
@@ -57,13 +57,6 @@
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "any maskable"
-        }
-    ],
-    "splash_screen": [
-        {
-            "src": "images/splash/startup-image-1284x2778.png",
-            "sizes": "1284x2778",
-            "type": "image/png"
         }
     ]
 }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -75,49 +75,13 @@ function updateManifest(pathName: string): void {
             lang: 'no',
             icons: [
                 {
-                    src: `${pathName}/images/logo/logo-72x72.png`,
-                    sizes: '72x72',
-                    type: 'image/png',
-                    purpose: 'any maskable',
-                },
-                {
-                    src: `${pathName}images/logo/logo-96x96.png`,
-                    sizes: '96x96',
-                    type: 'image/png',
-                    purpose: 'any maskable',
-                },
-                {
-                    src: `${pathName}images/logo/logo-128x128.png`,
-                    sizes: '128x128',
-                    type: 'image/png',
-                    purpose: 'any maskable',
-                },
-                {
-                    src: `${pathName}images/logo/logo-144x144.png`,
-                    sizes: '144x144',
-                    type: 'image/png',
-                    purpose: 'any maskable',
-                },
-                {
-                    src: `${pathName}images/logo/logo-152x152.png`,
-                    sizes: '152x152',
-                    type: 'image/png',
-                    purpose: 'any maskable',
-                },
-                {
-                    src: `${pathName}images/logo/logo-192x192.png`,
+                    src: '/images/logo/logo-192x192.png',
                     sizes: '192x192',
                     type: 'image/png',
                     purpose: 'any maskable',
                 },
                 {
-                    src: `${pathName}images/logo/logo-384x384.png`,
-                    sizes: '384x384',
-                    type: 'image/png',
-                    purpose: 'any maskable',
-                },
-                {
-                    src: `${pathName}images/logo/logo-512x512.png`,
+                    src: '/images/logo/logo-512x512.png',
                     sizes: '512x512',
                     type: 'image/png',
                     purpose: 'any maskable',
@@ -125,7 +89,7 @@ function updateManifest(pathName: string): void {
             ],
             splash_screen: [
                 {
-                    src: `${pathName}/images/splash/startup-image-1284x2778.png`,
+                    src: '/images/splash/startup-image-1284x2778.png',
                     sizes: '1284x2778',
                     type: 'image/png',
                 },


### PR DESCRIPTION
Denne tilbakerullingen gjøres da den originale PRen fikset en warning, men innførte en error. Denne feilen viste seg ikke før etter litt tid og var derfor ikke oppdaget da PRen ble laget. Ved å rulle tilbake blir det «mindre feil» og lettere å ta for seg dette problemet på nytt for hvem som helst ved en senere anledning. 

Reverts entur/tavla#468