### PR TITLE
Add EmptyStopTile, similar to ErrorTile

### DIFF
--- a/src/components/EmptyStopTile/EmptyStopTile.tsx
+++ b/src/components/EmptyStopTile/EmptyStopTile.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import classNames from 'classnames'
+import { Paragraph } from '@entur/typography'
+import { Tile } from '../Tile/Tile'
+import { TileHeader } from '../TileHeader/TileHeader'
+
+interface Props {
+    className?: string
+    title: string
+}
+
+const EmptyStopTile: React.FC<Props> = ({ className, title }) => (
+    <Tile className={classNames(className)}>
+        <TileHeader icons={[]} title={title} />
+        <Paragraph>Vi fant ingen avganger for dette stoppestedet.</Paragraph>
+    </Tile>
+)
+
+export { EmptyStopTile }

--- a/src/containers/Admin/EditTab/StopPlacePanel/StopPlacePanel.tsx
+++ b/src/containers/Admin/EditTab/StopPlacePanel/StopPlacePanel.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useMemo } from 'react'
+import React, { ChangeEvent, useCallback } from 'react'
 import { Checkbox } from '@entur/form'
 import { Paragraph } from '@entur/typography'
 import { Loader } from '@entur/loader'
@@ -18,11 +18,6 @@ interface StopPlacePanelProps {
 function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
     const [settings, setSettings] = useSettings()
 
-    const filteredStopPlaces = useMemo(
-        () => stops?.filter(({ lines }) => lines.length) || [],
-        [stops],
-    )
-
     const onChooseAllPressed = useCallback(() => {
         if (settings.hiddenStops.length > 0) {
             setSettings({
@@ -36,7 +31,7 @@ function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
             })
         } else {
             setSettings({
-                hiddenStops: stops?.map(({ id }) => id) || [],
+                hiddenStops: stops?.map(({ id }) => id),
             })
         }
     }, [
@@ -50,9 +45,7 @@ function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
         (event: ChangeEvent<HTMLInputElement>) => {
             const checked = event.target.checked
             const stopId = event.target.id
-            const stopPlace = filteredStopPlaces.find(
-                (item) => item.id === stopId,
-            )
+            const stopPlace = stops?.find((item) => item.id === stopId)
 
             const uniqueTransportModes = Array.from(
                 new Set(
@@ -68,12 +61,7 @@ function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
                 },
             })
         },
-        [
-            filteredStopPlaces,
-            settings.hiddenStopModes,
-            settings.hiddenStops,
-            setSettings,
-        ],
+        [stops, settings.hiddenStopModes, settings.hiddenStops, setSettings],
     )
 
     const onToggleRoute = useCallback(
@@ -101,9 +89,7 @@ function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
                     mode,
                 ),
             }
-            const stopPlace = filteredStopPlaces.find(
-                (item) => item.id === stopPlaceId,
-            )
+            const stopPlace = stops?.find((item) => item.id === stopPlaceId)
 
             const uniqueTransportModes = Array.from(
                 new Set(
@@ -130,15 +116,10 @@ function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
                 hiddenStopModes: newHiddenModes,
             })
         },
-        [
-            filteredStopPlaces,
-            settings.hiddenStopModes,
-            settings.hiddenStops,
-            setSettings,
-        ],
+        [stops, settings.hiddenStopModes, settings.hiddenStops, setSettings],
     )
 
-    if (!filteredStopPlaces.length) {
+    if (!stops?.length) {
         return (
             <div className="stop-place-panel">
                 {stops ? (
@@ -171,7 +152,7 @@ function StopPlacePanel({ stops }: StopPlacePanelProps): JSX.Element {
                     </div>
                 </div>
                 {settings
-                    ? filteredStopPlaces.map((stopPlace) => (
+                    ? stops?.map((stopPlace) => (
                           <PanelRow
                               onToggleMode={onToggleMode}
                               onToggleRoute={onToggleRoute}

--- a/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
+++ b/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../../logic/use-stop-place-with-estimated-calls/departure'
 import { WalkTrip } from '../../../../components/WalkTrip/WalkTrip'
 import { ErrorTile } from '../../../../components/ErrorTile/ErrorTile'
+import { EmptyStopTile } from '../../../../components/EmptyStopTile/EmptyStopTile'
 import classes from './BusStopTile.module.scss'
 
 interface Props {
@@ -50,6 +51,15 @@ const BusStopTile = ({ stopPlaceId }: Props): JSX.Element => {
 
     if (!stopPlaceWithEstimatedCalls) {
         return <ErrorTile className={classes.BusStopTile} />
+    }
+
+    if (!departures.length) {
+        return (
+            <EmptyStopTile
+                className={classes.BusStopTile}
+                title={stopPlaceWithEstimatedCalls.name}
+            />
+        )
     }
 
     return (

--- a/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.tsx
+++ b/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../logic/use-stop-place-with-estimated-calls/departure'
 import { WalkTrip } from '../../../components/WalkTrip/WalkTrip'
 import { ErrorTile } from '../../../components/ErrorTile/ErrorTile'
+import { EmptyStopTile } from '../../../components/EmptyStopTile/EmptyStopTile'
 import classes from './ChronoDepartureTile.module.scss'
 
 interface ChronoDepartureTileProps {
@@ -50,6 +51,15 @@ const ChronoDepartureTile: React.FC<ChronoDepartureTileProps> = ({
 
     if (!stopPlaceWithEstimatedCalls) {
         return <ErrorTile className={classes.ChronoDepartureTile} />
+    }
+
+    if (!departures.length) {
+        return (
+            <EmptyStopTile
+                className={classes.ChronoDepartureTile}
+                title={stopPlaceWithEstimatedCalls.name}
+            />
+        )
     }
 
     return (

--- a/src/dashboards/Compact/CompactDepartureTile/CompactDepartureTile.tsx
+++ b/src/dashboards/Compact/CompactDepartureTile/CompactDepartureTile.tsx
@@ -15,6 +15,7 @@ import { WalkTrip } from '../../../components/WalkTrip/WalkTrip'
 import { createTileSubLabel } from '../../../utils/utils'
 import { TransportModeIcon } from '../../../components/TransportModeIcon/TransportModeIcon'
 import { ErrorTile } from '../../../components/ErrorTile/ErrorTile'
+import { EmptyStopTile } from '../../../components/EmptyStopTile/EmptyStopTile'
 import classes from './CompactDepartureTile.module.scss'
 
 interface CompactDepartureTileProps {
@@ -56,6 +57,15 @@ const CompactDepartureTile: React.FC<CompactDepartureTileProps> = ({
 
     if (!stopPlaceWithEstimatedCalls) {
         return <ErrorTile className={classes.CompactDepartureTile} />
+    }
+
+    if (!departures.length) {
+        return (
+            <EmptyStopTile
+                className={classes.CompactDepartureTile}
+                title={stopPlaceWithEstimatedCalls.name}
+            />
+        )
     }
 
     return (


### PR DESCRIPTION
Because of changes to how we fetch and present data, we no longer filter out stopplaces with no departures on dashboards, but they are filtered out in the admin panel. This PR removes the admin panel filtering so the user can remove empty stopplaces if they want, and adds a new tile that is shown whenever a stopplace has no departures.