### PR TITLE
Enforce import grouping, react first, siblings last

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,7 +56,21 @@
                     "sibling",
                     "index"
                 ],
-                "newlines-between": "always-and-inside-groups"
+                "newlines-between": "always-and-inside-groups",
+                "pathGroups": [
+                    {
+                        "pattern": "react+(|-**)",
+                        "group": "external",
+                        "position": "before"
+                    },
+                    {
+                        "pattern": "@entur/**",
+                        "group": "external",
+                        "position": "after"
+                    }
+                ],
+                "warnOnUnassignedImports": true,
+                "pathGroupsExcludedImportTypes": []
             }
         ],
         "no-console": "error",

--- a/src/assets/icons/ResizeHandle.tsx
+++ b/src/assets/icons/ResizeHandle.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import '../../variables.scss'
+
 import { colors } from '@entur/tokens'
+
+import '../../variables.scss'
 
 function ResizeHandle({ className, size, variant }: Props): JSX.Element | null {
     const color =

--- a/src/components/Clock/index.tsx
+++ b/src/components/Clock/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { Heading2 } from '@entur/typography'
 
 import { useCounter } from '../../utils'

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+
 import type { User } from 'firebase/auth'
 
 import { useToast } from '@entur/alert'

--- a/src/components/Map/BikeRentalStationTag/index.tsx
+++ b/src/components/Map/BikeRentalStationTag/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { colors } from '@entur/tokens'
 import { BicycleIcon, ParkIcon } from '@entur/icons'
 

--- a/src/components/Map/RealtimeVehicleTag/TooltipContent/index.tsx
+++ b/src/components/Map/RealtimeVehicleTag/TooltipContent/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import './styles.scss'
 
 import { colors } from '@entur/tokens'
 import { TransportMode } from '@entur/sdk'
@@ -15,6 +14,8 @@ import {
 
 import { IconColorType } from '../../../../types'
 import { RealtimeVehicle } from '../../../../services/realtimeVehicles/types/realtimeVehicle'
+
+import './styles.scss'
 
 interface Props {
     realtimeVehicle: RealtimeVehicle

--- a/src/components/Map/RealtimeVehicleTag/index.tsx
+++ b/src/components/Map/RealtimeVehicleTag/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import './styles.scss'
 
 import { Tooltip } from '@entur/tooltip'
 import { colors } from '@entur/tokens'
@@ -11,6 +10,7 @@ import { IconColorType } from '../../../types'
 import { RealtimeVehicle } from '../../../services/realtimeVehicles/types/realtimeVehicle'
 
 import TooltipContent from './TooltipContent'
+import './styles.scss'
 
 interface Props {
     realtimeVehicle: RealtimeVehicle

--- a/src/components/Map/ScooterMarkerTag/index.tsx
+++ b/src/components/Map/ScooterMarkerTag/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { ScooterIcon } from '@entur/icons'
 
 import { Operator } from '@entur/sdk/lib/mobility/types'

--- a/src/components/Map/StopPlaceTag/index.tsx
+++ b/src/components/Map/StopPlaceTag/index.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { colors } from '@entur/tokens'
 
 import { getIcon, getIconColor } from '../../../utils'
+import { IconColorType, StopPlaceWithDepartures } from '../../../types'
 
 import './styles.scss'
-import { IconColorType, StopPlaceWithDepartures } from '../../../types'
 
 const StopPlaceTag = ({ stopPlace, walkTime }: Props): JSX.Element => {
     const uniqueTypes = [

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, memo, useRef, useEffect, useMemo } from 'react'
 
 import { InteractiveMap, Marker } from 'react-map-gl'
 import type { MapRef } from 'react-map-gl'
+
 import useSupercluster from 'use-supercluster'
 
 import type { ClusterProperties } from 'supercluster'

--- a/src/components/SituationModal/index.tsx
+++ b/src/components/SituationModal/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
+
 import { Modal } from '@entur/modal'
 import { PrimaryButton } from '@entur/button'
 
 import { Paragraph } from '@entur/typography'
 
-import './styles.scss'
 import ValidationExclamation from '../../assets/icons/ValidationExclamation'
+
+import './styles.scss'
 
 interface Props {
     situationMessage: string

--- a/src/components/WeatherTile/index.tsx
+++ b/src/components/WeatherTile/index.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react'
-import './styles.scss'
 
 import { CloudRainIcon, UmbrellaIcon, WindIcon } from '@entur/icons'
 
 import { useWeather } from '../../logic'
 import { getWeatherDescriptionFromApi, getWeatherIconEntur } from '../../utils'
 import { useSettingsContext } from '../../settings'
+
+import './styles.scss'
 
 interface Props {
     className?: string

--- a/src/components/backButton/BackButton.tsx
+++ b/src/components/backButton/BackButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { BackArrowIcon } from '@entur/icons'
 
 import './styles.scss'

--- a/src/containers/Admin/DashboardPickerTab/index.tsx
+++ b/src/containers/Admin/DashboardPickerTab/index.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useCallback } from 'react'
-import { Heading2 } from '@entur/typography'
 
-import './styles.scss'
+import { Heading2 } from '@entur/typography'
 
 import RadioCard from '../../../components/RadioCard'
 
 import { useSettingsContext } from '../../../settings'
 import { ThemeDashboardPreview } from '../../../assets/icons/ThemeDashboardPreview'
+
+import './styles.scss'
 
 const DashboardPickerTab = (): JSX.Element => {
     const [settings, setSettings] = useSettingsContext()

--- a/src/containers/Admin/EditTab/BikeSearch/index.tsx
+++ b/src/containers/Admin/EditTab/BikeSearch/index.tsx
@@ -6,8 +6,9 @@ import { Station } from '@entur/sdk/lib/mobility/types'
 
 import service from '../../../../service'
 
-import './styles.scss'
 import { getTranslation } from '../../../../utils'
+
+import './styles.scss'
 
 const MAX_SEARCH_RANGE = 100_000
 

--- a/src/containers/Admin/EditTab/RealtimeDataPanel/index.tsx
+++ b/src/containers/Admin/EditTab/RealtimeDataPanel/index.tsx
@@ -1,8 +1,9 @@
+import React from 'react'
+
 import { FilterChip } from '@entur/chip'
 import { Fieldset } from '@entur/form'
 import { Loader } from '@entur/loader'
 import { Paragraph } from '@entur/typography'
-import React from 'react'
 
 import { Line } from '../../../../types'
 import { getIcon } from '../../../../utils'

--- a/src/containers/Admin/EditTab/ScooterPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ScooterPanel/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react'
+
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
 import { Label } from '@entur/typography'

--- a/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlaceSearch/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { Coordinates, Feature } from '@entur/sdk'
 
 import { Dropdown } from '@entur/dropdown'

--- a/src/containers/Admin/EditTab/ToggleDetailsPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ToggleDetailsPanel/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
 import { Label } from '@entur/typography'
-import './styles.scss'
 
 import { useSettingsContext } from '../../../../settings'
+
+import './styles.scss'
 
 function ToggleDetailsPanel(): JSX.Element {
     const [settings, setSettings] = useSettingsContext()

--- a/src/containers/Admin/EditTab/WeatherPanel/index.tsx
+++ b/src/containers/Admin/EditTab/WeatherPanel/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react'
+
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
 import { Label } from '@entur/typography'

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -5,11 +5,13 @@ import React, {
     useCallback,
     SyntheticEvent,
 } from 'react'
+
+import { WidthProvider, Responsive } from 'react-grid-layout'
+
 import { Heading2, Heading3, Heading4, SubParagraph } from '@entur/typography'
 import { Switch, TextField } from '@entur/form'
 import { Tooltip } from '@entur/tooltip'
 import { ValidationInfoIcon } from '@entur/icons'
-import { WidthProvider, Responsive } from 'react-grid-layout'
 
 import { FormFactor, Station } from '@entur/sdk/lib/mobility/types'
 

--- a/src/containers/Admin/LogoTab/LogoUpload/index.tsx
+++ b/src/containers/Admin/LogoTab/LogoUpload/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
 
-import { FileUpload } from '@entur/fileupload'
 import type { FileRejection } from 'react-dropzone'
+
+import { FileUpload } from '@entur/fileupload'
 import { Label, Link } from '@entur/typography'
 import { DeleteIcon } from '@entur/icons'
 import { Loader } from '@entur/loader'

--- a/src/containers/Admin/ThemeTab/index.tsx
+++ b/src/containers/Admin/ThemeTab/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+
 import { Heading2, Paragraph } from '@entur/typography'
 
 import { useSettingsContext } from '../../../settings'
@@ -9,8 +10,9 @@ import Dark from '../../../assets/previews/Dark-theme.svg'
 import Light from '../../../assets/previews/Light-theme.svg'
 import Entur from '../../../assets/previews/Entur-theme.svg'
 
-import './styles.scss'
 import { getDocumentId } from '../../../utils'
+
+import './styles.scss'
 
 const ThemeTab = (): JSX.Element => {
     const [radioValue, setRadioValue] = useState<Theme | null>(null)

--- a/src/containers/Admin/index.tsx
+++ b/src/containers/Admin/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
+
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@entur/tab'
 import { ClosedLockIcon } from '@entur/icons'
 
-import './styles.scss'
 import { useFirebaseAuthentication } from '../../auth'
 
 import { useSettingsContext } from '../../settings'
@@ -17,6 +17,7 @@ import ThemeTab from './ThemeTab'
 import VisningTab from './DashboardPickerTab'
 import NameTab from './NameTab'
 import FloatingButtons from './FloatingButtons'
+import './styles.scss'
 
 const AdminPage = (): JSX.Element => {
     const user = useFirebaseAuthentication()

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect } from 'react'
 import { Route, Switch, Router, useLocation } from 'react-router-dom'
+
+import PWAPrompt from 'react-ios-pwa-prompt'
+
 import analytics from 'universal-ga'
 
-import { ToastProvider } from '@entur/alert'
-import PWAPrompt from 'react-ios-pwa-prompt'
 import { ApolloProvider } from '@apollo/client'
+
+import { ToastProvider } from '@entur/alert'
 
 import { SettingsContext, useSettings } from '../settings'
 import { useFirebaseAuthentication, UserProvider } from '../auth'

--- a/src/containers/DashboardWrapper/BottomMenu/MenuButton/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/MenuButton/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
-import './styles.scss'
-
 import { Tooltip } from '@entur/tooltip'
+
+import './styles.scss'
 
 function MenuButton({ title, icon, callback, tooltip }: Props): JSX.Element {
     const button = (

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
 
+import { useParams } from 'react-router-dom'
+
 import { signOut } from 'firebase/auth'
 
-import { useParams } from 'react-router-dom'
 import copy from 'copy-to-clipboard'
 import { useScrollPosition } from '@n8tb1t/use-scroll-position'
 import { useWindowWidth } from '@react-hook/window-size'

--- a/src/containers/DashboardWrapper/UpgradeTavlaBanner/index.tsx
+++ b/src/containers/DashboardWrapper/UpgradeTavlaBanner/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+
 import { NewIcon } from '@entur/icons'
 
 import { getDocumentId } from '../../../utils'

--- a/src/containers/DashboardWrapper/index.tsx
+++ b/src/containers/DashboardWrapper/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { Loader } from '@entur/loader'
 
 import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'

--- a/src/containers/LandingPage/SearchPanel/index.tsx
+++ b/src/containers/LandingPage/SearchPanel/index.tsx
@@ -1,10 +1,12 @@
 import React, { memo, useState, useEffect } from 'react'
+
 import { Button } from '@entur/button'
 import { Coordinates, Feature, convertFeatureToLocation } from '@entur/sdk'
 import { Dropdown } from '@entur/dropdown'
 
 import service from '../../../service'
 import { useLocationPermission } from '../../../hooks'
+
 import './styles.scss'
 
 const YOUR_POSITION = 'Posisjonen din'

--- a/src/containers/LandingPage/TypographyCarousel/index.tsx
+++ b/src/containers/LandingPage/TypographyCarousel/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+
 import cx from 'classnames'
 
 import './styles.scss'

--- a/src/containers/MyBoards/BoardCard/OverflowMenu/index.tsx
+++ b/src/containers/MyBoards/BoardCard/OverflowMenu/index.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
+import copy from 'copy-to-clipboard'
+
 import {
     ConfigurationIcon,
     ShareIcon,
@@ -9,12 +11,10 @@ import {
 import { OverflowMenu, OverflowMenuItem, OverflowMenuLink } from '@entur/menu'
 import { useToast } from '@entur/alert'
 
-import copy from 'copy-to-clipboard'
+import '../styles.scss'
 
 import RemoveLockModal from './Modals/RemoveLockModal'
 import DeleteTavleModal from './Modals/DeleteTavleModal'
-
-import '../styles.scss'
 
 function BoardOverflowMenu({ id, uid, history }: Props): JSX.Element {
     const [removeLockModalOpen, setRemoveLockModalOpen] =

--- a/src/containers/Privacy/index.tsx
+++ b/src/containers/Privacy/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import {
     Heading1,
     Heading2,
@@ -7,8 +8,9 @@ import {
     Link,
 } from '@entur/typography'
 
-import './styles.scss'
 import { Contrast } from '@entur/layout'
+
+import './styles.scss'
 
 const Privacy = (): JSX.Element => (
     <article className="privacy">

--- a/src/dashboards/BusStop/DepartureTile/index.tsx
+++ b/src/dashboards/BusStop/DepartureTile/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+
 import { Table, TableRow, TableHead, HeaderCell } from '@entur/table'
 
 import {
@@ -14,11 +15,12 @@ import {
     IconColorType,
 } from '../../../types'
 
-import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { WalkInfo } from '../../../logic/useWalkInfo'
 import Tile from '../components/Tile'
 import TileRows from '../components/TileRows'
+
+import './styles.scss'
 
 function getTransportHeaderIcons(
     departures: LineData[],

--- a/src/dashboards/BusStop/MapTile/index.tsx
+++ b/src/dashboards/BusStop/MapTile/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
+
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import MapView from '../../../components/Map'
 
-import './styles.scss'
-
 import { StopPlaceWithDepartures } from '../../../types'
 import { isMobileWeb } from '../../../utils'
+
+import './styles.scss'
 
 function MapTile(data: Props): JSX.Element {
     return (

--- a/src/dashboards/BusStop/components/SubLabelIcon/index.tsx
+++ b/src/dashboards/BusStop/components/SubLabelIcon/index.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import ValidationExclamation from '../../../../assets/icons/ValidationExclamation'
 import ValidationError from '../../../../assets/icons/ValidationError'
 import { TileSubLabel } from '../../../../types'
+
 import './styles.scss'
 
 function SubLabelIcon({

--- a/src/dashboards/BusStop/components/Tile/index.tsx
+++ b/src/dashboards/BusStop/components/Tile/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+
 import { Heading2 } from '@entur/typography'
 
-import './styles.scss'
 import { WalkInfo } from '../../../../logic/useWalkInfo'
 import { useIsLongPressed } from '../../../../logic/longPressContext'
+
+import './styles.scss'
 
 function formatWalkInfo(walkInfo: WalkInfo) {
     if (walkInfo.walkTime / 60 < 1) {

--- a/src/dashboards/BusStop/components/TileRows/index.tsx
+++ b/src/dashboards/BusStop/components/TileRows/index.tsx
@@ -6,11 +6,11 @@ import { DataCell, TableBody, TableRow } from '@entur/table'
 
 import { IconColorType, LineData } from '../../../../types'
 
-import './styles.scss'
-
 import SituationModal from '../../../../components/SituationModal'
 import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
 import SubLabelIcon from '../SubLabelIcon'
+
+import './styles.scss'
 
 const isMobile = isMobileWeb()
 

--- a/src/dashboards/BusStop/index.tsx
+++ b/src/dashboards/BusStop/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { Layouts, Layout, WidthProvider, Responsive } from 'react-grid-layout'
 import { useRouteMatch } from 'react-router'
+
 import { useLongPress } from 'use-long-press'
+
 import { Loader } from '@entur/loader'
 
 import { FormFactor } from '@entur/sdk/lib/mobility/types'

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -1,16 +1,18 @@
 import React, { useState, useEffect } from 'react'
+
 import { colors } from '@entur/tokens'
 import { BicycleIcon } from '@entur/icons'
 import { Station } from '@entur/sdk/lib/mobility/types'
 
 import Tile from '../components/Tile'
 
-import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { IconColorType } from '../../../types'
 import { getIconColorType, getTranslation } from '../../../utils'
 import useWalkInfoBike, { WalkInfoBike } from '../../../logic/useWalkInfoBike'
 import TileRow from '../components/TileRow'
+
+import './styles.scss'
 
 function getWalkInfoBike(
     walkInfos: WalkInfoBike[],

--- a/src/dashboards/Chrono/DepartureTile/index.tsx
+++ b/src/dashboards/Chrono/DepartureTile/index.tsx
@@ -18,9 +18,10 @@ import {
 import Tile from '../components/Tile'
 import TileRows from '../components/TileRows'
 
-import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { WalkInfo } from '../../../logic/useWalkInfo'
+
+import './styles.scss'
 
 function getTransportHeaderIcons(
     departures: LineData[],

--- a/src/dashboards/Chrono/MapTile/index.tsx
+++ b/src/dashboards/Chrono/MapTile/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
+
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import MapView from '../../../components/Map'
 
-import './styles.scss'
-
 import { StopPlaceWithDepartures } from '../../../types'
+
+import './styles.scss'
 
 function MapTile(data: Props): JSX.Element {
     return (

--- a/src/dashboards/Chrono/components/Tile/index.tsx
+++ b/src/dashboards/Chrono/components/Tile/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+
 import { Heading2 } from '@entur/typography'
 
-import './styles.scss'
 import { WalkInfo } from '../../../../logic/useWalkInfo'
 import { useIsLongPressed } from '../../../../logic/longPressContext'
+
+import './styles.scss'
 
 function formatWalkInfo(walkInfo: WalkInfo) {
     if (walkInfo.walkTime / 60 < 1) {

--- a/src/dashboards/Chrono/components/TileRow/index.tsx
+++ b/src/dashboards/Chrono/components/TileRow/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
+
 import { Heading3 } from '@entur/typography'
 
 import { TileSubLabel } from '../../../../types'
-import './styles.scss'
-
 import { WalkInfoBike } from '../../../../logic/useWalkInfoBike'
+
+import './styles.scss'
 
 function formatWalkInfo(walkInfoBike: WalkInfoBike) {
     if (walkInfoBike.walkTime / 60 < 1) {

--- a/src/dashboards/Chrono/components/TileRows/index.tsx
+++ b/src/dashboards/Chrono/components/TileRows/index.tsx
@@ -8,10 +8,10 @@ import ValidationExclamation from '../../../../assets/icons/ValidationExclamatio
 import ValidationError from '../../../../assets/icons/ValidationError'
 import { IconColorType, LineData, TileSubLabel } from '../../../../types'
 
-import './styles.scss'
-
 import SituationModal from '../../../../components/SituationModal'
 import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
+
+import './styles.scss'
 
 const isMobile = isMobileWeb()
 

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { WidthProvider, Responsive, Layouts, Layout } from 'react-grid-layout'
 
-import { useLongPress } from 'use-long-press'
 import { useRouteMatch } from 'react-router'
+
+import { useLongPress } from 'use-long-press'
 
 import { FormFactor } from '@entur/sdk/lib/mobility/types'
 
@@ -22,7 +23,7 @@ import {
     getFromLocalStorage,
     saveToLocalStorage,
 } from '../../settings/LocalStorage'
-import './styles.scss'
+
 import { useSettingsContext } from '../../settings'
 
 import { isEqualUnsorted, usePrevious, isMobileWeb } from '../../utils'
@@ -35,6 +36,8 @@ import WeatherTile from '../../components/WeatherTile'
 import DepartureTile from './DepartureTile'
 import MapTile from './MapTile'
 import BikeTile from './BikeTile'
+
+import './styles.scss'
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive)
 

--- a/src/dashboards/Compact/BikeTile/index.tsx
+++ b/src/dashboards/Compact/BikeTile/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+
 import { colors } from '@entur/tokens'
 import { BicycleIcon } from '@entur/icons'
 import { Station } from '@entur/sdk/lib/mobility/types'

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -18,9 +18,10 @@ import {
 import Tile from '../components/Tile'
 import TileRow from '../components/TileRow'
 
-import './styles.scss'
 import { useSettingsContext } from '../../../settings'
 import { WalkInfo } from '../../../logic/useWalkInfo'
+
+import './styles.scss'
 
 function getTransportHeaderIcons(
     departures: LineData[],

--- a/src/dashboards/Compact/MapTile/index.tsx
+++ b/src/dashboards/Compact/MapTile/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
+
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import { Station, Vehicle } from '@entur/sdk/lib/mobility/types'
 
 import MapView from '../../../components/Map'
+import { StopPlaceWithDepartures } from '../../../types'
 
 import './styles.scss'
-
-import { StopPlaceWithDepartures } from '../../../types'
 
 function MapTile(data: Props): JSX.Element {
     return (

--- a/src/dashboards/Compact/components/Tile/index.tsx
+++ b/src/dashboards/Compact/components/Tile/index.tsx
@@ -1,11 +1,11 @@
-import { Heading2 } from '@entur/typography'
-
-import './styles.scss'
 import React from 'react'
 
-import { WalkInfo } from '../../../../logic/useWalkInfo'
+import { Heading2 } from '@entur/typography'
 
+import { WalkInfo } from '../../../../logic/useWalkInfo'
 import { useIsLongPressed } from '../../../../logic/longPressContext'
+
+import './styles.scss'
 
 function formatWalkInfo(walkInfo: WalkInfo) {
     if (walkInfo.walkTime / 60 < 1) {

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
+
 import { Heading3 } from '@entur/typography'
 
 import { TileSubLabel } from '../../../../types'
 import ValidationExclamation from '../../../../assets/icons/ValidationExclamation'
 import ValidationError from '../../../../assets/icons/ValidationError'
-import './styles.scss'
 
 import SituationModal from '../../../../components/SituationModal'
 
@@ -12,6 +12,7 @@ import { isMobileWeb } from '../../../../utils'
 import { WalkInfoBike } from '../../../../logic/useWalkInfoBike'
 
 import PlatformInfo from './PlatformInfo'
+import './styles.scss'
 
 const isMobile = isMobileWeb()
 

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { WidthProvider, Responsive, Layouts, Layout } from 'react-grid-layout'
 
-import { useLongPress } from 'use-long-press'
 import { useRouteMatch } from 'react-router'
+
+import { useLongPress } from 'use-long-press'
+
 import { Loader } from '@entur/loader'
 
 import { FormFactor } from '@entur/sdk/lib/mobility/types'

--- a/src/dashboards/Map/DepartureTag/DepartureIcon/index.tsx
+++ b/src/dashboards/Map/DepartureTag/DepartureIcon/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import './styles.scss'
 
 const DepartureIcon = ({ icon, color, routeNumber }: Props): JSX.Element => (

--- a/src/dashboards/Map/index.tsx
+++ b/src/dashboards/Map/index.tsx
@@ -12,13 +12,13 @@ import {
 
 import MapView from '../../components/Map'
 
-import './styles.scss'
 import { useSettingsContext } from '../../settings'
 import { DEFAULT_ZOOM } from '../../constants'
 
 import WeatherTile from '../../components/WeatherTile'
 
 import DepartureTag from './DepartureTag'
+import './styles.scss'
 
 const MapDashboard = ({ history }: Props): JSX.Element => {
     const [settings] = useSettingsContext()

--- a/src/dashboards/Timeline/index.tsx
+++ b/src/dashboards/Timeline/index.tsx
@@ -1,13 +1,14 @@
 import React, { Fragment, useMemo, useEffect, useState, useRef } from 'react'
+
+import { useRouteMatch } from 'react-router'
+
+import { useLongPress } from 'use-long-press'
+
 import { Heading2 } from '@entur/typography'
 import { LegBone } from '@entur/travel'
 import { LegMode } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 import { WalkingIcon } from '@entur/icons'
-
-import { useRouteMatch } from 'react-router'
-
-import { useLongPress } from 'use-long-press'
 
 import {
     getIcon,
@@ -23,7 +24,6 @@ import { LineData, IconColorType } from '../../types'
 import { useStopPlacesWithDepartures, useWalkInfo } from '../../logic'
 import DashboardWrapper from '../../containers/DashboardWrapper'
 
-import './styles.scss'
 import { useSettingsContext } from '../../settings'
 import { WalkInfo } from '../../logic/useWalkInfo'
 
@@ -34,6 +34,8 @@ import {
 } from '../../settings/LocalStorage'
 
 import { LongPressProvider } from '../../logic/longPressContext'
+
+import './styles.scss'
 
 const TICKS = [-1, 0, 1, 2, 3, 4, 5, 10, 15, 20, 30, 60]
 

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+
 import { Coordinates } from '@entur/sdk'
 import { Station } from '@entur/sdk/lib/mobility/types'
 

--- a/src/logic/useMobility.ts
+++ b/src/logic/useMobility.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+
 import { Coordinates } from '@entur/sdk'
 
 import { Vehicle, FormFactor, Operator } from '@entur/sdk/lib/mobility/types'

--- a/src/logic/useNearestPlaces.ts
+++ b/src/logic/useNearestPlaces.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+
 import { NearestPlace, Coordinates, TypeName } from '@entur/sdk'
 
 import service from '../service'

--- a/src/logic/useOperators.ts
+++ b/src/logic/useOperators.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+
 import { Operator } from '@entur/sdk/lib/mobility/types'
 
 import service from '../service'

--- a/src/logic/useRealtimeVehicleData.ts
+++ b/src/logic/useRealtimeVehicleData.ts
@@ -1,7 +1,7 @@
+import { useCallback, useEffect, useState } from 'react'
+
 import { useQuery, useSubscription } from '@apollo/client'
 import type { OnSubscriptionDataOptions } from '@apollo/client'
-
-import { useCallback, useEffect, useState } from 'react'
 
 import { Filter } from '../services/realtimeVehicles/types/filter'
 import { RealtimeVehicle } from '../services/realtimeVehicles/types/realtimeVehicle'

--- a/src/logic/useWalkInfo.ts
+++ b/src/logic/useWalkInfo.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+
 import { isEqual } from 'lodash'
 
 import { Coordinates, QueryMode } from '@entur/sdk'

--- a/src/logic/useWalkInfoBike.ts
+++ b/src/logic/useWalkInfoBike.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+
 import { isEqual } from 'lodash'
 
 import { Coordinates, QueryMode } from '@entur/sdk'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
-import 'react-app-polyfill/stable'
 import React from 'react'
 import ReactDOM from 'react-dom'
+
+import 'react-app-polyfill/stable'
+
 import analytics from 'universal-ga'
 import { createBrowserHistory } from 'history'
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -6,9 +6,10 @@ import {
     useEffect,
 } from 'react'
 import { useLocation } from 'react-router-dom'
-import { Coordinates, TransportMode } from '@entur/sdk'
 
 import { onSnapshot } from 'firebase/firestore'
+
+import { Coordinates, TransportMode } from '@entur/sdk'
 
 import { Theme } from '../types'
 import { getSettings } from '../services/firebase'


### PR DESCRIPTION
No blir det _orden_ på sakene!

`npm run eslint -- --fix` fikser det meste. 

 The "closer" an import is to a file, the lower its import should be.
    react imports must come first, then other 3rd parties.
    @entur imports are grouped together.
    Sibling files must come last.