### PR TITLE
ETU-25891: Fix date styling issue

### DIFF
--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -8,6 +8,7 @@ import {
     createTileSubLabel,
     getIconColorType,
     isNotNullOrUndefined,
+    filterMap,
 } from '../../../utils'
 import {
     StopPlaceWithDepartures,
@@ -66,30 +67,28 @@ const DepartureTile = ({
             icons={getTransportHeaderIcons(departures, iconColorType)}
             walkInfo={!hideWalkInfo ? walkInfo : undefined}
         >
-            {routes
-                .map((route) => {
-                    const routeData = groupedDepartures[route]
-                    const firstRouteData = routeData && routeData[0]
-                    if (!firstRouteData) return
+            {filterMap(routes, (route) => {
+                const routeData = groupedDepartures[route]
+                const firstRouteData = routeData && routeData[0]
+                if (!firstRouteData) return
 
-                    const subType = firstRouteData.subType
-                    const routeType = firstRouteData.type
-                    const icon = getIcon(routeType, iconColorType, subType)
-                    const platform = firstRouteData.quay?.publicCode
-                    return (
-                        <TileRow
-                            key={route}
-                            label={route}
-                            subLabels={routeData.map(createTileSubLabel)}
-                            icon={icon}
-                            hideSituations={hideSituations}
-                            hideTracks={hideTracks}
-                            platform={platform}
-                            type={routeType}
-                        />
-                    )
-                })
-                .filter(isNotNullOrUndefined)}
+                const subType = firstRouteData.subType
+                const routeType = firstRouteData.type
+                const icon = getIcon(routeType, iconColorType, subType)
+                const platform = firstRouteData.quay?.publicCode
+                return (
+                    <TileRow
+                        key={route}
+                        label={route}
+                        subLabels={routeData.map(createTileSubLabel)}
+                        icon={icon}
+                        hideSituations={hideSituations}
+                        hideTracks={hideTracks}
+                        platform={platform}
+                        type={routeType}
+                    />
+                )
+            })}
         </Tile>
     )
 }

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
-import { format, isSameDay, isToday } from 'date-fns'
+import { format, isSameDay, isToday, formatISO } from 'date-fns'
 
 import { nb } from 'date-fns/locale'
 
@@ -68,20 +68,26 @@ export function TileRow({
                         const showDate =
                             index === 0 && !isToday(subLabel.departureTime)
 
+                        const isoDate = formatISO(subLabel.departureTime)
+
                         return (
-                            <div className="tilerow__sublabel" key={index}>
-                                {subLabel.time}
+                            <Fragment key={index}>
+                                <div className="tilerow__sublabel">
+                                    <time dateTime={isoDate}>
+                                        {subLabel.time}
+                                    </time>
 
-                                <SubLabelIcon
-                                    hideSituations={hideSituations}
-                                    subLabel={subLabel}
-                                />
+                                    <SubLabelIcon
+                                        hideSituations={hideSituations}
+                                        subLabel={subLabel}
+                                    />
+
+                                    {showDate && (
+                                        <Date date={subLabel.departureTime} />
+                                    )}
+                                </div>
                                 {isLastDepartureOfDay && <Divider />}
-
-                                {showDate && (
-                                    <Date date={subLabel.departureTime} />
-                                )}
-                            </div>
+                            </Fragment>
                         )
                     })}
                 </div>
@@ -121,7 +127,7 @@ function SubLabelIcon({
 }
 
 function Divider() {
-    return <div className="tilerow__sublabel__divider"></div>
+    return <div role="separator" className="tilerow__sublabel__divider"></div>
 }
 
 function Date({ date }: { date: Date }) {

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -55,7 +55,12 @@
         align-items: center;
         display: flex;
         font-weight: 400;
-        min-width: 6.5rem;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
+
+        &:first-child {
+            padding-left: 0;
+        }
 
         &__cancellation {
             align-items: center;
@@ -75,9 +80,6 @@
 
         &__divider {
             border-left: 2px solid var(--tavla-label-font-color);
-            height: 100%;
-            margin-left: auto;
-            margin-right: auto;
         }
 
         &__situation {

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -25,6 +25,7 @@ const GET_STOP_PLACES_WITH_DEPARTURES_QUERY = gql`
             transportSubmode
             estimatedCalls(
                 numberOfDepartures: 200
+                timeRange: 172800
                 numberOfDeparturesPerLineAndDestinationDisplay: 20
                 arrivalDeparture: departures
             ) {


### PR DESCRIPTION
In compact view the date was pushed under the next time item on small screens. Fixed using equal padding between items.

Also:
- moved divider between items
- Ask for departures the next two days (172800 seconds. Default was 1 day)