### PR TITLE
fix(departures): revert to fetching surplus data and filtering client-side

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -2,7 +2,7 @@
   "projects": {
     "vehicles": {
       "name": "vehicles-v1",
-      "schemaPath": "graphql-schemas/vehicles-v1.json",
+      "schemaPath": ["graphql-schemas/vehicles-v1.json", "graphql-schemas/ApiDirective.graphql"],
       "includes": [
         "graphql-schemas/ApiDirective.graphql",
         "src/**/*.vehicles.graphql"
@@ -10,7 +10,7 @@
     },
     "journey-planner-v3": {
       "name": "journey-planner-v3",
-      "schemaPath": "graphql-schemas/journey-planner-v3.json",
+      "schemaPath": ["graphql-schemas/journey-planner-v3.json", "graphql-schemas/ApiDirective.graphql"],
       "includes": [
         "graphql-schemas/ApiDirective.graphql",
         "src/**/*.journey-planner.graphql"
@@ -18,7 +18,7 @@
     },
     "mobility-v2": {
       "name": "mobility-v2",
-      "schemaPath": "graphql-schemas/mobility-v2.json",
+      "schemaPath": ["graphql-schemas/mobility-v2.json", "graphql-schemas/ApiDirective.graphql"],
       "includes": [
         "graphql-schemas/ApiDirective.graphql",
         "src/**/*.mobility.graphql"

--- a/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
+++ b/src/dashboards/BusStop/components/BusStopTile/BusStopTile.tsx
@@ -32,7 +32,7 @@ const BusStopTile = ({ stopPlaceId }: Props): JSX.Element => {
     const { stopPlaceWithEstimatedCalls, loading } =
         useStopPlaceWithEstimatedCalls({
             stopPlaceId,
-            numberOfDepartures: 20,
+            numberOfDeparturesPerLineAndDestinationDisplay: 20,
             hiddenStopModes: settings.hiddenStopModes,
         })
 

--- a/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.tsx
+++ b/src/dashboards/Chrono/ChronoDepartureTile/ChronoDepartureTile.tsx
@@ -34,7 +34,7 @@ const ChronoDepartureTile: React.FC<ChronoDepartureTileProps> = ({
     const { stopPlaceWithEstimatedCalls, loading } =
         useStopPlaceWithEstimatedCalls({
             stopPlaceId,
-            numberOfDepartures: 20,
+            numberOfDeparturesPerLineAndDestinationDisplay: 20,
             hiddenStopModes: settings.hiddenStopModes,
         })
 

--- a/src/dashboards/Responsive/ResponsiveDepartureTile/ResponsiveDepartureTile.tsx
+++ b/src/dashboards/Responsive/ResponsiveDepartureTile/ResponsiveDepartureTile.tsx
@@ -21,7 +21,7 @@ const ResponsiveDepartureTile: React.FC<{ stopPlaceId: string }> = ({
     const { stopPlaceWithEstimatedCalls, loading } =
         useStopPlaceWithEstimatedCalls({
             stopPlaceId,
-            numberOfDepartures: 20,
+            numberOfDeparturesPerLineAndDestinationDisplay: 20,
             hiddenStopModes: settings.hiddenStopModes,
         })
 


### PR DESCRIPTION
Partially reverts change in #917
Now fetches the next 200 departures (default value) like before, but limits to 20 departures per line.