### PR TITLE
added autocomplete field for better uu

### DIFF
--- a/src/containers/Admin/ShareTab/components/AddNewOwnersInput.tsx
+++ b/src/containers/Admin/ShareTab/components/AddNewOwnersInput.tsx
@@ -92,6 +92,7 @@ const AddNewOwnersInput = ({
                 <TextField
                     label="E-postadressen til brukeren"
                     value={newOwnerInput}
+                    autoComplete="email"
                     onChange={(e) => {
                         setNewOwnerInput(e.currentTarget.value)
                         setInputFeedbackMessageType(inputFeedbackType.CLEAR)


### PR DESCRIPTION
Motivasjon: 
- Felt for tavle-eier er ikke smart
Problemet her er at feltet for å legge til eier av ei tavle indikerer ikke at det er e-postadresse som skal fylles inn.

Løsningen her er å legge noe i koden som gjør at inputfeltet skjønner at det er e-post og kan foreslå dine e-postadresser.