### PR TITLE
Revert "Bump typescript from 3.9.10 to 4.4.4 in /functions"

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,7 +13,7 @@
             "devDependencies": {
                 "@types/cors": "^2.8.6",
                 "firebase-functions-test": "^0.3.3",
-                "typescript": "^4.4.4"
+                "typescript": "^3.8.0"
             },
             "engines": {
                 "node": "12"
@@ -2170,9 +2170,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "3.9.10",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -4103,9 +4103,9 @@
             }
         },
         "typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "3.9.10",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
             "dev": true
         },
         "unique-string": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,7 @@
     "devDependencies": {
         "@types/cors": "^2.8.6",
         "firebase-functions-test": "^0.3.3",
-        "typescript": "^4.4.4"
+        "typescript": "^3.8.0"
     },
     "private": true
 }


### PR DESCRIPTION
Reverts entur/tavla#501

Krasjer ved deploying av funksjoner til staging. Feilmelding virker til å ikke kunne løses før kanskje firebase-admin er oppdatert. Ruller derfor tilbake til vi får oppdatert firebase-admin