### PR TITLE
Improve custom url backend

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -81,7 +81,7 @@ export const scheduledDeleteOfDocumentsSetToBeDeleted = region('us-central1')
             const batch = firestore().batch()
             firestore()
                 .collection('settings')
-                .where('delete', '==', true)
+                .where('isScheduledForDelete', '==', true)
                 .get()
                 .then((querySnapshot) => {
                     querySnapshot.forEach((doc) => {

--- a/src/containers/MyBoards/index.tsx
+++ b/src/containers/MyBoards/index.tsx
@@ -29,7 +29,7 @@ function sortBoard(boards: BoardProps[]): BoardProps[] {
 }
 
 const filterBoards = (boards: BoardProps[]): BoardProps[] =>
-    boards.filter((board) => !(board.data.delete == true))
+    boards.filter((board) => !board.data.isScheduledForDelete)
 
 const MyBoards = ({ history }: Props): JSX.Element | null => {
     const [boards, setBoards] = useState<DocumentData>()

--- a/src/containers/MyBoards/index.tsx
+++ b/src/containers/MyBoards/index.tsx
@@ -28,6 +28,9 @@ function sortBoard(boards: BoardProps[]): BoardProps[] {
     })
 }
 
+const filterBoards = (boards: BoardProps[]): BoardProps[] =>
+    boards.filter((board) => !(board.data.delete == true))
+
 const MyBoards = ({ history }: Props): JSX.Element | null => {
     const [boards, setBoards] = useState<DocumentData>()
     const user = useUser()
@@ -51,7 +54,11 @@ const MyBoards = ({ history }: Props): JSX.Element | null => {
                             id: docSnapshot.id,
                         } as BoardProps),
                 )
-                setBoards(updatedBoards.length ? sortBoard(updatedBoards) : [])
+                setBoards(
+                    updatedBoards.length
+                        ? sortBoard(filterBoards(updatedBoards))
+                        : [],
+                )
             },
             error: () => setBoards([]),
         })

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -161,7 +161,7 @@ export const copySettingsToNewId = async (
     try {
         const document = await getDoc(newDocRef)
         if (document.exists()) {
-            if (document.data().delete == true) {
+            if (document.data().isScheduledForDelete) {
                 await deleteDoc(newDocRef)
                 await createSettingsWithId(settings, newDocId)
                 return true
@@ -177,4 +177,4 @@ export const copySettingsToNewId = async (
 }
 
 export const setIdToBeDeleted = (docId: string): Promise<void> =>
-    updateSingleSettingsField(docId, 'delete', true)
+    updateSingleSettingsField(docId, 'isScheduledForDelete', true)

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -150,26 +150,30 @@ export const uploadLogo = async (
     )
 }
 
-export const copySettingsToNewId = (
+export const copySettingsToNewId = async (
     newDocId: string,
     settings: Settings | null,
 ): Promise<boolean> => {
+    if (!settings) return false
+
     const newDocRef: DocumentReference = getSettings(newDocId)
 
-    return getDoc(newDocRef)
-        .then((document) => {
-            if (document.exists()) {
-                return false
-            } else {
-                if (settings) {
-                    createSettingsWithId(settings, newDocId)
-                    return true
-                } else {
-                    return false
-                }
+    try {
+        const document = await getDoc(newDocRef)
+        if (document.exists()) {
+            if (document.data().delete == true) {
+                await deleteDoc(newDocRef)
+                await createSettingsWithId(settings, newDocId)
+                return true
             }
-        })
-        .catch(() => false)
+            return false
+        } else {
+            await createSettingsWithId(settings, newDocId)
+            return true
+        }
+    } catch {
+        return false
+    }
 }
 
 export const setIdToBeDeleted = (docId: string): Promise<void> =>

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -62,6 +62,7 @@ export interface Settings {
     hideWalkInfo?: boolean
     hideRealtimeData?: boolean
     hiddenRealtimeDataLineRefs: string[]
+    delete?: boolean
 }
 
 type Setter = (settings: Partial<Settings>) => void

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -62,7 +62,7 @@ export interface Settings {
     hideWalkInfo?: boolean
     hideRealtimeData?: boolean
     hiddenRealtimeDataLineRefs: string[]
-    delete?: boolean
+    isScheduledForDelete?: boolean
 }
 
 type Setter = (settings: Partial<Settings>) => void


### PR DESCRIPTION
Denne PRen forbedrer funksjonaliteten til egendefinert URL ved hjelp av to endringer:

- Det er nå mulig å sette tavla si til en URL som eksisterer, men er satt med `isScheduledForDelete === true`. Dette ga før en feilmelding om at denne url-en ikke er tilgjengelig. Når man gjør dette slettes den tavla som har url-en man ønsker med en gang før man lager en kopi av nåværende tavle med den nye urlen og setter gamle til `isScheduledForDelete = true`.
- I Mine tavler vises nå ikke lenger tavler som har `isScheduledForDelete === true` lenger. Dette gjør at man ikke lenger får duplikater i listen.