### PR TITLE
Small fix for theme styling bug

### DIFF
--- a/src/hooks/useThemeHandler.ts
+++ b/src/hooks/useThemeHandler.ts
@@ -6,11 +6,13 @@ function useThemeHandler() {
     const [settings] = useSettings()
 
     useEffect(() => {
-        Object.values(Theme).forEach((theme) => {
-            document.body.classList.remove(`${theme}-theme`)
-        })
-
         document.body.classList.add(`${settings.theme}-theme`)
+
+        return () => {
+            Object.values(Theme).forEach((theme) => {
+                document.body.classList.remove(`${theme}-theme`)
+            })
+        }
     }, [settings.theme])
 }
 


### PR DESCRIPTION
Styling was not cleared from body when navigating to front page.
To reproduce, go to admin panel, set theme to non-default, then click the Entur logo to go to the front page.

bug
![image](https://user-images.githubusercontent.com/18345134/210384277-df1a01ac-664b-41c2-b899-bff73f8d3979.png)

intended
![image](https://user-images.githubusercontent.com/18345134/210384399-dc8fe7b6-c47a-4441-9f74-57901413c134.png)
