### PR TITLE
sort-by-departure-time

### DIFF
--- a/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
+++ b/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
@@ -12,6 +12,7 @@ import { Tile } from '../../../../components/Tile/Tile'
 import { TileHeader } from '../../../../components/TileHeader/TileHeader'
 import { useStopPlaceWithEstimatedCalls } from '../../../../logic/use-stop-place-with-estimated-calls/useStopPlaceWithEstimatedCalls'
 import {
+    byDepartureTime,
     filterHidden,
     toDeparture,
 } from '../../../../logic/use-stop-place-with-estimated-calls/departure'
@@ -38,7 +39,8 @@ const BusStopTile = ({ stopPlaceId }: Props): JSX.Element => {
         () =>
             stopPlaceWithEstimatedCalls?.estimatedCalls
                 .map(toDeparture)
-                .filter(filterHidden(stopPlaceId, settings)) ?? [],
+                .filter(filterHidden(stopPlaceId, settings))
+                .sort(byDepartureTime) ?? [],
         [stopPlaceWithEstimatedCalls?.estimatedCalls, settings, stopPlaceId],
     )
 

--- a/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.tsx
+++ b/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.tsx
@@ -9,6 +9,7 @@ import { TileHeader } from '../../../components/TileHeader/TileHeader'
 import { Tile } from '../../../components/Tile/Tile'
 import { useStopPlaceWithEstimatedCalls } from '../../../logic/use-stop-place-with-estimated-calls/useStopPlaceWithEstimatedCalls'
 import {
+    byDepartureTime,
     filterHidden,
     toDeparture,
 } from '../../../logic/use-stop-place-with-estimated-calls/departure'
@@ -37,7 +38,8 @@ const ChronoDepartureTile: React.FC<ChronoDepartureTileProps> = ({
         () =>
             stopPlaceWithEstimatedCalls?.estimatedCalls
                 .map(toDeparture)
-                .filter(filterHidden(stopPlaceId, settings)) ?? [],
+                .filter(filterHidden(stopPlaceId, settings))
+                .sort(byDepartureTime) ?? [],
         [stopPlaceWithEstimatedCalls?.estimatedCalls, stopPlaceId, settings],
     )
 

--- a/src/logic/use-stop-place-with-estimated-calls/departure.ts
+++ b/src/logic/use-stop-place-with-estimated-calls/departure.ts
@@ -1,4 +1,4 @@
-import { differenceInMinutes, format, parseISO } from 'date-fns'
+import { compareAsc, differenceInMinutes, format, parseISO } from 'date-fns'
 import {
     TransportMode,
     TransportSubmode,
@@ -66,5 +66,8 @@ const filterHidden =
             departure.transportMode,
         )
 
-export { toDeparture, filterHidden }
+const byDepartureTime = (a: Departure, b: Departure) =>
+    compareAsc(a.departureTime, b.departureTime)
+
+export { toDeparture, filterHidden, byDepartureTime }
 export type { Departure }


### PR DESCRIPTION
* Sort departures by departure time. This was previously done by the api.