### PR TITLE
Change deletion path for logo to be based on URL

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -60,7 +60,11 @@ export const deleteImagefromStorage = firestoreDB
     .onUpdate(async (change, context) => {
         if (change.before.data().logo && !change.after.data().logo) {
             try {
-                const path = `images/${context.params.settingsID}`
+                const imageUrl: string = change.before.data().logo
+                const imageIdMatch = imageUrl.match(/(?<=\%2F)(.*?)(?=\?)/)
+                const path = `images/${
+                    imageIdMatch ? imageIdMatch[0] : context.params.settingsID
+                }`
                 await storage().bucket().file(path).delete()
             } catch (error) {
                 console.error(error)


### PR DESCRIPTION
Denne PRen endrer litt på hvordan logosletting fungerer. Når man setter en logo til en tavle havner den i `images/{tavleID}`. For sletting har da tidligere man referet til denne pathen, men dette fungerer ikke hvis man laster opp logo og så setter custom url da dette endrer tavleID-en. I denne PRen endres pathen til å være basert på selve url-en til filen da denne inneholder en refernse til filnavnet. Dette gjør at man kan referere til et bilde selv etter endret tavleID. Hvis man ikke finner en regex-match er fallback det gamle systemet. 

Obs: denne løsningen er avhengig av at formatet på url-en forblir det samme. En alternaltiv løsning kan være å legge til enda et felt i `settings` som lagrer filnavnet i storage, men jeg valgte å ikke implementere det da det ikke er backwards compatible. 