### PR TITLE
Made overflowing text cut off in chrono and busstop table headers

### DIFF
--- a/src/dashboards/BusStop/components/BusStopTile/BusStopTile.module.scss
+++ b/src/dashboards/BusStop/components/BusStopTile/BusStopTile.module.scss
@@ -8,6 +8,12 @@
     border-bottom: none;
 }
 
+.Cell {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .Icon {
     width: 10%;
 }

--- a/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
+++ b/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import classNames from 'classnames'
 import { Table, TableRow, TableHead, HeaderCell, TableBody } from '@entur/table'
 import { Loader } from '@entur/loader'
 import { useSettings } from '../../../../settings/SettingsProvider'
@@ -77,18 +78,37 @@ const BusStopTile = ({ stopPlaceId }: Props): JSX.Element => {
             <Table spacing="large" fixed>
                 <TableHead className={classes.TableHead}>
                     <TableRow>
-                        <HeaderCell className={classes.Icon}> </HeaderCell>
+                        <HeaderCell
+                            className={classNames(classes.Icon, classes.Cell)}
+                        >
+                            {' '}
+                        </HeaderCell>
                         <HeaderCell>Linje</HeaderCell>
-                        <HeaderCell className={classes.Departure}>
+                        <HeaderCell
+                            className={classNames(
+                                classes.Departure,
+                                classes.Cell,
+                            )}
+                        >
                             Avgang
                         </HeaderCell>
                         {!settings.hideTracks && (
-                            <HeaderCell className={classes.Track}>
+                            <HeaderCell
+                                className={classNames(
+                                    classes.Track,
+                                    classes.Cell,
+                                )}
+                            >
                                 Plattform
                             </HeaderCell>
                         )}
                         {!settings.hideSituations && (
-                            <HeaderCell className={classes.Situation}>
+                            <HeaderCell
+                                className={classNames(
+                                    classes.Situation,
+                                    classes.Cell,
+                                )}
+                            >
                                 Avvik
                             </HeaderCell>
                         )}

--- a/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.module.scss
+++ b/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.module.scss
@@ -8,6 +8,9 @@
 
 .Cell {
     padding: 1rem 0 1rem 0.1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .Icon {


### PR DESCRIPTION
Change from "spor" to "platform" made cell header text overflow in chrono and busstop dashboards