### PR TITLE
Fix permissions-policy header

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -26,7 +26,7 @@
                     },
                     {
                         "key": "Permissions-Policy",
-                        "value": "geolocation=(self);"
+                        "value": "geolocation=(self)"
                     },
                     {
                         "key": "Referrer-Policy",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,7 @@ module.exports = (env, args) => ({
         headers: {
             'Content-Security-Policy':
                 "child-src 'self' blob:;default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://apis.google.com blob:; connect-src 'self' wss://*.entur.io https://api.met.no https://stats.g.doubleclick.net https://*.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com https://*.entur.io https://*.entur.org https://*.cloudfunctions.net https://*.googleapis.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:  https://www.google.no  https://www.google.com https://*.googleapis.com https://www.google-analytics.com; object-src 'none'; frame-ancestors https:; manifest-src 'self' blob:; frame-src https://entur-tavla-staging.firebaseapp.com/ https://entur-tavla-prod.firebaseapp.com/",
+            'Permissions-Policy': 'geolocation=(self)',
         },
     },
     plugins: [


### PR DESCRIPTION
Ref appendixet nederst [her](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#appendix-big-changes-since-this-was-called-feature-policy) så virker det som feilen oppsto pga semikolonet. 

La også til headeren i devServer da vi vil prøve å simulere remote hostingen mest mulig lokalt.

Usikker på om det faktisk fikser feilen før det er i staging, men feilen oppsto også lokalt da jeg la til headeren slik den var orginalt, og ble fikset av å fjerne semikolonet, så jeg har trua!

![image](https://user-images.githubusercontent.com/32391231/137156718-0b6c8dc2-f20d-462a-b781-3c9ee1eb13c7.png)
