### PR TITLE
Fix all lint warnings

### DIFF
--- a/src/assets/icons/ThemeDashboardPreview.ts
+++ b/src/assets/icons/ThemeDashboardPreview.ts
@@ -19,11 +19,12 @@ import TimelineGrey from '../previews/previewGrey/Tidslinje-grey.svg'
 import MapGrey from '../previews/previewGrey/Kart-grey.svg'
 import BusStopGrey from '../previews/previewGrey/Holdeplass-gray.svg'
 
-import { GenericKeyValueObject, Theme } from '../../types'
+import { Theme } from '../../types'
 
 export function ThemeDashboardPreview(
     theme: Theme | undefined,
-): GenericKeyValueObject {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, any> {
     switch (theme) {
         case Theme.DARK:
             return {

--- a/src/assets/icons/ThemeDashboardPreview.ts
+++ b/src/assets/icons/ThemeDashboardPreview.ts
@@ -19,11 +19,11 @@ import TimelineGrey from '../previews/previewGrey/Tidslinje-grey.svg'
 import MapGrey from '../previews/previewGrey/Kart-grey.svg'
 import BusStopGrey from '../previews/previewGrey/Holdeplass-gray.svg'
 
-import { Theme } from '../../types'
+import { GenericKeyValueObject, Theme } from '../../types'
 
-export function ThemeDashboardPreview(theme: Theme | undefined): {
-    [key: string]: any
-} {
+export function ThemeDashboardPreview(
+    theme: Theme | undefined,
+): GenericKeyValueObject {
     switch (theme) {
         case Theme.DARK:
             return {

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -18,6 +18,7 @@ import {
     IconColorType,
     Line,
     StopPlaceWithDepartures,
+    Viewport,
 } from '../../types'
 
 import { Filter } from '../../services/realtimeVehicles/types/filter'
@@ -48,7 +49,7 @@ const Map = ({
     longitude,
     zoom,
 }: Props): JSX.Element => {
-    const [viewport, setViewPort] = useState({
+    const [viewport, setViewPort] = useState<Viewport>({
         latitude,
         longitude,
         width: 'auto',
@@ -346,7 +347,7 @@ const Map = ({
             mapStyle={mapStyle || process.env.MAPBOX_STYLE_MAPVIEW}
             onViewportChange={
                 interactive
-                    ? (newViewPort: any): void => {
+                    ? (newViewPort: Viewport): void => {
                           const {
                               zoom: newZoom,
                               maxZoom,

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect } from 'react'
-import { Route, Switch, Router, useLocation } from 'react-router-dom'
+import {
+    Route,
+    Switch,
+    BrowserRouter as Router,
+    useLocation,
+} from 'react-router-dom'
 
 import PWAPrompt from 'react-ios-pwa-prompt'
 
@@ -260,11 +265,11 @@ const Content = (): JSX.Element => {
 }
 
 interface Props {
-    history: any
+    history: History
 }
 
-const App = ({ history }: Props): JSX.Element => (
-    <Router history={history}>
+const App = (): JSX.Element => (
+    <Router>
         <Content />
     </Router>
 )

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect } from 'react'
-import {
-    Route,
-    Switch,
-    BrowserRouter as Router,
-    useLocation,
-} from 'react-router-dom'
+import { Route, Switch, BrowserRouter, useLocation } from 'react-router-dom'
 
 import PWAPrompt from 'react-ios-pwa-prompt'
 
@@ -47,7 +42,7 @@ const numberOfVisits = getFromLocalStorage<number>('numberOfVisits') || 1
 
 function getDashboardComponent(
     dashboardKey?: string | void,
-): (props: Props) => JSX.Element | null {
+): () => JSX.Element | null {
     switch (dashboardKey) {
         case 'Timeline':
             return Timeline
@@ -264,14 +259,10 @@ const Content = (): JSX.Element => {
     )
 }
 
-interface Props {
-    history: History
-}
-
 const App = (): JSX.Element => (
-    <Router>
+    <BrowserRouter>
         <Content />
-    </Router>
+    </BrowserRouter>
 )
 
 export default App

--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
 
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 
 import { signOut } from 'firebase/auth'
 
@@ -27,8 +27,9 @@ import MineTavlerModal from '../../MineTavlerModal'
 import MenuButton from './MenuButton'
 import './styles.scss'
 
-function BottomMenu({ className, history }: Props): JSX.Element {
+function BottomMenu({ className }: Props): JSX.Element {
     const URL = document.location.href
+    const history = useHistory()
 
     const user = useUser()
     const width = useWindowWidth()
@@ -246,7 +247,6 @@ function BottomMenu({ className, history }: Props): JSX.Element {
 
 interface Props {
     className?: string
-    history: any
 }
 
 export default BottomMenu

--- a/src/containers/DashboardWrapper/index.tsx
+++ b/src/containers/DashboardWrapper/index.tsx
@@ -22,7 +22,6 @@ function DashboardWrapper(props: Props): JSX.Element {
     const {
         className,
         children,
-        history,
         bikeRentalStations,
         stopPlacesWithDepartures,
         scooters,
@@ -68,10 +67,7 @@ function DashboardWrapper(props: Props): JSX.Element {
                     </div>
                 )}
                 <ThemeContrastWrapper useContrast={true}>
-                    <BottomMenu
-                        className="dashboard-wrapper__bottom-menu"
-                        history={history}
-                    />
+                    <BottomMenu className="dashboard-wrapper__bottom-menu" />
                 </ThemeContrastWrapper>
             </div>
         </ThemeContrastWrapper>
@@ -84,7 +80,6 @@ interface Props {
     scooters?: Vehicle[] | null
     className: string
     children: JSX.Element | JSX.Element[]
-    history: any
 }
 
 export default DashboardWrapper

--- a/src/containers/Error/ErrorPages.tsx
+++ b/src/containers/Error/ErrorPages.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 
+import { useHistory } from 'react-router'
+
 import { signOut } from 'firebase/auth'
 
 import { useToast } from '@entur/alert'
@@ -15,9 +17,10 @@ import sauerLight from '../../assets/images/sauer_lag@2x.png'
 
 import ErrorWrapper from '.'
 
-export function LockedTavle({ history }: Props): JSX.Element {
+export function LockedTavle(): JSX.Element {
     const user = useUser()
     const userLoggedin = Boolean(user && !user.isAnonymous)
+    const history = useHistory()
     const documentId = getDocumentId()
     const { addToast } = useToast()
 
@@ -35,7 +38,7 @@ export function LockedTavle({ history }: Props): JSX.Element {
                   variant: 'success',
               })
 
-              signOut(auth).then(history.push(`/t/${documentId}`))
+              signOut(auth).then(() => history.push(`/t/${documentId}`))
           }
     const callbackMessage = !userLoggedin ? 'Logg inn' : 'Logg ut'
 
@@ -65,7 +68,8 @@ export function LockedTavle({ history }: Props): JSX.Element {
     )
 }
 
-export function PageDoesNotExist({ history }: Props): JSX.Element {
+export function PageDoesNotExist(): JSX.Element {
+    const history = useHistory()
     const callback = (event: React.SyntheticEvent<HTMLButtonElement>): void => {
         event.preventDefault()
         history.push(`/`)
@@ -95,7 +99,8 @@ export function NoStopsOnTavle(): JSX.Element {
     )
 }
 
-export function NoTavlerAvailable({ history }: Props): JSX.Element {
+export function NoTavlerAvailable(): JSX.Element {
+    const history = useHistory()
     const callback = (event: React.SyntheticEvent<HTMLButtonElement>): void => {
         event.preventDefault()
         history.push(`/`)
@@ -139,8 +144,4 @@ export function NoAccessToTavler(): JSX.Element {
             />
         </div>
     )
-}
-
-interface Props {
-    history: any
 }

--- a/src/containers/Error/index.tsx
+++ b/src/containers/Error/index.tsx
@@ -45,7 +45,7 @@ function ErrorWrapper({
 interface Props {
     title: string
     message: string
-    image: any
+    image: string
     callbackMessage?: string
     callback?: (event: React.SyntheticEvent<HTMLButtonElement>) => void
 }

--- a/src/containers/LandingPage/SearchPanel/index.tsx
+++ b/src/containers/LandingPage/SearchPanel/index.tsx
@@ -15,6 +15,7 @@ const YOUR_POSITION = 'Posisjonen din'
 interface Item {
     value: string
     label: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     icons?: Array<React.ComponentType<any>>
     coordinates?: Coordinates
 }

--- a/src/containers/LandingPage/index.tsx
+++ b/src/containers/LandingPage/index.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback } from 'react'
 
+import { useHistory } from 'react-router'
+
 import { Coordinates } from '@entur/sdk'
 import { Heading1, Heading2, Paragraph, Link } from '@entur/typography'
 import { Contrast } from '@entur/layout'
@@ -24,7 +26,8 @@ function EnturLink(): JSX.Element {
     )
 }
 
-function LandingPage({ history }: Props): JSX.Element {
+function LandingPage(): JSX.Element {
+    const history = useHistory()
     const addLocation = useCallback(
         (position: Coordinates, locationName: string): void => {
             const initialSettings = {
@@ -120,10 +123,6 @@ function LandingPage({ history }: Props): JSX.Element {
             </div>
         </div>
     )
-}
-
-interface Props {
-    history: any
 }
 
 export default LandingPage

--- a/src/containers/MyBoards/BoardCard/OverflowMenu/index.tsx
+++ b/src/containers/MyBoards/BoardCard/OverflowMenu/index.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
+import { useHistory } from 'react-router'
+
 import copy from 'copy-to-clipboard'
 
 import {
@@ -16,7 +18,8 @@ import '../styles.scss'
 import RemoveLockModal from './Modals/RemoveLockModal'
 import DeleteTavleModal from './Modals/DeleteTavleModal'
 
-function BoardOverflowMenu({ id, uid, history }: Props): JSX.Element {
+function BoardOverflowMenu({ id, uid }: Props): JSX.Element {
+    const history = useHistory()
     const [removeLockModalOpen, setRemoveLockModalOpen] =
         useState<boolean>(false)
     const [deleteTavleModalOpen, setDeleteTavleModalOpen] =
@@ -86,7 +89,6 @@ function BoardOverflowMenu({ id, uid, history }: Props): JSX.Element {
 interface Props {
     id: string
     uid: string
-    history: any
 }
 
 export default BoardOverflowMenu

--- a/src/containers/MyBoards/BoardCard/index.tsx
+++ b/src/containers/MyBoards/BoardCard/index.tsx
@@ -52,7 +52,6 @@ function BoardCard({
     timestamp,
     created,
     className,
-    history,
 }: Props): JSX.Element {
     const [titleEditMode, setTitleEditMode] = useState<boolean>(false)
     const [boardTitle, setBoardTitle] = useState<string>('Uten tittel')
@@ -129,11 +128,7 @@ function BoardCard({
                         {boardTitleElement}
                     </div>
                     <div>
-                        <BoardOverflowMenu
-                            id={id}
-                            uid={uid}
-                            history={history}
-                        />
+                        <BoardOverflowMenu id={id} uid={uid} />
                     </div>
                 </div>
 
@@ -161,7 +156,6 @@ interface Props {
     timestamp: Timestamp
     created: Timestamp
     className?: string
-    history: any
 }
 
 export default BoardCard

--- a/src/containers/MyBoards/index.tsx
+++ b/src/containers/MyBoards/index.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import type { DocumentData, Timestamp } from 'firebase/firestore'
+import type {
+    DocumentData,
+    DocumentSnapshot,
+    Timestamp,
+} from 'firebase/firestore'
 
 import { Contrast } from '@entur/layout'
 import { Heading2, Heading3 } from '@entur/typography'
@@ -31,7 +35,7 @@ function sortBoard(boards: BoardProps[]): BoardProps[] {
 const filterBoards = (boards: BoardProps[]): BoardProps[] =>
     boards.filter((board) => !board.data.isScheduledForDelete)
 
-const MyBoards = ({ history }: Props): JSX.Element | null => {
+const MyBoards = (): JSX.Element | null => {
     const [boards, setBoards] = useState<DocumentData>()
     const user = useUser()
     const preview = ThemeDashboardPreview(Theme.DEFAULT)
@@ -46,11 +50,11 @@ const MyBoards = ({ history }: Props): JSX.Element | null => {
             next: (querySnapshot) => {
                 if (querySnapshot.metadata.hasPendingWrites) return
                 const updatedBoards = querySnapshot.docs.map(
-                    (docSnapshot: any) =>
+                    (docSnapshot: DocumentSnapshot) =>
                         ({
                             data: docSnapshot.data(),
-                            lastmodified: docSnapshot.data().lastmodified,
-                            created: docSnapshot.data().created,
+                            lastmodified: docSnapshot.data()?.lastmodified,
+                            created: docSnapshot.data()?.created,
                             id: docSnapshot.id,
                         } as BoardProps),
                 )
@@ -72,7 +76,7 @@ const MyBoards = ({ history }: Props): JSX.Element | null => {
         return <NoAccessToTavler />
     }
     if (!boards.length) {
-        return <NoTavlerAvailable history={history} />
+        return <NoTavlerAvailable />
     }
 
     return (
@@ -90,7 +94,6 @@ const MyBoards = ({ history }: Props): JSX.Element | null => {
                             timestamp={board.lastmodified}
                             created={board.created}
                             settings={board.data}
-                            history={history}
                         />
                     ))}
                     <Link to="/">
@@ -124,10 +127,6 @@ const MyBoards = ({ history }: Props): JSX.Element | null => {
             </div>
         </Contrast>
     )
-}
-
-interface Props {
-    history: any
 }
 
 interface BoardProps {

--- a/src/dashboards/BusStop/index.tsx
+++ b/src/dashboards/BusStop/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { Layouts, Layout, WidthProvider, Responsive } from 'react-grid-layout'
-import { useRouteMatch } from 'react-router'
+import { useHistory, useRouteMatch } from 'react-router'
 
 import { useLongPress } from 'use-long-press'
 
@@ -91,8 +91,9 @@ function removeStopPlacesWithNoDepartures(
     )
 }
 
-const BusStop = ({ history }: Props): JSX.Element | null => {
+const BusStop = (): JSX.Element | null => {
     const [settings] = useSettingsContext()
+    const history = useHistory()
     const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
     const [isLongPressStarted, setIsLongPressStarted] = useState<boolean>(false)
     const isCancelled = useRef<NodeJS.Timeout>()
@@ -107,7 +108,7 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
             ?.documentId
 
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
-        getFromLocalStorage(dashboardKey),
+        getFromLocalStorage(dashboardKey as string),
     )
     const [tileOrder, setTileOrder] = useState<Item[] | undefined>(
         boardId ? getFromLocalStorage(boardId + '-tile-order') : undefined,
@@ -215,7 +216,6 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
         return (
             <DashboardWrapper
                 className="busStop"
-                history={history}
                 bikeRentalStations={bikeRentalStations}
                 stopPlacesWithDepartures={stopPlacesWithDepartures}
                 scooters={scooters}
@@ -295,7 +295,6 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
     return (
         <DashboardWrapper
             className="busStop"
-            history={history}
             bikeRentalStations={bikeRentalStations}
             stopPlacesWithDepartures={stopPlacesWithDepartures}
             scooters={scooters}
@@ -322,7 +321,10 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
                         ): void => {
                             if (numberOfStopPlaces > 0) {
                                 setGridLayouts(layouts)
-                                saveToLocalStorage(dashboardKey, layouts)
+                                saveToLocalStorage(
+                                    dashboardKey as string,
+                                    layouts,
+                                )
                             }
                         }}
                     >
@@ -371,10 +373,6 @@ const BusStop = ({ history }: Props): JSX.Element | null => {
             )}
         </DashboardWrapper>
     )
-}
-
-interface Props {
-    history: any
 }
 
 export default BusStop

--- a/src/dashboards/Chrono/index.tsx
+++ b/src/dashboards/Chrono/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { WidthProvider, Responsive, Layouts, Layout } from 'react-grid-layout'
 
-import { useRouteMatch } from 'react-router'
+import { useHistory, useRouteMatch } from 'react-router'
 
 import { useLongPress } from 'use-long-press'
 
@@ -92,8 +92,9 @@ const COLS: { [key: string]: number } = {
     xxs: 1,
 }
 
-const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
+const ChronoDashboard = (): JSX.Element | null => {
     const [settings] = useSettingsContext()
+    const history = useHistory()
     const dashboardKey = history.location.key
     const boardId =
         useRouteMatch<{ documentId: string }>('/t/:documentId')?.params
@@ -104,7 +105,7 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
 
     const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
-        getFromLocalStorage(dashboardKey),
+        getFromLocalStorage(dashboardKey as string),
     )
     const [tileOrder, setTileOrder] = useState<Item[] | undefined>(
         boardId ? getFromLocalStorage(boardId + '-tile-order') : undefined,
@@ -258,7 +259,6 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
         return (
             <DashboardWrapper
                 className="chrono"
-                history={history}
                 bikeRentalStations={bikeRentalStations}
                 stopPlacesWithDepartures={stopPlacesWithDepartures}
                 scooters={scooters}
@@ -364,7 +364,6 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
     return (
         <DashboardWrapper
             className="chrono"
-            history={history}
             bikeRentalStations={bikeRentalStations}
             stopPlacesWithDepartures={stopPlacesWithDepartures}
         >
@@ -390,7 +389,10 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
                         ): void => {
                             if (numberOfStopPlaces > 0) {
                                 setGridLayouts(layouts)
-                                saveToLocalStorage(dashboardKey, layouts)
+                                saveToLocalStorage(
+                                    dashboardKey as string,
+                                    layouts,
+                                )
                             }
                         }}
                     >
@@ -464,10 +466,6 @@ const ChronoDashboard = ({ history }: Props): JSX.Element | null => {
             )}
         </DashboardWrapper>
     )
-}
-
-interface Props {
-    history: any
 }
 
 export default ChronoDashboard

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { WidthProvider, Responsive, Layouts, Layout } from 'react-grid-layout'
 
-import { useRouteMatch } from 'react-router'
+import { useHistory, useRouteMatch } from 'react-router'
 
 import { useLongPress } from 'use-long-press'
 
@@ -95,8 +95,9 @@ const COLS: { [key: string]: number } = {
     xxs: 1,
 }
 
-const EnturDashboard = ({ history }: Props): JSX.Element | null => {
+const EnturDashboard = (): JSX.Element | null => {
     const [settings] = useSettingsContext()
+    const history = useHistory()
     const [breakpoint, setBreakpoint] = useState<string>(getDefaultBreakpoint())
     const [isLongPressStarted, setIsLongPressStarted] = useState<boolean>(false)
     const isCancelled = useRef<NodeJS.Timeout>()
@@ -107,7 +108,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
             ?.documentId
 
     const [gridLayouts, setGridLayouts] = useState<Layouts | undefined>(
-        getFromLocalStorage(dashboardKey),
+        getFromLocalStorage(dashboardKey as string),
     )
 
     const [tileOrder, setTileOrder] = useState<Item[] | undefined>(
@@ -259,7 +260,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
         return (
             <DashboardWrapper
                 className="compact"
-                history={history}
                 bikeRentalStations={bikeRentalStations}
                 stopPlacesWithDepartures={stopPlacesWithDepartures}
                 scooters={scooters}
@@ -359,7 +359,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
     return (
         <DashboardWrapper
             className="compact"
-            history={history}
             bikeRentalStations={bikeRentalStations}
             stopPlacesWithDepartures={stopPlacesWithDepartures}
             scooters={scooters}
@@ -387,7 +386,10 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
                         ): void => {
                             if (numberOfStopPlaces > 0) {
                                 setGridLayouts(layouts)
-                                saveToLocalStorage(dashboardKey, layouts)
+                                saveToLocalStorage(
+                                    dashboardKey as string,
+                                    layouts,
+                                )
                             }
                         }}
                     >
@@ -486,10 +488,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element | null => {
             )}
         </DashboardWrapper>
     )
-}
-
-interface Props {
-    history: any
 }
 
 export default EnturDashboard

--- a/src/dashboards/Map/index.tsx
+++ b/src/dashboards/Map/index.tsx
@@ -20,7 +20,7 @@ import WeatherTile from '../../components/WeatherTile'
 import DepartureTag from './DepartureTag'
 import './styles.scss'
 
-const MapDashboard = ({ history }: Props): JSX.Element => {
+const MapDashboard = (): JSX.Element => {
     const [settings] = useSettingsContext()
 
     const stopPlacesWithDepartures = useStopPlacesWithDepartures()
@@ -35,7 +35,6 @@ const MapDashboard = ({ history }: Props): JSX.Element => {
     return (
         <DashboardWrapper
             className="map-view"
-            history={history}
             stopPlacesWithDepartures={stopPlacesWithDepartures}
             bikeRentalStations={bikeRentalStations}
         >
@@ -73,10 +72,6 @@ const MapDashboard = ({ history }: Props): JSX.Element => {
             </div>
         </DashboardWrapper>
     )
-}
-
-interface Props {
-    history: any
 }
 
 export default MapDashboard

--- a/src/dashboards/Timeline/index.tsx
+++ b/src/dashboards/Timeline/index.tsx
@@ -178,7 +178,7 @@ interface TimelineData {
     groupedDepartures: Array<[LegMode, LineData[]]>
 }
 
-const TimelineDashboard = (): JSX.Element => {
+const TimelineDashboard = (): JSX.Element | null => {
     useCounter()
     const stopPlacesWithDepartures = useStopPlacesWithDepartures()
     const [settings] = useSettingsContext()
@@ -369,7 +369,7 @@ const TimelineDashboard = (): JSX.Element => {
         )
     }
     if (window.innerWidth < BREAKPOINTS.md) {
-        if (!tileOrder) return <></>
+        if (!tileOrder) return null
 
         return (
             <DashboardWrapper

--- a/src/dashboards/Timeline/index.tsx
+++ b/src/dashboards/Timeline/index.tsx
@@ -178,7 +178,7 @@ interface TimelineData {
     groupedDepartures: Array<[LegMode, LineData[]]>
 }
 
-const TimelineDashboard = ({ history }: Props): JSX.Element => {
+const TimelineDashboard = (): JSX.Element => {
     useCounter()
     const stopPlacesWithDepartures = useStopPlacesWithDepartures()
     const [settings] = useSettingsContext()
@@ -369,12 +369,11 @@ const TimelineDashboard = ({ history }: Props): JSX.Element => {
         )
     }
     if (window.innerWidth < BREAKPOINTS.md) {
-        if (!tileOrder) return null as any
+        if (!tileOrder) return <></>
 
         return (
             <DashboardWrapper
                 className="timeline"
-                history={history}
                 stopPlacesWithDepartures={stopPlacesWithDepartures}
             >
                 <LongPressProvider value={isLongPressStarted}>
@@ -413,7 +412,6 @@ const TimelineDashboard = ({ history }: Props): JSX.Element => {
     return (
         <DashboardWrapper
             className="timeline"
-            history={history}
             stopPlacesWithDepartures={stopPlacesWithDepartures}
         >
             <div className="timeline__body">
@@ -506,10 +504,6 @@ const TimelineDashboard = ({ history }: Props): JSX.Element => {
             </div>
         </DashboardWrapper>
     )
-}
-
-interface Props {
-    history: any
 }
 
 export default TimelineDashboard

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,8 @@ import ReactDOM from 'react-dom'
 
 import 'react-app-polyfill/stable'
 
-import { createBrowserHistory } from 'history'
-
 import './main.scss'
 
 import App from './containers/App'
 
-const history = createBrowserHistory()
-
-ReactDOM.render(<App history={history} />, document.getElementById('app'))
+ReactDOM.render(<App />, document.getElementById('app'))

--- a/src/routers/PrivateRoute/index.tsx
+++ b/src/routers/PrivateRoute/index.tsx
@@ -32,14 +32,10 @@ function PrivateRoute({
 }
 
 interface Props {
-    component: (({ history }: HistoryProps) => JSX.Element) | null
-    errorComponent: ({ history }: HistoryProps) => JSX.Element
+    component: (() => JSX.Element) | null
+    errorComponent: () => JSX.Element
     path: string
     exact: boolean
-}
-
-interface HistoryProps {
-    history: any
 }
 
 export default PrivateRoute

--- a/src/service.ts
+++ b/src/service.ts
@@ -23,6 +23,7 @@ export default createEnturService({
 
 function journeyplannerPost<T>(
     query: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     variables: Record<string, any>,
     signal: AbortSignal,
 ): Promise<T> {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -7,7 +7,7 @@ import {
 } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { onSnapshot } from 'firebase/firestore'
+import { DocumentSnapshot, onSnapshot } from 'firebase/firestore'
 
 import { Coordinates, TransportMode } from '@entur/sdk'
 
@@ -108,46 +108,52 @@ export function useSettings(): [Settings | null, Setter] {
         }
 
         if (id) {
-            return onSnapshot(getSettings(id), (documentSnapshot: any) => {
-                if (!documentSnapshot.exists()) {
-                    window.location.pathname = '/'
-                    return
-                }
+            return onSnapshot(
+                getSettings(id),
+                (documentSnapshot: DocumentSnapshot) => {
+                    if (!documentSnapshot.exists()) {
+                        window.location.pathname = '/'
+                        return
+                    }
 
-                const data = documentSnapshot.data() as Settings
+                    const data = documentSnapshot.data() as Settings
 
-                const settingsWithDefaults: Settings = {
-                    ...DEFAULT_SETTINGS,
-                    ...data,
-                }
+                    const settingsWithDefaults: Settings = {
+                        ...DEFAULT_SETTINGS,
+                        ...data,
+                    }
 
-                // The fields under are added if missing, and if the tavle is not locked.
-                // If a tavle is locked by a user, you are not allowed to write to
-                // tavle unless you are logged in as the user who locked tavla, so we need
-                // to check if you have edit access.
-                const editAccess =
-                    user &&
-                    (!data.owners?.length || data.owners.includes(user.uid))
+                    // The fields under are added if missing, and if the tavle is not locked.
+                    // If a tavle is locked by a user, you are not allowed to write to
+                    // tavle unless you are logged in as the user who locked tavla, so we need
+                    // to check if you have edit access.
+                    const editAccess =
+                        user &&
+                        (!data.owners?.length || data.owners.includes(user.uid))
 
-                if (editAccess) {
-                    Object.entries(DEFAULT_SETTINGS).forEach(([key, value]) => {
-                        if (data[key as keyof Settings] === undefined) {
-                            persistSingleFieldToFirebase(
-                                id,
-                                key,
-                                value as FieldTypes,
-                            )
-                        }
+                    if (editAccess) {
+                        Object.entries(DEFAULT_SETTINGS).forEach(
+                            ([key, value]) => {
+                                if (data[key as keyof Settings] === undefined) {
+                                    persistSingleFieldToFirebase(
+                                        id,
+                                        key,
+                                        value as FieldTypes,
+                                    )
+                                }
+                            },
+                        )
+                    }
+
+                    setLocalSettings((prevSettings) => {
+                        const onAdmin =
+                            location.pathname.split('/')[1] === 'admin'
+                        return prevSettings && onAdmin
+                            ? prevSettings
+                            : settingsWithDefaults
                     })
-                }
-
-                setLocalSettings((prevSettings) => {
-                    const onAdmin = location.pathname.split('/')[1] === 'admin'
-                    return prevSettings && onAdmin
-                        ? prevSettings
-                        : settingsWithDefaults
-                })
-            })
+                },
+            )
         }
 
         let positionArray: string[] = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,5 @@
 import { TransportMode, TransportSubmode, StopPlace, Quay } from '@entur/sdk'
 
-export interface GenericKeyValueObject {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any
-}
 export interface LineData {
     id: string
     type: TransportMode

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 import { TransportMode, TransportSubmode, StopPlace, Quay } from '@entur/sdk'
 
+export interface GenericKeyValueObject {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any
+}
 export interface LineData {
     id: string
     type: TransportMode
@@ -54,4 +58,14 @@ export enum Theme {
 export enum IconColorType {
     DEFAULT = 'default',
     CONTRAST = 'contrast',
+}
+
+export interface Viewport {
+    latitude: number
+    longitude: number
+    width: string
+    height: string
+    zoom: number
+    maxZoom: number
+    minZoom: number
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -29,13 +29,7 @@ import type { TravelSwitchProps } from '@entur/form'
 import { Departure, LegMode, TransportMode, TransportSubmode } from '@entur/sdk'
 import { TranslatedString, Translation } from '@entur/sdk/lib/mobility/types'
 
-import {
-    LineData,
-    TileSubLabel,
-    Theme,
-    IconColorType,
-    GenericKeyValueObject,
-} from './types'
+import { LineData, TileSubLabel, Theme, IconColorType } from './types'
 import { useSettingsContext } from './settings'
 
 export function isNotNullOrUndefined<T>(
@@ -171,7 +165,8 @@ export function getIcon(
     }
 }
 
-export function groupBy<T extends GenericKeyValueObject>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function groupBy<T extends Record<string, any>>(
     objectArray: T[],
     property: keyof T,
 ): { [key: string]: T[] } {
@@ -182,7 +177,8 @@ export function groupBy<T extends GenericKeyValueObject>(
         }
         acc[key].push(obj)
         return acc
-    }, {} as GenericKeyValueObject)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }, {} as Record<string, any>)
 }
 
 function formatDeparture(minDiff: number, departureTime: Date): string {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -29,7 +29,13 @@ import type { TravelSwitchProps } from '@entur/form'
 import { Departure, LegMode, TransportMode, TransportSubmode } from '@entur/sdk'
 import { TranslatedString, Translation } from '@entur/sdk/lib/mobility/types'
 
-import { LineData, TileSubLabel, Theme, IconColorType } from './types'
+import {
+    LineData,
+    TileSubLabel,
+    Theme,
+    IconColorType,
+    GenericKeyValueObject,
+} from './types'
 import { useSettingsContext } from './settings'
 
 export function isNotNullOrUndefined<T>(
@@ -165,7 +171,7 @@ export function getIcon(
     }
 }
 
-export function groupBy<T extends { [key: string]: any }>(
+export function groupBy<T extends GenericKeyValueObject>(
     objectArray: T[],
     property: keyof T,
 ): { [key: string]: T[] } {
@@ -176,7 +182,7 @@ export function groupBy<T extends { [key: string]: any }>(
         }
         acc[key].push(obj)
         return acc
-    }, {} as { [key: string]: any })
+    }, {} as GenericKeyValueObject)
 }
 
 function formatDeparture(minDiff: number, departureTime: Date): string {


### PR DESCRIPTION
Ved å gjøre om `<Router />` til `<BrowserRouter />` og legge på noen `// eslint-disable-next-line @typescript-eslint/no-explicit-any` der `any`-typen faktisk er ønsket, fjerner denne PRen alle warnings som kommer opp i konsollen når man kjører `npm run lint`. 