### PR TITLE
Make CSP conditional based on development run or not

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,11 +77,14 @@ module.exports = smp.wrap((env, args) => ({
         static: OUTPUT_PATH,
         port: 9090,
         historyApiFallback: true,
-        headers: {
-            'Content-Security-Policy':
-                "child-src 'self' blob:;default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://apis.google.com https://*.googleapis.com https://www.googletagmanager.com blob:; connect-src 'self' wss://*.entur.io https://api.met.no https://stats.g.doubleclick.net https://*.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com https://*.entur.io https://*.entur.org https://*.cloudfunctions.net https://*.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:  https://www.google.no  https://www.google.com https://*.googleapis.com https://www.google-analytics.com; object-src 'none'; frame-ancestors https:; manifest-src 'self' blob:; frame-src https://entur-tavla-staging.firebaseapp.com/ https://entur-tavla-prod.firebaseapp.com/",
-            'Permissions-Policy': 'geolocation=(self)',
-        },
+        headers:
+            resolveEnv(env) === 'development'
+                ? {}
+                : {
+                      'Content-Security-Policy':
+                          "child-src 'self' blob:;default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://apis.google.com https://*.googleapis.com https://www.googletagmanager.com blob:; connect-src 'self' wss://*.entur.io https://api.met.no https://stats.g.doubleclick.net https://*.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com https://*.entur.io https://*.entur.org https://*.cloudfunctions.net https://*.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:  https://www.google.no  https://www.google.com https://*.googleapis.com https://www.google-analytics.com; object-src 'none'; frame-ancestors https:; manifest-src 'self' blob:; frame-src https://entur-tavla-staging.firebaseapp.com/ https://entur-tavla-prod.firebaseapp.com/",
+                      'Permissions-Policy': 'geolocation=(self)',
+                  },
     },
     plugins: [
         new HtmlWebPackPlugin({


### PR DESCRIPTION
Denne PRen fikser en uoppdaget feil innført i #466. Feilen hindret Firebase Emulators i å fungere korrekt da den innførte CSP-en (Content-security-policy) blokkerete de lokale requestene. Siden emulatoren kun er ment til lokal testing av firebase-funksjonalitet gjør denne PRen CSP-en avhengig av om det er `development` build eller ikke og fjerner den hvis det er det. 

Etter hva jeg forstår skal ikke det være noe problem å fjerne denne i local development mode, men hvis det er det og jeg har missforstått, si i fra! Til info hadde ikke `development` noen CSP-header i det hele tatt før #466.