### PR TITLE
Gjør at bunnmenyen forblir synlig på mobil ved innlasting

### DIFF
--- a/src/containers/DashboardWrapper/BottomMenu/index.tsx
+++ b/src/containers/DashboardWrapper/BottomMenu/index.tsx
@@ -34,7 +34,7 @@ function BottomMenu({ className }: Props): JSX.Element {
     const user = useUser()
     const width = useWindowWidth()
     const [settings] = useSettingsContext()
-    const [menuHiddenByScroll, setMenuHiddenByScroll] = useState(true)
+    const [menuHiddenByScroll, setMenuHiddenByScroll] = useState(false)
     const [isMobileWidth, setIsMobileWidth] = useState<boolean>(
         document.body.clientWidth <= 900,
     )
@@ -134,10 +134,8 @@ function BottomMenu({ className }: Props): JSX.Element {
     }, [width])
 
     useEffect(() => {
-        if (menuRef.current) {
-            isMobileWidth
-                ? menuRef.current.classList.add('hidden-menu')
-                : menuRef.current.classList.remove('hidden-menu')
+        if (menuRef.current && !isMobileWidth) {
+            menuRef.current.classList.remove('hidden-menu')
         }
     }, [isMobileWidth])
 


### PR DESCRIPTION
Denne PRen innfører en enkel fiks som gjør at bunnmeyen ikke «gjemmer seg» rett etter innlasting når man er på mobil. Det er ønskelig at den forblir synlig for å tydlig vise brukeren mulighetene menyen gir, samt at tavler med så få tiles at det ikke kan scrolles ville aldri ha mulighet til å vise bunnmenyen igjen.