### PR TITLE
Bug fix for stop places nearby

### DIFF
--- a/src/logic/useNearestPlaces.ts
+++ b/src/logic/useNearestPlaces.ts
@@ -91,7 +91,7 @@ export default function useNearestPlaces(
                     latitude,
                     longitude,
                     maximumDistance: distance,
-                    filterByPlaceTypes: ['stopPlace', 'bicycleRent'],
+                    filterByPlaceTypes: ['stopPlace'],
                     multiModalMode: 'parent',
                 },
             })


### PR DESCRIPTION
Fixes a bug were the list of nearby stop places did not list all the relevant, because bike rental stations and scooters also was listed in the result list