### PR TITLE
Avoid errors if AbortController not supported

### DIFF
--- a/src/components/WeatherTile/index.tsx
+++ b/src/components/WeatherTile/index.tsx
@@ -3,7 +3,11 @@ import React, { useEffect, useState } from 'react'
 import { CloudRainIcon, UmbrellaIcon, WindIcon } from '@entur/icons'
 
 import { useWeather } from '../../logic'
-import { getWeatherDescriptionFromApi, getWeatherIconEntur } from '../../utils'
+import {
+    createAbortController,
+    getWeatherDescriptionFromApi,
+    getWeatherIconEntur,
+} from '../../utils'
 import { useSettingsContext } from '../../settings'
 
 import './styles.scss'
@@ -35,7 +39,7 @@ function WeatherTile(props: Props): JSX.Element {
     const [description, setDescription] = useState('')
 
     useEffect(() => {
-        const abortController = new AbortController()
+        const abortController = createAbortController()
 
         if (weather) {
             if (

--- a/src/containers/Admin/EditTab/BikeSearch/index.tsx
+++ b/src/containers/Admin/EditTab/BikeSearch/index.tsx
@@ -6,7 +6,7 @@ import { Station } from '@entur/sdk/lib/mobility/types'
 
 import service from '../../../../service'
 
-import { getTranslation } from '../../../../utils'
+import { createAbortController, getTranslation } from '../../../../utils'
 
 import './styles.scss'
 
@@ -28,7 +28,7 @@ const BikePanelSearch = ({ onSelected, position }: Props): JSX.Element => {
     const [stations, setStations] = useState<Station[]>([])
 
     useEffect(() => {
-        const controller = new AbortController()
+        const controller = createAbortController()
         if (position) {
             service.mobility
                 .getStations(
@@ -45,7 +45,7 @@ const BikePanelSearch = ({ onSelected, position }: Props): JSX.Element => {
                     setStations(data)
                 })
                 .catch((err) => {
-                    if (!controller.signal.aborted) {
+                    if (!controller.signal?.aborted) {
                         throw err
                     }
                 })

--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -5,10 +5,11 @@ import { Station } from '@entur/sdk/lib/mobility/types'
 
 import service from '../service'
 import { useSettingsContext } from '../settings'
+import { createAbortController } from '../utils'
 
 async function fetchBikeRentalStationsById(
     allStationIds: string[],
-    signal: AbortSignal,
+    signal?: AbortSignal,
 ): Promise<Station[] | null> {
     const allStations = await service.mobility.getStationsById(
         {
@@ -22,7 +23,7 @@ async function fetchBikeRentalStationsById(
 async function fetchBikeRentalStationsNearby(
     coordinates: Coordinates,
     distance: number,
-    signal: AbortSignal,
+    signal?: AbortSignal,
 ): Promise<Station[] | null> {
     const allStations = await service.mobility.getStations(
         {
@@ -58,7 +59,7 @@ export default function useBikeRentalStations(
     const isDisabled = Boolean(hiddenModes?.includes('bysykkel'))
 
     useEffect(() => {
-        const abortController = new AbortController()
+        const abortController = createAbortController()
         if (!coordinates || !distance || isDisabled) {
             return setBikeRentalStations(null)
         }
@@ -78,7 +79,7 @@ export default function useBikeRentalStations(
     }, [coordinates, distance, isDisabled])
 
     useEffect(() => {
-        const abortController = new AbortController()
+        const abortController = createAbortController()
         if (isDisabled) {
             return setBikeRentalStations(null)
         }

--- a/src/logic/useMobility.ts
+++ b/src/logic/useMobility.ts
@@ -8,13 +8,15 @@ import service from '../service'
 import { useSettingsContext } from '../settings'
 import { REFRESH_INTERVAL } from '../constants'
 
+import { createAbortController } from '../utils'
+
 import { useOperators } from '.'
 
 async function fetchVehicles(
     coordinates: Coordinates,
     distance: number,
     operators: Operator[],
-    signal: AbortSignal,
+    signal?: AbortSignal,
     formFactor?: FormFactor,
 ): Promise<Vehicle[]> {
     if (!coordinates || !distance || !operators?.length) {
@@ -57,7 +59,7 @@ export default function useMobility(formFactor?: FormFactor): Vehicle[] | null {
     const isDisabled = Boolean(hiddenModes?.includes('sparkesykkel'))
 
     useEffect(() => {
-        const abortController = new AbortController()
+        const abortController = createAbortController()
         if (!coordinates || !distance || isDisabled) {
             return setVehicles(null)
         }

--- a/src/logic/useStopPlacesWithLines.ts
+++ b/src/logic/useStopPlacesWithLines.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { Line, StopPlaceWithLines } from '../types'
-import { unique } from '../utils'
+import { createAbortController, unique } from '../utils'
 
 import { useSettingsContext } from '../settings'
 
@@ -25,7 +25,7 @@ export const useStopPlacesWithLines = (): Return => {
     >([])
 
     useEffect(() => {
-        const abortController = new AbortController()
+        const abortController = createAbortController()
         const fetchDataAndSetStates = async () => {
             if (!stopPlaces) return
             try {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -381,7 +381,7 @@ export function isEqualUnsorted<T>(array: T[], includes: T[]): boolean {
 
 export const getWeatherDescriptionFromApi = async (
     iconName: string,
-    signal: AbortSignal,
+    signal?: AbortSignal,
 ): Promise<string> => {
     const weatherNameMatch = iconName.match(/.+?(?=_|$)/)
     if (!weatherNameMatch)
@@ -494,4 +494,21 @@ export function createTimeString(date: Date): string {
 export function nonEmpty<A>(arr: A[]): NonEmpty<A> | undefined {
     if (arr[0]) return arr as NonEmpty<A>
     return undefined
+}
+
+export function createAbortController():
+    | AbortController
+    | { signal: undefined; abort: () => void } {
+    try {
+        return createAbortController()
+    } catch (error) {
+        /**
+         * AbortController is not supported by this browser.
+         * We make a fake one that does nothing.
+         */
+        return {
+            signal: undefined,
+            abort: () => undefined,
+        }
+    }
 }


### PR DESCRIPTION
AbortController is not supported by all browsers. But our usage of the abort controller is more an optimization than critical functionality. So this fake AbortController stub should be good enough.