### PR TITLE
Fix crash from missing pointsOnLink

### DIFF
--- a/src/components/Map/RealtimeVehicleTag/TooltipContent/index.tsx
+++ b/src/components/Map/RealtimeVehicleTag/TooltipContent/index.tsx
@@ -53,7 +53,7 @@ const TooltipContent = ({ realtimeVehicle }: Props): JSX.Element => {
                     routeNumber={realtimeVehicle.line.publicCode ?? ''}
                 />
                 <div className="map__realtime-vehicle-tag__tooltip-content-front-text">
-                    {realtimeVehicle.line.lineName.split('=>').pop()?.trim()}
+                    {realtimeVehicle.line.lineName?.split('=>').pop()?.trim()}
                 </div>
             </div>
             <Label

--- a/src/containers/Admin/EditTab/RealtimeDataPanel/PermanentLinesPanel.tsx
+++ b/src/containers/Admin/EditTab/RealtimeDataPanel/PermanentLinesPanel.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+
+import { ExpandablePanel } from '@entur/expand'
+import { ClosedLockIcon } from '@entur/icons'
+
+import { FilterChip } from '@entur/chip'
+
+import { DrawableRoute, Line } from '../../../../types'
+import { Settings } from '../../../../settings'
+import {
+    getIcon,
+    isNotNullOrUndefined,
+    transportModeNameMapper,
+} from '../../../../utils'
+
+import './styles.scss'
+
+type PermanentLinesPanelProps = {
+    realtimeLines: Line[]
+    hiddenRealtimeDataLineRefs: string[]
+    permanentlyVisibleRoutesInMap: DrawableRoute[]
+    setSettings: (settings: Partial<Settings>) => void
+}
+
+function PermanentLinesPanel({
+    realtimeLines,
+    hiddenRealtimeDataLineRefs,
+    permanentlyVisibleRoutesInMap,
+    setSettings,
+}: PermanentLinesPanelProps) {
+    const filteredLines = realtimeLines.filter(
+        (line) => !hiddenRealtimeDataLineRefs.includes(line.id),
+    )
+
+    const sortedLines = filteredLines
+        .sort((a, b) =>
+            transportModeNameMapper(a.transportMode) + a.publicCode >
+            transportModeNameMapper(b.transportMode) + b.publicCode
+                ? 1
+                : -1,
+        )
+        .map(({ id, publicCode, transportMode, pointsOnLink }) =>
+            pointsOnLink
+                ? {
+                      id,
+                      publicCode,
+                      transportMode,
+                      pointsOnLink,
+                  }
+                : undefined,
+        )
+        .filter(isNotNullOrUndefined)
+
+    const handleFilterChipOnChange = (
+        id: string,
+        pointsOnLink: string,
+        transportMode: string,
+    ): void =>
+        permanentlyVisibleRoutesInMap
+            ?.map(({ lineRef }) => lineRef)
+            .includes(id)
+            ? setSettings({
+                  permanentlyVisibleRoutesInMap:
+                      permanentlyVisibleRoutesInMap.filter(
+                          (route) => route.lineRef !== id,
+                      ),
+                  hideRealtimeData: false,
+              })
+            : setSettings({
+                  permanentlyVisibleRoutesInMap: [
+                      ...permanentlyVisibleRoutesInMap,
+                      {
+                          lineRef: id,
+                          pointsOnLink,
+                          mode: transportMode,
+                      },
+                  ],
+                  hideRealtimeData: false,
+              })
+
+    return (
+        <div className="expandable-panel__wrapper">
+            <ExpandablePanel
+                title={
+                    <div className="expandable-panel__title-wrapper">
+                        <span className="expandable-panel__title-icon">
+                            <ClosedLockIcon />
+                        </span>
+                        <span>Permanente rutelinjer</span>
+                    </div>
+                }
+                defaultOpen={filteredLines.length > 0}
+            >
+                <div className="realtime-detail-panel__container">
+                    {sortedLines.map(
+                        ({ id, publicCode, transportMode, pointsOnLink }) => (
+                            <div
+                                className="realtime-detail-panel__buttons"
+                                key={id}
+                            >
+                                <FilterChip
+                                    value={id}
+                                    checked={permanentlyVisibleRoutesInMap
+                                        ?.map(
+                                            (drawableRoute) =>
+                                                drawableRoute.lineRef,
+                                        )
+                                        .includes(id)}
+                                    onChange={() =>
+                                        handleFilterChipOnChange(
+                                            id,
+                                            pointsOnLink,
+                                            transportMode,
+                                        )
+                                    }
+                                >
+                                    {publicCode}
+                                    {getIcon(transportMode)}
+                                </FilterChip>
+                            </div>
+                        ),
+                    )}
+                </div>
+            </ExpandablePanel>
+        </div>
+    )
+}
+
+export default PermanentLinesPanel

--- a/src/containers/Admin/EditTab/RealtimeDataPanel/PermanentLinesPanel.tsx
+++ b/src/containers/Admin/EditTab/RealtimeDataPanel/PermanentLinesPanel.tsx
@@ -7,11 +7,7 @@ import { FilterChip } from '@entur/chip'
 
 import { DrawableRoute, Line } from '../../../../types'
 import { Settings } from '../../../../settings'
-import {
-    getIcon,
-    isNotNullOrUndefined,
-    transportModeNameMapper,
-} from '../../../../utils'
+import { filterMap, getIcon, transportModeNameMapper } from '../../../../utils'
 
 import './styles.scss'
 
@@ -28,37 +24,25 @@ function PermanentLinesPanel({
     permanentlyVisibleRoutesInMap,
     setSettings,
 }: PermanentLinesPanelProps) {
-    const filteredLines = realtimeLines.filter(
-        (line) => !hiddenRealtimeDataLineRefs.includes(line.id),
+    const filteredLines = filterMap(realtimeLines, (line) =>
+        !hiddenRealtimeDataLineRefs.includes(line.id) && line.pointsOnLink
+            ? { ...line, pointsOnLink: line.pointsOnLink }
+            : undefined,
     )
 
-    const sortedLines = filteredLines
-        .sort((a, b) =>
-            transportModeNameMapper(a.transportMode) + a.publicCode >
-            transportModeNameMapper(b.transportMode) + b.publicCode
-                ? 1
-                : -1,
-        )
-        .map(({ id, publicCode, transportMode, pointsOnLink }) =>
-            pointsOnLink
-                ? {
-                      id,
-                      publicCode,
-                      transportMode,
-                      pointsOnLink,
-                  }
-                : undefined,
-        )
-        .filter(isNotNullOrUndefined)
+    const sortedLines = filteredLines.sort((a, b) =>
+        transportModeNameMapper(a.transportMode) + a.publicCode >
+        transportModeNameMapper(b.transportMode) + b.publicCode
+            ? 1
+            : -1,
+    )
 
     const handleFilterChipOnChange = (
         id: string,
         pointsOnLink: string,
         transportMode: string,
     ): void =>
-        permanentlyVisibleRoutesInMap
-            ?.map(({ lineRef }) => lineRef)
-            .includes(id)
+        permanentlyVisibleRoutesInMap.map(({ lineRef }) => lineRef).includes(id)
             ? setSettings({
                   permanentlyVisibleRoutesInMap:
                       permanentlyVisibleRoutesInMap.filter(

--- a/src/containers/Admin/EditTab/RealtimeDataPanel/index.tsx
+++ b/src/containers/Admin/EditTab/RealtimeDataPanel/index.tsx
@@ -5,7 +5,6 @@ import { Switch, TravelSwitch } from '@entur/form'
 import { Loader } from '@entur/loader'
 import { Heading3, Label, Paragraph } from '@entur/typography'
 import { ExpandablePanel } from '@entur/expand'
-import { ClosedLockIcon } from '@entur/icons'
 
 import { Line } from '../../../../types'
 import {
@@ -17,6 +16,7 @@ import {
 import { useSettingsContext } from '../../../../settings'
 
 import './styles.scss'
+import PermanentLinesPanel from './PermanentLinesPanel'
 
 interface Props {
     realtimeLines: Line[] | undefined
@@ -69,9 +69,19 @@ const RealtimeDataPanel = ({
         [hiddenRealtimeDataLineRefs, setSettings],
     )
 
-    return !realtimeLines ? (
-        <Loader>Laster...</Loader>
-    ) : realtimeLines.length > 0 ? (
+    if (!realtimeLines) {
+        return <Loader>Laster...</Loader>
+    }
+
+    if (realtimeLines.length === 0) {
+        return (
+            <Paragraph>
+                Ingen sanntidsdata å vise for stasjonene og modusene som er
+                valgt.
+            </Paragraph>
+        )
+    }
+    return (
         <div className="realtime-detail-panel">
             <div className="realtime-detail-panel__realtime-selection-panel">
                 {modes.map((mode) => (
@@ -218,120 +228,20 @@ const RealtimeDataPanel = ({
                                 hideRealtimeData: false,
                             })
                         }}
-                    ></Switch>
+                    />
                 </div>
                 {showRoutesInMap && (
-                    <div className="expandable-panel__wrapper">
-                        <ExpandablePanel
-                            title={
-                                <div className="expandable-panel__title-wrapper">
-                                    <span className="expandable-panel__title-icon">
-                                        <ClosedLockIcon></ClosedLockIcon>
-                                    </span>
-                                    <span>Permanente rutelinjer</span>
-                                </div>
-                            }
-                            defaultOpen={
-                                realtimeLines.filter(
-                                    (line) =>
-                                        !hiddenRealtimeDataLineRefs.includes(
-                                            line.id,
-                                        ),
-                                ).length > 0
-                            }
-                        >
-                            <div className="realtime-detail-panel__container">
-                                {realtimeLines
-                                    .filter(
-                                        (line) =>
-                                            !hiddenRealtimeDataLineRefs.includes(
-                                                line.id,
-                                            ),
-                                    )
-                                    .sort((a, b) =>
-                                        transportModeNameMapper(
-                                            a.transportMode,
-                                        ) +
-                                            a.publicCode >
-                                        transportModeNameMapper(
-                                            b.transportMode,
-                                        ) +
-                                            b.publicCode
-                                            ? 1
-                                            : -1,
-                                    )
-                                    .map(
-                                        ({
-                                            id,
-                                            publicCode,
-                                            transportMode,
-                                            pointsOnLink,
-                                        }) => (
-                                            <div
-                                                className="realtime-detail-panel__buttons"
-                                                key={id}
-                                            >
-                                                <FilterChip
-                                                    value={id}
-                                                    checked={permanentlyVisibleRoutesInMap
-                                                        ?.map(
-                                                            (drawableRoute) =>
-                                                                drawableRoute.lineRef,
-                                                        )
-                                                        .includes(id)}
-                                                    onChange={() =>
-                                                        permanentlyVisibleRoutesInMap
-                                                            ?.map(
-                                                                (
-                                                                    drawableRoute,
-                                                                ) =>
-                                                                    drawableRoute.lineRef,
-                                                            )
-                                                            .includes(id)
-                                                            ? setSettings({
-                                                                  permanentlyVisibleRoutesInMap:
-                                                                      permanentlyVisibleRoutesInMap.filter(
-                                                                          (
-                                                                              route,
-                                                                          ) =>
-                                                                              route.lineRef !==
-                                                                              id,
-                                                                      ),
-                                                                  hideRealtimeData:
-                                                                      false,
-                                                              })
-                                                            : setSettings({
-                                                                  permanentlyVisibleRoutesInMap:
-                                                                      [
-                                                                          ...permanentlyVisibleRoutesInMap,
-                                                                          {
-                                                                              lineRef:
-                                                                                  id,
-                                                                              pointsOnLink,
-                                                                              mode: transportMode,
-                                                                          },
-                                                                      ],
-                                                                  hideRealtimeData:
-                                                                      false,
-                                                              })
-                                                    }
-                                                >
-                                                    {publicCode}
-                                                    {getIcon(transportMode)}
-                                                </FilterChip>
-                                            </div>
-                                        ),
-                                    )}
-                            </div>
-                        </ExpandablePanel>
-                    </div>
+                    <PermanentLinesPanel
+                        realtimeLines={realtimeLines}
+                        hiddenRealtimeDataLineRefs={hiddenRealtimeDataLineRefs}
+                        permanentlyVisibleRoutesInMap={
+                            permanentlyVisibleRoutesInMap
+                        }
+                        setSettings={setSettings}
+                    />
                 )}
             </div>
         </div>
-    ) : (
-        <Paragraph>
-            Ingen sanntidsdata å vise for stasjonene og modusene som er valgt.
-        </Paragraph>
     )
 }
 

--- a/src/logic/getStopPlacesWithLines.ts
+++ b/src/logic/getStopPlacesWithLines.ts
@@ -69,7 +69,7 @@ interface EstimatedCall {
             transportSubmode: TransportSubmode
             publicCode: string
         }
-        pointsOnLink: {
+        pointsOnLink?: {
             points: string
         }
     }
@@ -131,7 +131,7 @@ export async function getStopPlacesWithLines(
                 .map(({ destinationDisplay, serviceJourney }) => ({
                     ...serviceJourney.line,
                     name: `${serviceJourney.line.publicCode} ${destinationDisplay.frontText}`,
-                    pointsOnLink: serviceJourney.pointsOnLink.points,
+                    pointsOnLink: serviceJourney.pointsOnLink?.points,
                 }))
 
             const uniqueLines = unique(

--- a/src/services/realtimeVehicles/types/line.ts
+++ b/src/services/realtimeVehicles/types/line.ts
@@ -1,6 +1,6 @@
 export type Line = {
     lineRef: string
-    lineName: string
+    lineName?: string
     publicCode?: string
     pointsOnLink?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Line {
     transportMode: TransportMode
     transportSubmode: TransportSubmode
     publicCode: string
-    pointsOnLink: string
+    pointsOnLink?: string
 }
 
 export interface DrawableRoute {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -39,6 +39,17 @@ export function isNotNullOrUndefined<T>(
     return thing !== undefined && thing !== null
 }
 
+export function filterMap<A, B>(
+    arr: A[],
+    mapper: (item: A, index: number, array: A[]) => B | undefined,
+): B[] {
+    return arr.reduce((acc: B[], item: A, index, array) => {
+        const b = mapper(item, index, array)
+        if (b === undefined) return acc
+        return [...acc, b]
+    }, [])
+}
+
 function isSubModeAirportLink(subMode?: string): boolean {
     if (!subMode) return false
     const airportLinkTypes = ['airportLinkRail', 'airportLinkBus']


### PR DESCRIPTION
`pointsOnLink` can be undefined, and this caused a crash when creating
`stops` in `getStopPlacesWithLines.ts:124`.

Fixed types to handle undefined values, and refactored `RealtimeDataPanel`
where `pointsOnLink` was used.

Also added util function, `filterMap`.