### PR TITLE
Endre høyden på værinnstillinger i settings

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -465,7 +465,7 @@ const EditTab = (): JSX.Element => {
             },
             { i: 'scooterPanel', x: 0, y: 5, w: 1, h: 1.6 },
             { i: 'mapPanel', x: 0, y: 9.5, w: 1, h: 3 },
-            { i: 'weatherPanel', x: 0, y: 8, w: 1, h: 3 },
+            { i: 'weatherPanel', x: 0, y: 8, w: 1, h: 2 },
             {
                 i: 'realtimeDataPanel',
                 x: 0,


### PR DESCRIPTION
Boksen som lar deg velge hvordan du vil vise været i talva di var litt for høy fra breakpoint xxs og under. Denne PRen endrer høyden fra 3 til 2. 