### PR TITLE
F/delay time display

### DIFF
--- a/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.module.scss
+++ b/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.module.scss
@@ -20,4 +20,16 @@
 .Track {
     font-size: 1.25rem;
     font-weight: 400;
+    text-align: center;
+}
+
+.DelayedTime {
+    display: block;
+    color: var(--tavla-failure-font-color);
+}
+
+.OutdatedTime {
+    display: block;
+    text-decoration: line-through;
+    font-size: 1rem;
 }

--- a/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.tsx
+++ b/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.tsx
@@ -25,7 +25,7 @@ function BusStopTableRow({
                 ) : (
                     <>
                         <span className={classes.DelayedTime}>
-                            {departure.formattedExpectedDepartureTime}
+                            {departure.displayTime}
                         </span>
                         <span className={classes.OutdatedTime}>
                             {departure.formattedAimedDepartureTime}

--- a/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.tsx
+++ b/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.tsx
@@ -19,7 +19,9 @@ function BusStopTableRow({
         <TableRow>
             <DataCell className={classes.Line}>{departure.publicCode}</DataCell>
             <DataCell className={classes.Route}>{departure.frontText}</DataCell>
-            <DataCell className={classes.Time}>{departure.time}</DataCell>
+            <DataCell className={classes.Time}>
+                {departure.displayTime}
+            </DataCell>
             {!hideTracks && (
                 <DataCell className={classes.Track}>
                     {departure.quay?.publicCode || '-'}

--- a/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.tsx
+++ b/src/dashboards/BusStop/components/BusStopTableRow/BusStopTableRow.tsx
@@ -20,7 +20,18 @@ function BusStopTableRow({
             <DataCell className={classes.Line}>{departure.publicCode}</DataCell>
             <DataCell className={classes.Route}>{departure.frontText}</DataCell>
             <DataCell className={classes.Time}>
-                {departure.displayTime}
+                {!departure.delayed ? (
+                    departure.displayTime
+                ) : (
+                    <>
+                        <span className={classes.DelayedTime}>
+                            {departure.formattedExpectedDepartureTime}
+                        </span>
+                        <span className={classes.OutdatedTime}>
+                            {departure.formattedAimedDepartureTime}
+                        </span>
+                    </>
+                )}
             </DataCell>
             {!hideTracks && (
                 <DataCell className={classes.Track}>

--- a/src/dashboards/Chrono/ChronoTableRows/ChronoTableRows.tsx
+++ b/src/dashboards/Chrono/ChronoTableRows/ChronoTableRows.tsx
@@ -31,8 +31,8 @@ function ChronoTableRows({
                 return (
                     <Fragment key={data.id}>
                         <NewDayTableRow
-                            currentDate={data.departureTime}
-                            previousDate={previousRow?.departureTime}
+                            currentDate={data.expectedDepartureTime}
+                            previousDate={previousRow?.expectedDepartureTime}
                         />
                         <TableRow className={classes.ChronoTableRow}>
                             <DataCell>
@@ -51,7 +51,7 @@ function ChronoTableRows({
                             </DataCell>
                             <DataCell className={classes.DataCell}>
                                 <div className={classes.Sublabel}>
-                                    {subLabel.time}
+                                    {subLabel.displayTime}
                                 </div>
                             </DataCell>
                             {!hideTracks && (

--- a/src/dashboards/Compact/CompactTileRow/CompactTileRow.tsx
+++ b/src/dashboards/Compact/CompactTileRow/CompactTileRow.tsx
@@ -42,20 +42,23 @@ function CompactTileRow({
                         const isLastDepartureOfDay =
                             nextLabel &&
                             !isSameDay(
-                                nextLabel.departureTime,
-                                subLabel.departureTime,
+                                nextLabel.expectedDepartureTime,
+                                subLabel.expectedDepartureTime,
                             )
 
                         const showDate =
-                            index === 0 && !isToday(subLabel.departureTime)
+                            index === 0 &&
+                            !isToday(subLabel.expectedDepartureTime)
 
-                        const isoDate = formatISO(subLabel.departureTime)
+                        const isoDate = formatISO(
+                            subLabel.expectedDepartureTime,
+                        )
 
                         return (
                             <Fragment key={index}>
                                 <div className={classes.Sublabel}>
                                     <time dateTime={isoDate}>
-                                        {subLabel.time}
+                                        {subLabel.displayTime}
                                     </time>
 
                                     <SubLabelIcon
@@ -64,7 +67,11 @@ function CompactTileRow({
                                     />
 
                                     {showDate && (
-                                        <Date date={subLabel.departureTime} />
+                                        <Date
+                                            date={
+                                                subLabel.expectedDepartureTime
+                                            }
+                                        />
                                     )}
                                 </div>
                                 {isLastDepartureOfDay && <Divider />}

--- a/src/dashboards/Map/DepartureTag/DepartureTag.tsx
+++ b/src/dashboards/Map/DepartureTag/DepartureTag.tsx
@@ -93,10 +93,10 @@ const DepartureTag: React.FC<Props> = ({ stopPlaceId }): JSX.Element => {
                             {getDepartureDirection(departure)}
                         </div>
                         <div className={classes.Departure}>
-                            {departure.time}
+                            {departure.displayTime}
                         </div>
-                        {!isToday(departure.departureTime) && (
-                            <Date date={departure.departureTime} />
+                        {!isToday(departure.expectedDepartureTime) && (
+                            <Date date={departure.expectedDepartureTime} />
                         )}
                     </div>
                 ))}

--- a/src/dashboards/Poster/components/BusTile/BusTile.tsx
+++ b/src/dashboards/Poster/components/BusTile/BusTile.tsx
@@ -40,7 +40,12 @@ function BusTile(): JSX.Element {
                         .filter(isNotNullOrUndefined)
                         .map(toDeparture),
                 )
-                .sort((a, b) => compareAsc(a.departureTime, b.departureTime))
+                .sort((a, b) =>
+                    compareAsc(
+                        a.expectedDepartureTime,
+                        b.expectedDepartureTime,
+                    ),
+                )
                 .slice(0, numberOfLines) ?? [],
         [data?.stopPlaces, numberOfLines],
     )
@@ -73,7 +78,9 @@ function BusTile(): JSX.Element {
                             <p className={classes.Destination}>
                                 {routeDestination}
                             </p>
-                            <p className={classes.Time}>{departure.time}</p>
+                            <p className={classes.Time}>
+                                {departure.displayTime}
+                            </p>
                         </div>
                     )
                 })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,8 @@ export interface DrawableRoute {
 
 export interface TileSubLabel {
     situation?: string
-    time: string
-    departureTime: Date
+    displayTime: string
+    expectedDepartureTime: Date
     hasCancellation?: boolean
     hasSituation?: boolean
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,8 +1,8 @@
 import differenceInSeconds from 'date-fns/differenceInSeconds'
 import parseISO from 'date-fns/parseISO'
 
-function timeUntil(time: string): number {
-    return differenceInSeconds(parseISO(time), new Date())
+function timeUntil(time: Date): number {
+    return differenceInSeconds(time, new Date())
 }
 
 const getLastUpdated = (lastUpdated: string): number =>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,16 +5,16 @@ import { Departure } from '../logic/use-stop-place-with-estimated-calls/departur
 export function createTileSubLabel({
     situations,
     cancellation,
-    time,
-    departureTime,
+    displayTime,
+    expectedDepartureTime,
 }: Departure): TileSubLabel {
     const situation = situations[0]?.summary[0]?.value
     return {
         situation,
         hasSituation: Boolean(situation),
         hasCancellation: cancellation,
-        time,
-        departureTime,
+        displayTime,
+        expectedDepartureTime,
     }
 }
 


### PR DESCRIPTION
Adds a crossed out aimed departure time and a current expected departure time.
![image](https://user-images.githubusercontent.com/18345134/214632915-b34be2cd-a59d-4517-a164-a5fc41714f98.png)
This is shown on departures that are delayed two or more minutes.