### PR TITLE
Småfikser for delte tavler

### DIFF
--- a/src/containers/Admin/ShareTab/components/BoardOwnersList.tsx
+++ b/src/containers/Admin/ShareTab/components/BoardOwnersList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { Table, TableHead, TableRow, HeaderCell, TableBody } from '@entur/table'
 
@@ -26,11 +26,18 @@ export const BoardOwnersList = ({
         uid: '',
         email: invite.receiver,
     }))
+    const [userEmailsBeingRemoved, setUserEmailsBeingRemoved] = useState<
+        string[]
+    >([])
 
     const onRemoveOwnerFromBoard = async (
         userToRemove: BoardOwnersData,
     ): Promise<void> => {
         try {
+            setUserEmailsBeingRemoved([
+                ...userEmailsBeingRemoved,
+                userToRemove.email,
+            ])
             const ownersUids: string[] = ownersData.map(
                 (owner: BoardOwnersData) => owner.uid,
             )
@@ -41,6 +48,12 @@ export const BoardOwnersList = ({
             throw new Error(
                 'Write error: could not remove owner from board. ' + error,
             )
+        } finally {
+            setUserEmailsBeingRemoved(
+                userEmailsBeingRemoved.filter(
+                    (email) => email !== userToRemove.email,
+                ),
+            )
         }
     }
 
@@ -48,6 +61,10 @@ export const BoardOwnersList = ({
         userToRemove: BoardOwnersData,
     ): Promise<void> => {
         try {
+            setUserEmailsBeingRemoved([
+                ...userEmailsBeingRemoved,
+                userToRemove.email,
+            ])
             await removeSentBoardInviteAsOwner(
                 documentId,
                 user,
@@ -56,6 +73,12 @@ export const BoardOwnersList = ({
         } catch (error) {
             throw new Error(
                 'Write error: could not remove invite from board. ' + error,
+            )
+        } finally {
+            setUserEmailsBeingRemoved(
+                userEmailsBeingRemoved.filter(
+                    (email) => email !== userToRemove.email,
+                ),
             )
         }
     }
@@ -76,13 +99,15 @@ export const BoardOwnersList = ({
                     statusText="Har tilgang"
                     tooltipTextRemove="Fjern tilgang"
                     onRemove={onRemoveOwnerFromBoard}
+                    userEmailsBeingRemoved={userEmailsBeingRemoved}
                 />
                 <SharedWithRows
                     users={invitesMapped}
                     currentUserEmail={user?.uid ?? ''}
                     statusText="Venter på svar"
-                    tooltipTextRemove="Fjern forespørsel"
+                    tooltipTextRemove="Fjern invitasjon"
                     onRemove={onRemoveInviteFromBoard}
+                    userEmailsBeingRemoved={userEmailsBeingRemoved}
                 />
             </TableBody>
         </Table>

--- a/src/containers/Admin/ShareTab/components/SharedWithRows.tsx
+++ b/src/containers/Admin/ShareTab/components/SharedWithRows.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { IconButton } from '@entur/button'
-import { CloseIcon } from '@entur/icons'
+import { CloseIcon, LoadingIcon } from '@entur/icons'
 import { TableRow, DataCell } from '@entur/table'
 import { Tooltip } from '@entur/tooltip'
 
@@ -13,6 +13,7 @@ export const SharedWithRows = ({
     onRemove,
     statusText,
     tooltipTextRemove,
+    userEmailsBeingRemoved,
 }: Props): JSX.Element => {
     const ownersFiltered = users.filter(
         (user) => user.email !== currentUserEmail,
@@ -29,8 +30,15 @@ export const SharedWithRows = ({
                             <IconButton
                                 onClick={() => onRemove(user)}
                                 className="share-page__title__button"
+                                disabled={userEmailsBeingRemoved.includes(
+                                    user.email,
+                                )}
                             >
-                                <CloseIcon />
+                                {userEmailsBeingRemoved.includes(user.email) ? (
+                                    <LoadingIcon />
+                                ) : (
+                                    <CloseIcon />
+                                )}
                             </IconButton>
                         </Tooltip>
                     </DataCell>
@@ -46,6 +54,7 @@ interface Props {
     statusText: string
     tooltipTextRemove: string
     onRemove: (user: BoardOwnersData) => void
+    userEmailsBeingRemoved: string[]
 }
 
 export default SharedWithRows

--- a/src/containers/Admin/ShareTab/index.tsx
+++ b/src/containers/Admin/ShareTab/index.tsx
@@ -7,6 +7,7 @@ import { Heading2, Heading3, Paragraph } from '@entur/typography'
 import { GridItem, GridContainer } from '@entur/grid'
 import { NegativeButton } from '@entur/button'
 
+import { useSettingsContext } from '../../../settings'
 import { useUser } from '../../../auth'
 import { getDocumentId } from '../../../utils'
 import {
@@ -29,6 +30,7 @@ import './styles.scss'
 
 const ShareTab = ({ tabIndex, setTabIndex, locked }: Props): JSX.Element => {
     const user = useUser()
+    const [settings] = useSettingsContext()
 
     const [loginModalOpen, setLoginModalOpen] = useState<boolean>(false)
     const [needToBeOwnerModalOpen, setNeedToBeOwnerModalOpen] =
@@ -62,7 +64,7 @@ const ShareTab = ({ tabIndex, setTabIndex, locked }: Props): JSX.Element => {
         if (user && !user.isAnonymous) {
             if (
                 tabIndex === 5 &&
-                !ownersData.some((owner) => owner.uid === user.uid)
+                !settings?.owners?.some((ownerUID) => ownerUID === user.uid)
             ) {
                 setNeedToBeOwnerModalOpen(true)
             } else {
@@ -70,7 +72,7 @@ const ShareTab = ({ tabIndex, setTabIndex, locked }: Props): JSX.Element => {
                 setNeedToBeOwnerModalOpen(false)
             }
         }
-    }, [user, ownersData, tabIndex, setTabIndex])
+    }, [user, settings?.owners, tabIndex, setTabIndex])
 
     useEffect(() => {
         if (locked) return
@@ -126,7 +128,7 @@ const ShareTab = ({ tabIndex, setTabIndex, locked }: Props): JSX.Element => {
 
     return (
         <div className="share-page">
-            <Heading2 className="heading">Del din tavle med andre</Heading2>
+            <Heading2 className="heading">Del tavla med andre</Heading2>
             <Paragraph>
                 Denne siden lar deg dele den låste tavla di med andre, slik at
                 dere kan samarbeide på&nbsp;den.

--- a/src/containers/MyBoards/index.tsx
+++ b/src/containers/MyBoards/index.tsx
@@ -163,7 +163,7 @@ const MyBoards = (): JSX.Element | null => {
                     <TabList>
                         <Tab>Mine tavler</Tab>
                         <Tab>
-                            Delt med meg
+                            Invitasjoner
                             {sharedBoards.length > 0 ? (
                                 <NotificationBadge
                                     variant="info"

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -417,6 +417,7 @@ export const getOwnersDataByBoardIdAsOwner = async (
     const response = await getOwnersDataByBoardIdAsOwnerFunction({
         boardId,
     } as UploadData)
+
     const ownerData: BoardOwnersData[] = response.data
 
     return ownerData


### PR DESCRIPTION
Etter at den nye delte-tavler-funksjonaliteten ble lagt til i staging ble noen områder for forbedring funnet. Denne PRen inneholder de relevante fiksene. 

## Inkluderer: 
- Varsel med modal om at du må være owner er nå basser på listen av owner fra `settingsContext` og ikke snapshotet som hentes ved update. Dette er gjort av hensyn til hastighet. `settingsContext` er tilgjengelig for oss før `ownersData` er, noe som gjør at man unngår å i noen tilfeller få opp modalen når man faktisk er en eier, men venter på å fetche data. Dette burde heller ikke gå utover sikkerheten, da selv om man skulle greie å manipulere settings til å si at man er en owner, vil fortsatt ingen kall gjort til firestore om å endre ting fungere på grunn av sikkerhetsregler og -sjekker.
- Når man skal fjerne en eier eller invitasjon fra en tavle får man nå opp et lite loading-ikon i `IconButton`-elementet i tillegg til at knappen blir satt til `disabled`. Dette gjør at i situasjoner hvor kallet går tregt så virker ikke tavla lenger uresponsiv. 
- Fanenavnet til der man mottar informasjon om delte tavler er endret fra «Delt med meg» til «Invitasjoner» da dette gir en bedre forståelse av hva fanen fakisk er. 
- Hvis man mister tilgang til en tavle mens man er inne på Rediger vil nå siden lastes inn på nytt og man blir møtt med en infoskjerm om at man ikke lenger har tilgang til tavlen.    