### PR TITLE
ETU-25891: Indicate next day on departures

### DIFF
--- a/src/components/DateRow/index.tsx
+++ b/src/components/DateRow/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { format, isSameDay } from 'date-fns'
+import { nb } from 'date-fns/locale'
+
+import { DataCell, TableRow } from '@entur/table'
+import { Heading4 } from '@entur/typography'
+
+import { LineData } from '../../types'
+
+import './styles.scss'
+
+export function DateRow({ previousRow, currentRow }: Props) {
+    const isNewDay =
+        previousRow &&
+        !isSameDay(previousRow.departureTime, currentRow.departureTime)
+
+    const formatedDate = format(currentRow.departureTime, 'EEEE d. MMMM', {
+        locale: nb,
+    })
+
+    return isNewDay ? (
+        <TableRow className="date-row">
+            <DataCell>
+                <Heading4 as="h3">{formatedDate}</Heading4>
+            </DataCell>
+        </TableRow>
+    ) : null
+}
+
+type Props = {
+    previousRow?: LineData
+    currentRow: LineData
+}

--- a/src/components/DateRow/styles.scss
+++ b/src/components/DateRow/styles.scss
@@ -1,0 +1,6 @@
+.date-row {
+    border-bottom: none !important;
+    text-transform: capitalize;
+    width: max-content;
+    white-space: nowrap;
+}

--- a/src/dashboards/BusStop/components/TileRows/index.tsx
+++ b/src/dashboards/BusStop/components/TileRows/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import { Heading3 } from '@entur/typography'
 
@@ -9,6 +9,8 @@ import { IconColorType, LineData } from '../../../../types'
 import SituationModal from '../../../../components/SituationModal'
 import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
 import SubLabelIcon from '../SubLabelIcon'
+
+import { DateRow } from '../../../../components/DateRow'
 
 import './styles.scss'
 
