### PR TITLE
Downgrade to Node 14 because of build issues with node-gyp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
 jobs:
     build:
         docker:
-            - image: cimg/node:16.14
+            - image: cimg/node:14.18
 
         working_directory: ~/Tavla
 
@@ -39,7 +39,7 @@ jobs:
 
     deploy:
         docker:
-            - image: cimg/node:16.14
+            - image: cimg/node:14.18
 
         working_directory: ~/Tavla
 
@@ -57,7 +57,7 @@ jobs:
             - slack/status: *slack-status-prod
     deploy-staging:
         docker:
-            - image: cimg/node:16.14
+            - image: cimg/node:14.18
 
         working_directory: ~/Tavla
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
         "logs": "firebase functions:log"
     },
     "engines": {
-        "node": "16",
+        "node": "14",
         "npm": "8"
     },
     "main": "lib/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
                 "webpack-dev-server": "^4.7.4"
             },
             "engines": {
-                "node": "16",
+                "node": "14",
                 "npm": "8"
             }
         },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/entur/tavla/"
     },
     "engines": {
-        "node": "16",
+        "node": "14",
         "npm": "8"
     },
     "main": "index.js",


### PR DESCRIPTION
Using Node 16 leads to some serious `node-gyp` related issues with npm install that we haven't been able to solve.