### PR TITLE
Increase z-index of weather-tile in map view

### DIFF
--- a/src/components/WeatherTile/styles.scss
+++ b/src/components/WeatherTile/styles.scss
@@ -10,6 +10,7 @@
     align-items: center;
     padding: $space-medium !important;
     min-height: 150px;
+    z-index: 3;
 
     &__icon-and-temperature {
         display: flex;


### PR DESCRIPTION
Realtime-ikonene havnet over værinformasjonen. Nå havner de under, som er ønsket oppførsel. 