@@ -22,45 +24,53 @@ export function TileRows({
 }: Props): JSX.Element {
     return (
         <TableBody>
-            {visibleDepartures.map((data) => {
+            {visibleDepartures.map((data, index) => {
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
+                const previousRow = visibleDepartures[index - 1]
+
                 return (
-                    <TableRow key={data.id} className="tilerow">
-                        <DataCell>
-                            <div className="tilerow__icon">{icon}</div>
-                        </DataCell>
-                        <DataCell>
-                            <Heading3 className="tilerow__label">
-                                {data.route}
-                            </Heading3>
-                        </DataCell>
-                        <DataCell>
-                            <div className="tilerow__sublabel">
-                                {subLabel.time}
-                            </div>
-                        </DataCell>
-                        {!hideTracks ? (
+                    <Fragment key={data.id}>
+                        <DateRow
+                            currentRow={data}
+                            previousRow={previousRow}
+                        ></DateRow>
+                        <TableRow className="tilerow">
+                            <DataCell>
+                                <div className="tilerow__icon">{icon}</div>
+                            </DataCell>
+                            <DataCell>
+                                <Heading3 className="tilerow__label">
+                                    {data.route}
+                                </Heading3>
+                            </DataCell>
                             <DataCell>
                                 <div className="tilerow__sublabel">
-                                    {data.quay?.publicCode || '-'}
+                                    {subLabel.time}
                                 </div>
                             </DataCell>
-                        ) : null}
-                        {!hideSituations ? (
-                            <DataCell>
-                                {isMobile && data?.situation ? (
-                                    <SituationModal
-                                        situationMessage={data?.situation}
-                                    />
-                                ) : (
-                                    <SubLabelIcon
-                                        subLabel={createTileSubLabel(data)}
-                                    />
-                                )}
-                            </DataCell>
-                        ) : null}
-                    </TableRow>
+                            {!hideTracks ? (
+                                <DataCell>
+                                    <div className="tilerow__sublabel">
+                                        {data.quay?.publicCode || '-'}
+                                    </div>
+                                </DataCell>
+                            ) : null}
+                            {!hideSituations ? (
+                                <DataCell>
+                                    {isMobile && data?.situation ? (
+                                        <SituationModal
+                                            situationMessage={data?.situation}
+                                        />
+                                    ) : (
+                                        <SubLabelIcon
+                                            subLabel={createTileSubLabel(data)}
+                                        />
+                                    )}
+                                </DataCell>
+                            ) : null}
+                        </TableRow>
+                    </Fragment>
                 )
             })}
         </TableBody>

--- a/src/dashboards/Chrono/BikeTile/index.tsx
+++ b/src/dashboards/Chrono/BikeTile/index.tsx
@@ -75,12 +75,14 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                                 station.numBikesAvailable === 1
                                     ? '1 sykkel'
                                     : `${station.numBikesAvailable} sykler`,
+                            departureTime: new Date(),
                         },
                         {
                             time:
                                 station.numDocksAvailable === 1
                                     ? '1 lås'
                                     : `${station.numBikesAvailable} låser`,
+                            departureTime: new Date(),
                         },
                     ]}
                 />

--- a/src/dashboards/Chrono/components/TileRows/index.tsx
+++ b/src/dashboards/Chrono/components/TileRows/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import { Heading3 } from '@entur/typography'
 
@@ -10,6 +10,7 @@ import { IconColorType, LineData, TileSubLabel } from '../../../../types'
 
 import SituationModal from '../../../../components/SituationModal'
 import { createTileSubLabel, getIcon, isMobileWeb } from '../../../../utils'
+import { DateRow } from '../../../../components/DateRow'
 
 import './styles.scss'
 
@@ -23,42 +24,50 @@ export function TileRows({
 }: Props): JSX.Element {
     return (
         <TableBody>
-            {visibleDepartures.map((data) => {
+            {visibleDepartures.map((data, index) => {
                 const icon = getIcon(data.type, iconColorType, data.subType)
                 const subLabel = createTileSubLabel(data)
+                const previousRow = visibleDepartures[index - 1]
+
                 return (
-                    <TableRow key={data.id} className="tilerows">
-                        <DataCell>
-                            <div className="tilerows__icon">{icon}</div>
-                        </DataCell>
-                        <DataCell>
-                            <Heading3 className="tilerows__label">
-                                {data.route}
-                            </Heading3>
-                        </DataCell>
-                        <DataCell>
-                            <div className="tilerows__sublabel">
-                                {subLabel.time}
-                            </div>
-                        </DataCell>
-                        {!hideTracks ? (
+                    <Fragment key={data.id}>
+                        <DateRow
+                            currentRow={data}
+                            previousRow={previousRow}
+                        ></DateRow>
+                        <TableRow className="tilerows">
+                            <DataCell>
+                                <div className="tilerows__icon">{icon}</div>
+                            </DataCell>
+                            <DataCell>
+                                <Heading3 as="div" className="tilerows__label">
+                                    {data.route}
+                                </Heading3>
+                            </DataCell>
                             <DataCell>
                                 <div className="tilerows__sublabel">
-                                    {data.quay?.publicCode || '-'}
+                                    {subLabel.time}
                                 </div>
                             </DataCell>
-                        ) : null}
-                        {!hideSituations ? (
-                            <DataCell>
-                                <div className="tilerows__sublabel">
-                                    <SubLabelIcon
-                                        hideSituations={hideSituations}
-                                        subLabel={subLabel}
-                                    />
-                                </div>
-                            </DataCell>
-                        ) : null}
-                    </TableRow>
+                            {!hideTracks ? (
+                                <DataCell>
+                                    <div className="tilerows__sublabel">
+                                        {data.quay?.publicCode || '-'}
+                                    </div>
+                                </DataCell>
+                            ) : null}
+                            {!hideSituations ? (
+                                <DataCell>
+                                    <div className="tilerows__sublabel">
+                                        <SubLabelIcon
+                                            hideSituations={hideSituations}
+                                            subLabel={subLabel}
+                                        />
+                                    </div>
+                                </DataCell>
+                            ) : null}
+                        </TableRow>
+                    </Fragment>
                 )
             })}
         </TableBody>

--- a/src/dashboards/Compact/BikeTile/index.tsx
+++ b/src/dashboards/Compact/BikeTile/index.tsx
@@ -76,12 +76,14 @@ const BikeTile = ({ stations }: Props): JSX.Element => {
                                 station.numBikesAvailable === 1
                                     ? '1 sykkel'
                                     : `${station.numBikesAvailable} sykler`,
+                            departureTime: new Date(),
                         },
                         {
                             time:
                                 station.numDocksAvailable === 1
                                     ? '1 lås'
                                     : `${station.numDocksAvailable} låser`,
+                            departureTime: new Date(),
                         },
                     ]}
                 />

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 
+import { format, isSameDay, isToday } from 'date-fns'
+
+import { nb } from 'date-fns/locale'
+
 import { Heading3 } from '@entur/typography'
 
 import { TileSubLabel } from '../../../../types'
@@ -50,15 +54,36 @@ export function TileRow({
                     </div>
                 ) : null}
                 <div className="tilerow__sublabels">
-                    {subLabels.map((subLabel, index) => (
-                        <div className="tilerow__sublabel" key={index}>
-                            {subLabel.time}
-                            <SubLabelIcon
-                                hideSituations={hideSituations}
-                                subLabel={subLabel}
-                            />
-                        </div>
-                    ))}
+                    {subLabels.map((subLabel, index) => {
+                        const nextLabel: TileSubLabel | undefined =
+                            subLabels[index + 1]
+
+                        const isLastDepartureOfDay =
+                            nextLabel &&
+                            !isSameDay(
+                                nextLabel.departureTime,
+                                subLabel.departureTime,
+                            )
+
+                        const showDate =
+                            index === 0 && !isToday(subLabel.departureTime)
+
+                        return (
+                            <div className="tilerow__sublabel" key={index}>
+                                {subLabel.time}
+
+                                <SubLabelIcon
+                                    hideSituations={hideSituations}
+                                    subLabel={subLabel}
+                                />
+                                {isLastDepartureOfDay && <Divider />}
+
+                                {showDate && (
+                                    <Date date={subLabel.departureTime} />
+                                )}
+                            </div>
+                        )
+                    })}
                 </div>
             </div>
         </div>
@@ -93,6 +118,16 @@ function SubLabelIcon({
             </div>
         )
     return null
+}
+
+function Divider() {
+    return <div className="tilerow__sublabel__divider"></div>
+}
+
+function Date({ date }: { date: Date }) {
+    const formatedDate = format(date, 'd. MMMM', { locale: nb })
+
+    return <div className="tilerow__sublabel__date">{`(${formatedDate})`}</div>
 }
 
 interface Props {

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -68,6 +68,18 @@
             width: 0.875rem;
         }
 
+        &__date {
+            color: var(--tavla-label-font-color);
+            margin-left: 0.5rem;
+        }
+
+        &__divider {
+            border-left: 2px solid var(--tavla-label-font-color);
+            height: 100%;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
         &__situation {
             font-size: 1.125rem;
             height: 1.25rem;

--- a/src/dashboards/Map/DepartureTag/index.tsx
+++ b/src/dashboards/Map/DepartureTag/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
 
+import { format, isToday } from 'date-fns'
+import { nb } from 'date-fns/locale'
+
 import { colors } from '@entur/tokens'
 import { Heading4 } from '@entur/typography'
 
@@ -46,12 +49,21 @@ const DepartureTag = (props: Props): JSX.Element => (
                     <div className="departure-row__departure">
                         {departure.time}
                     </div>
+                    {isToday(departure.departureTime) ? null : (
+                        <Date date={departure.departureTime} />
+                    )}
                 </div>
             ))}
         </div>
         <div className="divider"></div>
     </div>
 )
+
+function Date({ date }: { date: Date }) {
+    const formatedDate = format(date, 'd. MMMM', { locale: nb })
+
+    return <div className="departure-row__date">{`(${formatedDate})`}</div>
+}
 
 interface Props {
     stopPlace: StopPlaceWithDepartures

--- a/src/dashboards/Map/DepartureTag/styles.scss
+++ b/src/dashboards/Map/DepartureTag/styles.scss
@@ -39,6 +39,11 @@
     margin-bottom: 1.5rem;
     padding-top: 0.5rem;
 
+    &__date {
+        color: $colors-greys-grey30;
+        margin-left: 0.5rem;
+    }
+
     &__direction {
         flex: 1;
         display: flex;

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -167,6 +167,7 @@ function transformDepartureToLineData(
         type: transportMode,
         subType,
         time: formatDeparture(minDiff, departureTime),
+        departureTime,
         route,
         situation: situations[0]?.summary?.[0]?.value,
         hasCancellation: cancellation,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface LineData {
     type: TransportMode
     subType?: TransportSubmode
     time: string
+    departureTime: Date
     route: string
     expectedDepartureTime: string
     situation?: string
@@ -48,6 +49,7 @@ export interface NearestPlaces {
 export interface TileSubLabel {
     situation?: string
     time: string
+    departureTime: Date
     hasCancellation?: boolean
     hasSituation?: boolean
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -211,12 +211,14 @@ export function createTileSubLabel({
     situation,
     hasCancellation,
     time,
+    departureTime,
 }: LineData): TileSubLabel {
     return {
         situation,
         hasSituation: Boolean(situation),
         hasCancellation,
         time,
+        departureTime,
     }
 }
 


### PR DESCRIPTION
- Implemented for Compact, Chrono, BusStop and Map

[Kan testes i staging](https://tavla.staging.entur.no/t/ggmVjIorQJi3sWD3FYUU)

Compact:
![bilde](https://user-images.githubusercontent.com/7575185/165504785-985e4d14-66dc-407d-8a66-03178e976de9.png)

Chrono:
![bilde](https://user-images.githubusercontent.com/7575185/165504892-fcc80bd7-681f-4059-851e-4c562252df0f.png)

BusStop:
![bilde](https://user-images.githubusercontent.com/7575185/165504993-c0a7b4c6-1160-487d-b118-59331c1f700a.png)

Map:
![bilde](https://user-images.githubusercontent.com/7575185/165505126-e1a33a6b-36c0-408b-a9f6-7ca253baaae3.png)
