### PR TITLE
update-types-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
                 "@types/lodash.debounce": "4.0.7",
                 "@types/lz-string": "1.3.34",
                 "@types/node": "16.11.28",
-                "@types/react": "17.0.44",
+                "@types/react": "18.0.21",
                 "@types/react-dom": "18.0.6",
                 "@types/react-grid-layout": "1.3.2",
                 "@types/react-map-gl": "6.1.2",
@@ -4240,9 +4240,9 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "17.0.44",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
-            "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
+            "version": "18.0.21",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+            "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -32383,7 +32383,7 @@
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
             "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
             "requires": {
-                "@types/react": "17.0.44",
+                "@types/react": "*",
                 "hoist-non-react-statics": "^3.3.0"
             }
         },
@@ -32533,9 +32533,9 @@
             "dev": true
         },
         "@types/react": {
-            "version": "17.0.44",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
-            "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
+            "version": "18.0.21",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+            "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -32547,7 +32547,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.2.tgz",
             "integrity": "sha512-+OvPkB8CdE/bGdXKyIhc/Lm2U7UAYCCJgsqmopFmh9gbAudmslkI8eOrPDjg4JhwSE6wytz4a3/wRjKtovHVJg==",
             "requires": {
-                "@types/react": "17.0.44"
+                "@types/react": "*"
             }
         },
         "@types/react-dom": {
@@ -32556,7 +32556,7 @@
             "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
             "dev": true,
             "requires": {
-                "@types/react": "17.0.44"
+                "@types/react": "*"
             }
         },
         "@types/react-grid-layout": {
@@ -32565,7 +32565,7 @@
             "integrity": "sha512-ZzpBEOC1JTQ7MGe1h1cPKSLP4jSWuxc+yvT4TsAlEW9+EFPzAf8nxQfFd7ea9gL17Em7PbwJZAsiwfQQBUklZQ==",
             "dev": true,
             "requires": {
-                "@types/react": "17.0.44"
+                "@types/react": "*"
             }
         },
         "@types/react-map-gl": {
@@ -32576,7 +32576,7 @@
             "requires": {
                 "@types/geojson": "*",
                 "@types/mapbox-gl": "*",
-                "@types/react": "17.0.44",
+                "@types/react": "*",
                 "@types/viewport-mercator-project": "*"
             }
         },
@@ -32586,7 +32586,7 @@
             "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
             "requires": {
                 "@types/hoist-non-react-statics": "^3.3.0",
-                "@types/react": "17.0.44",
+                "@types/react": "*",
                 "hoist-non-react-statics": "^3.3.0",
                 "redux": "^4.0.0"
             }
@@ -32598,7 +32598,7 @@
             "dev": true,
             "requires": {
                 "@types/history": "^4.7.11",
-                "@types/react": "17.0.44"
+                "@types/react": "*"
             }
         },
         "@types/react-router-dom": {
@@ -32608,7 +32608,7 @@
             "dev": true,
             "requires": {
                 "@types/history": "^4.7.11",
-                "@types/react": "17.0.44",
+                "@types/react": "*",
                 "@types/react-router": "*"
             }
         },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "@types/lodash.debounce": "4.0.7",
         "@types/lz-string": "1.3.34",
         "@types/node": "16.11.28",
-        "@types/react": "17.0.44",
+        "@types/react": "18.0.21",
         "@types/react-dom": "18.0.6",
         "@types/react-grid-layout": "1.3.2",
         "@types/react-map-gl": "6.1.2",
@@ -132,8 +132,5 @@
         "webpack": "5.74.0",
         "webpack-cli": "4.10.0",
         "webpack-dev-server": "4.11.1"
-    },
-    "overrides": {
-        "@types/react": "17.0.44"
     }
 }

--- a/src/containers/Admin/EditTab/BikePanel/index.tsx
+++ b/src/containers/Admin/EditTab/BikePanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { ChangeEvent, useCallback } from 'react'
 
 import { Station } from '@entur/sdk/lib/mobility/types'
 import { Checkbox, Fieldset } from '@entur/form'
