### PR TITLE
2.1.1: Tastatur

### DIFF
--- a/src/containers/Admin/ShareTab/components/EditableBoardTitle.tsx
+++ b/src/containers/Admin/ShareTab/components/EditableBoardTitle.tsx
@@ -35,7 +35,7 @@ const EditableBoardTitle = ({ boardName, documentId }: Props): JSX.Element => {
                     defaultValue={boardName}
                     autoFocus={true}
                     onChange={(e) => setNewBoardName(e.currentTarget.value)}
-                    onKeyUp={(e): void => {
+                    onKeyDown={(e): void => {
                         if (e.key === 'Enter') onChangeTitle()
                     }}
                 />


### PR DESCRIPTION
Problem: 

Inne på "Deling" ligg namnet til Tavla med eit rediger-ikon bak. Ved å tab'e gjennom og trykke enter så hopper den raskt over i rediger-modus et sekund før den hopper ut igjen.

Løsning: 
Fikset bug med redigerknappen sånn at man kan ha fokus på knappen, trykke enter og redigere.