### PR TITLE
Fix app not redirecting to root on page that doesnt exist

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -95,7 +95,7 @@ export function useSettings(): [Settings | null, Setter] {
 
         if (id) {
             return onSnapshot(getSettings(id), (document: any) => {
-                if (!document.exists) {
+                if (!document.exists()) {
                     window.location.pathname = '/'
                     return
                 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -94,13 +94,13 @@ export function useSettings(): [Settings | null, Setter] {
         }
 
         if (id) {
-            return onSnapshot(getSettings(id), (document: any) => {
-                if (!document.exists()) {
+            return onSnapshot(getSettings(id), (documentSnapshot: any) => {
+                if (!documentSnapshot.exists()) {
                     window.location.pathname = '/'
                     return
                 }
 
-                const data = document.data() as Settings
+                const data = documentSnapshot.data() as Settings
 
                 const settingsWithDefaults: Settings = {
                     ...DEFAULT_SETTINGS,


### PR DESCRIPTION
På grunn av oppgradering til firebase web version 9 har syntaks endret seg. Det å oppdatere `document.exists` til `.exists()` ble glemt og denne PRen legger det til. Fiksen gjør at man igjen bli auto-redirectet til startsiden hvis man skriver inn en utilgjengelig tavle-id i URL-feltet.

https://firebase.google.com/docs/firestore/query-data/get-data#web-version-9_1