### PR TITLE
Legg til manglende indeksfil for at deploy ikke skal feile

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,15 @@
 {
     "indexes": [],
-    "fieldOverrides": []
+    "fieldOverrides": [
+        {
+            "collectionGroup": "invites",
+            "fieldPath": "receiver",
+            "indexes": [
+                {
+                    "queryScope": "COLLECTION_GROUP",
+                    "order": "ASCENDING"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Deploy to staging gir følgende feil: 

``` firestore: The following field overrides are defined in your project but are not present in your firestore indexes file:
	[invites.receiver] -- (ASCENDING) (DESCENDING) (CONTAINS) (ASCENDING)
? Would you like to delete these field overrides? Selecting no will continue the
 rest of the deployment. (y/N) ? Would you like to delete these field overrides? Selecting no will continue the
 rest of the deployment. (y/N) ? Would you like to delete these field overrides? Selecting no will continue the
 rest of the deployment. (y/N) 

Too long with no output (exceeded 10m0s): context deadline exceeded

```

Denne PRen legger til filen som beskriver indeksen opprettet i firebase console slik at man ikke får spørsmål om man ønsker å overskrive dataen. 

Testet ved å kjøre `firebase deploy -P staging --only firestore:indexes`, og dette fungerte uten problemer.