### PR TITLE
Don't let Dependabot create PRs for major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       open-pull-requests-limit: 3
       ignore:
           - dependency-name: '*'
-            update-types: ['version-update:semver-patch']
+            update-types: ['version-update:semver-major']
 
     # For dependencies in functions directory
     - package-ecosystem: 'npm'
@@ -25,4 +25,4 @@ updates:
       open-pull-requests-limit: 2
       ignore:
           - dependency-name: '*'
-            update-types: ['version-update:semver-patch']
+            update-types: ['version-update:semver-major']


### PR DESCRIPTION
Dependabot should only create PRs for patch and minor updates, which are easier to merge because they should not have any breaking changes.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore