### PR TITLE
Gjør tavla mer klimavennlig!

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ const smp = new SpeedMeasurePlugin()
 module.exports = smp.wrap((env, args) => ({
     mode: args.mode === 'production' ? 'production' : 'development',
     entry: './src/main.tsx',
-    devtool: 'inline-source-map',
+    devtool: args.mode === 'production' ? false : 'inline-source-map',
     output: {
         path: OUTPUT_PATH,
         filename: '[name].[fullhash].js',


### PR DESCRIPTION
Leste meg litt opp på [webpack](https://webpack.js.org/configuration/devtool/ ) og fant ut at devtool ikke er noe man trenger å ha i prod (som vi kanskje burde skjønt basert på navnet :Pp) og som jeg ikke ser noe behov for at vi har i prod. 

En kjapp sjekk viser at det reduserer js-bundlene med ca 75% som for oss vil si ca 3MB. Google-søket mitt til [kilder](https://www.energuide.be/en/questions-answers/do-i-emit-co2-when-i-surf-the-internet/69/) av ubekreftet kvalitet sier at én MB internett er ca 20g CO2. Antar vi rundt 200 sidenedlastinger per dag (fant ikke nøyaktig tall i firebase-konsollen på dette så det er basert på 60 (ekte tall) daglige brukere og antatt 3-4 lastinger per bruker) vil det si 200 * 20 * 3 * 365 / 1000 = 4380 kg CO2 spart per år. Det virket faktisk som en del så gjerne dobbeltsjekk matten min her. 

Anyways, tror dette vil gjøre susen og, om det funker så bra som jeg tror det gjør, vil det også gjøre at tavla scorer bedre på en god del performance metrics.   

Før:

![image](https://user-images.githubusercontent.com/32391231/141437072-8eed99cc-dc70-47b9-90b8-3ff1d44c5a92.png)

Etter: 

![image](https://user-images.githubusercontent.com/32391231/141437156-b764b13b-0923-4252-b18f-5ddd927d6ac6.png)