@@ -28,7 +28,7 @@ function BikePanel(props: Props): JSX.Element {
     }, [hiddenStations.length, setSettings, stations])
 
     const onToggleStation = useCallback(
-        (event) => {
+        (event: ChangeEvent<HTMLInputElement>) => {
             const stationId = event.target.id
             setSettings({
                 hiddenStations: toggleValueInList(hiddenStations, stationId),

--- a/src/containers/Admin/EditTab/ScooterPanel/index.tsx
+++ b/src/containers/Admin/EditTab/ScooterPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { ChangeEvent, useCallback } from 'react'
 
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
@@ -16,7 +16,7 @@ function ScooterPanel(): JSX.Element {
     const { hiddenMobilityOperators = [] } = settings || {}
 
     const onToggleOperator = useCallback(
-        (event) => {
+        (event: ChangeEvent<HTMLInputElement>) => {
             const OperatorId = event.target.id
             setSettings({
                 hiddenMobilityOperators: toggleValueInList(

--- a/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { ChangeEvent, useCallback, useMemo } from 'react'
 
 import { Checkbox } from '@entur/form'
 import { Paragraph } from '@entur/typography'
@@ -46,7 +46,7 @@ function StopPlacePanel(props: Props): JSX.Element {
     }, [hiddenStopModes, hiddenStops.length, setSettings, stops])
 
     const onToggleStop = useCallback(
-        (event) => {
+        (event: ChangeEvent<HTMLInputElement>) => {
             const checked = event.target.checked
             const stopId = event.target.id
             const stopPlace = filteredStopPlaces.find(

--- a/src/containers/Admin/EditTab/WeatherPanel/index.tsx
+++ b/src/containers/Admin/EditTab/WeatherPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { ChangeEvent, useCallback } from 'react'
 
 import { Fieldset } from '@entur/form'
 import { FilterChip } from '@entur/chip'
@@ -48,7 +48,7 @@ function WeatherPanel(): JSX.Element {
     ]
 
     const onToggle = useCallback(
-        (event) => {
+        (event: ChangeEvent<HTMLInputElement>) => {
             const weatherSetting = event.target.value
             switch (weatherSetting) {
                 case 'showIcon':

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -11,8 +11,6 @@ import classNames from 'classnames'
 
 import { ApolloProvider } from '@apollo/client'
 
-import { ToastProvider } from '@entur/alert'
-
 import { useFirebaseAuthentication, UserProvider } from '../auth'
 import '../firebase-init'
 import { SettingsContext, useSettings } from '../settings'
@@ -36,7 +34,7 @@ import {
 } from '../settings/LocalStorage'
 import { isMobileWeb } from '../utils'
 
-import { Direction } from '../types'
+import { Direction, ToastProvider } from '../types'
 
 import Admin from './Admin'
 import { LockedTavle, PageDoesNotExist } from './Error/ErrorPages'

--- a/src/containers/ThemeWrapper/ThemeProvider.tsx
+++ b/src/containers/ThemeWrapper/ThemeProvider.tsx
@@ -11,7 +11,11 @@ const ThemeContext = React.createContext<ThemeContextType>({
     themeContext: Theme.DEFAULT,
 })
 
-const ThemeProvider: FC = (props): JSX.Element => {
+interface ThemeProviderProps {
+    children: React.ReactNode
+}
+
+const ThemeProvider: FC<ThemeProviderProps> = (props) => {
     const [settings] = useSettingsContext()
 
     const themeContext = settings?.theme || Theme.DEFAULT

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,11 @@
+import React from 'react'
+
 import { FieldValue, Timestamp } from 'firebase/firestore'
 
 import { TransportMode, TransportSubmode, StopPlace } from '@entur/sdk'
+
+import { ToastProvider as _ToastProvider } from '@entur/alert'
+import { ToastProviderProps } from '@entur/alert/dist/ToastProvider'
 
 import { Settings } from './settings'
 
@@ -124,3 +129,10 @@ export interface Viewport {
 }
 
 export type NonEmpty<A> = [A, ...A[]]
+
+/* Augment the proptype of @entur/alert ToastProvider with children definition.
+ * This should be deleted when @entur/alert updates to @types/react@18.x and updates their definition
+ */
+export const ToastProvider = _ToastProvider as React.FC<
+    ToastProviderProps & { children: React.ReactNode }
+>


### PR DESCRIPTION
* Update to version 18 of @types/react
* Add missing type declaration for various onChange handler
* Add children to ThemeProvider
* Add casting workaround for @entur/alert ToastProvider. This it not a functional change and only changes the type of ToastProvider.