### PR TITLE
feat(settings): add "last active" field

### DIFF
--- a/src/containers/DashboardWrapper/DashboardWrapper.tsx
+++ b/src/containers/DashboardWrapper/DashboardWrapper.tsx
@@ -9,6 +9,7 @@ import { useReloadTavleOnUpdate } from 'hooks/useReloadTavleOnUpdate'
 import { useHandleFontScaling } from 'hooks/useHandleFontScaling'
 import { useThemeHandler } from 'hooks/useThemeHandler'
 import { DashboardHeader } from 'components/DashboardHeader/DashboardHeader'
+import { useUpdateLastActive } from 'hooks/useUpdateLastActive'
 import { ThemeContrastWrapper } from '../ThemeContrastWrapper/ThemeContrastWrapper'
 import { BottomMenu } from './BottomMenu/BottomMenu'
 import classes from './DashboardWrapper.module.scss'
@@ -30,6 +31,7 @@ function DashboardWrapper({
     useThemeHandler()
     useHandleFontScaling()
     useReloadTavleOnUpdate()
+    useUpdateLastActive()
     const [settings] = useSettings()
 
     return (

--- a/src/hooks/useUpdateLastActive.ts
+++ b/src/hooks/useUpdateLastActive.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useSettings } from 'settings/SettingsProvider'
+
+const useUpdateLastActive = () => {
+    const [settings, setSettings] = useSettings()
+
+    useEffect(() => {
+        const intervalId = setInterval(() => {
+            // Updates lastActive if previous value is more than 1 day ago
+            if (Date.now() - settings.lastActive > 86400000) {
+                setSettings({
+                    lastActive: Date.now(),
+                })
+            }
+        }, 3600000) // Runs every hour
+        return () => {
+            clearInterval(intervalId)
+        }
+    }, [settings.lastActive, setSettings])
+}
+
+export { useUpdateLastActive }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -40,6 +40,7 @@ interface Settings {
     newStops: string[]
     owners: string[]
     pageRefreshedAt: number
+    lastActive: number
     permanentlyVisibleRoutesInMap: DrawableRoute[]
     scooterDistance: { distance: number; enabled: boolean }
     showCustomTiles: boolean
@@ -84,6 +85,7 @@ const DEFAULT_SETTINGS: Settings = {
     newStops: [],
     owners: [],
     pageRefreshedAt: 0,
+    lastActive: 0,
     permanentlyVisibleRoutesInMap: [],
     scooterDistance: { distance: DEFAULT_DISTANCE, enabled: false },
     showCustomTiles: false,


### PR DESCRIPTION
Adds field to settings that is updated daily if website is running. Can be used to check for inactive boards.