### PR TITLE
style(dashboard): reduce footer and header spacing

### DIFF
--- a/src/components/DashboardHeader/DashboardHeader.module.scss
+++ b/src/components/DashboardHeader/DashboardHeader.module.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: end;
     padding: 2rem 0;
     overflow: hidden;
 }

--- a/src/containers/DashboardWrapper/DashboardWrapper.module.scss
+++ b/src/containers/DashboardWrapper/DashboardWrapper.module.scss
@@ -5,7 +5,7 @@
 }
 
 .Byline {
-    margin-top: 5rem;
+    margin-top: 2rem;
     display: flex;
     align-items: center;
     color: var(--tavla-font-color);

--- a/src/dashboards/BusStop/components/BusStopTile/BusStopTile.module.scss
+++ b/src/dashboards/BusStop/components/BusStopTile/BusStopTile.module.scss
@@ -1,6 +1,6 @@
 .BusStopTile {
     max-height: 80vh;
-    margin-bottom: 2rem;
+    margin-bottom: 4rem;
 }
 
 .TileHeader {


### PR DESCRIPTION
Reduce spacing in footer and align icon in header for better space utilization

Before
![image](https://user-images.githubusercontent.com/18345134/219078384-7e874926-103d-4e3d-b92e-8d93f10fe31f.png)

After
![image](https://user-images.githubusercontent.com/18345134/219078276-bb03230a-82ba-4e05-949f-f7a92b1ae14c.png)
