### PR TITLE
Refresh Tavle from admin panel

### DIFF
--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -21,6 +21,8 @@ import { ValidationInfoIcon } from '@entur/icons'
 
 import { Station } from '@entur/sdk/lib/mobility/types'
 
+import { Button } from '@entur/button'
+
 import { useSettingsContext, Mode } from '../../../settings'
 
 import {
@@ -35,6 +37,7 @@ import { DEFAULT_DISTANCE, DEFAULT_ZOOM } from '../../../constants'
 import { Line, StopPlaceWithLines } from '../../../types'
 import { useNearestPlaces, useBikeRentalStations } from '../../../logic'
 import { getStopPlacesWithLines } from '../../../logic/getStopPlacesWithLines'
+
 import {
     saveToLocalStorage,
     getFromLocalStorage,
@@ -342,6 +345,7 @@ const EditTab = (): JSX.Element => {
                 w: 1.5,
                 h: settings?.showMap ? 3.2 : 0.9,
             },
+            { i: 'refreshTavlePanel', x: 3, y: 0, w: 1.5, h: 1.65 },
             { i: 'weatherPanel', x: 3, y: 0, w: 1.5, h: 1.5 },
             {
                 i: 'realtimeDataPanel',
@@ -387,6 +391,7 @@ const EditTab = (): JSX.Element => {
             },
             { i: 'scooterPanel', x: 2, y: 3, w: 1, h: 1.75 },
             { i: 'mapPanel', x: 0, y: 7, w: 2, h: settings?.showMap ? 3 : 0.8 },
+            { i: 'refreshTavlePanel', x: 0, y: 4.5, w: 2, h: 1.7 },
             { i: 'weatherPanel', x: 0, y: 4.5, w: 2, h: 1.3 },
             {
                 i: 'realtimeDataPanel',
@@ -438,6 +443,7 @@ const EditTab = (): JSX.Element => {
                 w: 1,
                 h: settings?.showMap ? 3 : 0.8,
             },
+            { i: 'refreshTavlePanel', x: 0, y: 8, w: 1, h: 1.6 },
             { i: 'weatherPanel', x: 0, y: 8, w: 1, h: 1.3 },
             {
                 i: 'realtimeDataPanel',
@@ -489,7 +495,8 @@ const EditTab = (): JSX.Element => {
                 w: 1,
                 h: settings?.showMap ? 3 : 0.8,
             },
-            { i: 'weatherPanel', x: 0, y: 8, w: 1, h: 1.5 },
+            { i: 'refreshTavlePanel', x: 0, y: 8, w: 1, h: 1.8 },
+            { i: 'weatherPanel', x: 0, y: 8, w: 1, h: 2.5 },
             {
                 i: 'realtimeDataPanel',
                 x: 0,
@@ -540,6 +547,7 @@ const EditTab = (): JSX.Element => {
                 w: 1,
                 h: settings?.showMap ? 3 : 0.8,
             },
+            { i: 'refreshTavlePanel', x: 0, y: 8, w: 1, h: 1.8 },
             { i: 'weatherPanel', x: 0, y: 8, w: 1, h: 2 },
             {
                 i: 'realtimeDataPanel',
@@ -568,6 +576,12 @@ const EditTab = (): JSX.Element => {
                     ),
             },
         ],
+    }
+
+    const updateTavle = () => {
+        setSettings({
+            pageRefreshedAt: new Date().getTime(),
+        })
     }
 
     return (
@@ -734,6 +748,20 @@ const EditTab = (): JSX.Element => {
                         />
                     </div>
                     <WeatherPanel />
+                </div>
+                <div key="refreshTavlePanel" className="edit-tab__tile-refresh">
+                    <div className="edit-tab__header">
+                        <Heading2>Last inn tavler på nytt</Heading2>
+                    </div>
+                    <div>
+                        <Paragraph>
+                            Når du trykker på knappen vil alle skjermer som
+                            viser denne tavlen bli lastet inn på nytt.
+                        </Paragraph>
+                        <Button onClick={updateTavle} variant="primary">
+                            Last inn tavler på nytt
+                        </Button>
+                    </div>
                 </div>
                 <div key="customTilePanel" className="edit-tab__tile">
                     <div className="edit-tab__header">

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -578,11 +578,11 @@ const EditTab = (): JSX.Element => {
         ],
     }
 
-    const updateTavle = () => {
+    const handleUpdateTavle = useCallback(() => {
         setSettings({
             pageRefreshedAt: new Date().getTime(),
         })
-    }
+    }, [setSettings])
 
     return (
         <div className="edit-tab">
@@ -758,7 +758,7 @@ const EditTab = (): JSX.Element => {
                             Når du trykker på knappen vil alle skjermer som
                             viser denne tavlen bli lastet inn på nytt.
                         </Paragraph>
-                        <Button onClick={updateTavle} variant="primary">
+                        <Button onClick={handleUpdateTavle} variant="primary">
                             Last inn tavler på nytt
                         </Button>
                     </div>

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -50,6 +50,13 @@
         border-radius: 1rem;
         overflow-x: visible;
     }
+    &__tile-refresh {
+        padding: 2rem;
+        background-color: var(--tavla-box-background-color);
+        display: block;
+        border-radius: 1rem;
+        overflow-x: visible;
+    }
 
     .eds-checkbox-icon {
         background-color: var(--tavla-checkbox-color);

--- a/src/containers/Admin/EditTab/styles.scss
+++ b/src/containers/Admin/EditTab/styles.scss
@@ -50,6 +50,7 @@
         border-radius: 1rem;
         overflow-x: visible;
     }
+
     &__tile-refresh {
         padding: 2rem;
         background-color: var(--tavla-box-background-color);

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -194,6 +194,7 @@ const Content = (): JSX.Element => {
     const user = useFirebaseAuthentication()
     const settings = useSettings()
     const location = useLocation()
+    const [openTavle] = useState(new Date().getTime())
 
     const includeSettings = !['/privacy', '/tavler'].includes(location.pathname)
 
@@ -217,6 +218,16 @@ const Content = (): JSX.Element => {
             setIsRotated(false)
         }
     }, [location.pathname, isOnTavle, settings])
+
+    useEffect(() => {
+        if (isOnTavle && openTavle) {
+            if (settings[0]?.pageRefreshedAt) {
+                if (openTavle < settings[0]?.pageRefreshedAt) {
+                    window.location.reload()
+                }
+            }
+        }
+    }, [settings, isOnTavle, openTavle])
 
     return (
         <ApolloProvider client={realtimeVehiclesClient}>

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -194,7 +194,7 @@ const Content = (): JSX.Element => {
     const user = useFirebaseAuthentication()
     const settings = useSettings()
     const location = useLocation()
-    const [openTavle] = useState(new Date().getTime())
+    const [tavleOpenedAt] = useState(new Date().getTime())
 
     const includeSettings = !['/privacy', '/tavler'].includes(location.pathname)
 
@@ -220,14 +220,14 @@ const Content = (): JSX.Element => {
     }, [location.pathname, isOnTavle, settings])
 
     useEffect(() => {
-        if (isOnTavle && openTavle) {
-            if (settings[0]?.pageRefreshedAt) {
-                if (openTavle < settings[0]?.pageRefreshedAt) {
-                    window.location.reload()
-                }
-            }
+        if (
+            isOnTavle &&
+            settings[0]?.pageRefreshedAt &&
+            tavleOpenedAt < settings[0]?.pageRefreshedAt
+        ) {
+            window.location.reload()
         }
-    }, [settings, isOnTavle, openTavle])
+    }, [settings, isOnTavle, tavleOpenedAt])
 
     return (
         <ApolloProvider client={realtimeVehiclesClient}>

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -97,7 +97,6 @@ const DEFAULT_SETTINGS: Partial<Settings> = {
     customQrTiles: [],
     showCustomTiles: false,
     hiddenCustomTileIds: [],
-    //updated: false
 }
 
 export function useSettings(): [Settings | null, Setter] {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -69,6 +69,7 @@ export interface Settings {
     hiddenCustomTileIds: string[]
     fontScale?: number
     direction?: Direction
+    pageRefreshedAt?: number
 }
 
 type Setter = (settings: Partial<Settings>) => void
@@ -96,6 +97,7 @@ const DEFAULT_SETTINGS: Partial<Settings> = {
     customQrTiles: [],
     showCustomTiles: false,
     hiddenCustomTileIds: [],
+    //updated: false
 }
 
 export function useSettings(): [Settings | null, Setter] {


### PR DESCRIPTION
**Problem:**
When developers push new code, the existing Tavles are not necessary updated with the new features/fixes. 

**Solution:**
The possibility to refresh all Tavler on queue through the admin-panel.
When new code is pushed to master, the users can refresh their Tavler through the admin panel by clicking "last inn tavler på nytt". 

**Before:**
<img width="1683" alt="Screenshot 2022-09-28 at 09 25 38" src="https://user-images.githubusercontent.com/31958950/192715265-f5a23ba8-14e8-448c-b61a-cda6f557f4dd.png">

**After:**
<img width="1694" alt="Screenshot 2022-09-28 at 09 26 10" src="https://user-images.githubusercontent.com/31958950/192715342-f61aafbe-bc0d-4f22-a085-efd96024c646.png">
