### PR TITLE
Make functionality for hiding menu on scroll work as intended

### DIFF
--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -22,12 +22,9 @@ import { useFirebaseAuthentication, auth } from '../../../auth'
 import LockModal from '../../LockModal'
 import LoginModal from '../../../components/LoginModal'
 import MineTavlerModal from '../../MineTavlerModal'
-import { isMobileWeb } from '../../../utils'
 
 import MenuButton from './MenuButton'
 import './styles.scss'
-
-const isMobile = isMobileWeb()
 
 function BottomMenu({ className, history }: Props): JSX.Element {
     const URL = document.location.href
@@ -126,47 +123,45 @@ function BottomMenu({ className, history }: Props): JSX.Element {
 
     const menuRef = useRef<HTMLDivElement>(null)
 
-    const [mobileWidth, setMobileWidth] = useState<boolean>(
+    const [isMobileWidth, setIsMobileWidth] = useState<boolean>(
         document.body.clientWidth <= 900,
     )
     const width = useWindowWidth()
     useEffect(() => {
-        if (width > 900 && mobileWidth) {
-            setMobileWidth(false)
+        if (width > 900 && isMobileWidth) {
+            setIsMobileWidth(false)
             if (menuRef.current) {
                 menuRef.current.classList.remove('hidden-menu')
             }
-        } else if (width <= 900 && !mobileWidth) {
-            setMobileWidth(true)
+        } else if (width <= 900 && !isMobileWidth) {
+            setIsMobileWidth(true)
             if (menuRef.current) {
                 menuRef.current.classList.add('hidden-menu')
             }
         }
-    }, [width, mobileWidth, setMobileWidth])
+    }, [width, isMobileWidth, setIsMobileWidth])
 
-    const isWeb = !isMobile
-    const [hideOnScroll, setHideOnScroll] = useState(true)
+    const [menuHiddenByScroll, setMenuHiddenByScroll] = useState(true)
     useScrollPosition(
         ({ prevPos, currPos }) => {
-            if (!mobileWidth) return
-            const isShow = currPos.y < prevPos.y
-            const menu = menuRef.current
-            if (isShow !== hideOnScroll && isWeb) {
-                setHideOnScroll(isShow)
-                if (!menu) return
-                if (isShow) {
-                    menu.classList.add('hidden-menu')
-                } else {
-                    menu.classList.remove('hidden-menu')
-                }
+            if (!isMobileWidth) return
+            if (!menuRef.current) return
+
+            const hasScrolledDown = currPos.y < prevPos.y
+            if (!menuHiddenByScroll && hasScrolledDown) {
+                menuRef.current.classList.add('hidden-menu')
+                setMenuHiddenByScroll(true)
+            } else if (menuHiddenByScroll && !hasScrolledDown) {
+                menuRef.current.classList.remove('hidden-menu')
+                setMenuHiddenByScroll(false)
             }
         },
-        [hideOnScroll, mobileWidth, setHideOnScroll],
+        [menuHiddenByScroll, isMobileWidth, setMenuHiddenByScroll],
     )
 
     const [idle, setIdle] = useState<boolean>(false)
     useEffect(() => {
-        if (mobileWidth) return
+        if (isMobileWidth) return
         const createTimeout = (): number =>
             window.setTimeout(() => {
                 if (
@@ -216,7 +211,7 @@ function BottomMenu({ className, history }: Props): JSX.Element {
             }
             clearTimeout(timeout)
         }
-    }, [idle, mobileWidth, setIdle])
+    }, [idle, isMobileWidth, setIdle])
 
     return (
         <div

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -30,8 +30,12 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     const URL = document.location.href
 
     const user = useFirebaseAuthentication()
-
+    const width = useWindowWidth()
     const [settings] = useSettingsContext()
+    const [menuHiddenByScroll, setMenuHiddenByScroll] = useState(true)
+    const [isMobileWidth, setIsMobileWidth] = useState<boolean>(
+        document.body.clientWidth <= 900,
+    )
 
     const [lockModalOpen, setLockModalOpen] = useState<boolean>(false)
     const [loginModalOpen, setLoginModalOpen] = useState<boolean>(false)
@@ -41,6 +45,8 @@ function BottomMenu({ className, history }: Props): JSX.Element {
     const { addToast } = useToast()
 
     const { documentId } = useParams<{ documentId: string }>()
+
+    const menuRef = useRef<HTMLDivElement>(null)
 
     const onSettingsButtonClick = useCallback(
         (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -121,27 +127,18 @@ function BottomMenu({ className, history }: Props): JSX.Element {
         />
     )
 
-    const menuRef = useRef<HTMLDivElement>(null)
-
-    const [isMobileWidth, setIsMobileWidth] = useState<boolean>(
-        document.body.clientWidth <= 900,
-    )
-    const width = useWindowWidth()
     useEffect(() => {
-        if (width > 900 && isMobileWidth) {
-            setIsMobileWidth(false)
-            if (menuRef.current) {
-                menuRef.current.classList.remove('hidden-menu')
-            }
-        } else if (width <= 900 && !isMobileWidth) {
-            setIsMobileWidth(true)
-            if (menuRef.current) {
-                menuRef.current.classList.add('hidden-menu')
-            }
-        }
-    }, [width, isMobileWidth, setIsMobileWidth])
+        setIsMobileWidth(width < 900)
+    }, [width])
 
-    const [menuHiddenByScroll, setMenuHiddenByScroll] = useState(true)
+    useEffect(() => {
+        if (menuRef.current) {
+            isMobileWidth
+                ? menuRef.current.classList.add('hidden-menu')
+                : menuRef.current.classList.remove('hidden-menu')
+        }
+    }, [isMobileWidth])
+
     useScrollPosition(
         ({ prevPos, currPos }) => {
             if (!isMobileWidth) return


### PR DESCRIPTION
Denne PRen ser ut til å fikse at menyen ikke ble borte på scroll. Fiksen var i bunn og grunn å fjerne et krav om at `isWeb` måtte være sant, noe det ikke er på mobil. Jeg stusser litt over hvordan dette har fungert i det hele tatt noen ganger hvis dette faktisk er fiksen, så si gjerne fra hvis du ser noen potensielle bi-effekter av dette. 

Koden har også blitt litt refakturert for lesbarhet.

Tesstet på PC og mobil