### PR TITLE
Fix remove self from board not being async await

### DIFF
--- a/src/components/Modals/RemoveSelfFromTavleModal.tsx
+++ b/src/components/Modals/RemoveSelfFromTavleModal.tsx
@@ -26,17 +26,20 @@ const RemoveSelfFromTavleModal = ({
 
     const onRemoveSelfFromTavle = useCallback(
         (remove: boolean) => {
-            if (remove) {
-                removeFromOwners(id, uid)
-                addToast({
-                    title: 'Du ble fjernet fra tavla.',
-                    content:
-                        'Du er ikke lenger en eier av denne tavla og vil ikke ha mulighet til å gjøre endringer i den.',
-                    variant: 'success',
-                })
-                if (forceRefresh) window.location.reload()
+            const asyncRemove = async () => {
+                if (remove) {
+                    await removeFromOwners(id, uid)
+                    addToast({
+                        title: 'Du ble fjernet fra tavla.',
+                        content:
+                            'Du er ikke lenger en eier av denne tavla og vil ikke ha mulighet til å gjøre endringer i den.',
+                        variant: 'success',
+                    })
+                    if (forceRefresh) window.location.reload()
+                }
+                onDismiss()
             }
-            onDismiss()
+            asyncRemove()
         },
         [id, uid, forceRefresh, onDismiss, addToast],
     )


### PR DESCRIPTION
Enda en PR som fikser utilsiktet oppførsel i Shared Boards. Før denne fiksen kunne det hende siden lastet inn på nytt (for å tvinge at rettigheter oppdateres) før man hadde fullført requesten til firestore om å fjerne seg fra `owners`. Dette førte til at man i noen tilfeller ikke klarte å fjerne seg selv fra talva. Ved å legge til den manglende `await`-delen vil nå fjerningen alltid fullføre før siden lastes inn på nytt. 