### PR TITLE
feat(husky): added pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn run format:check
+yarn run eslint

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
         "serve:prod": "npm run build:prod && firebase serve",
         "serve:staging": "npm run build:staging && firebase serve",
         "deploy:prod": "npm run build:prod && firebase deploy -P prod",
-        "deploy:staging": "npm run build:staging && firebase deploy -P staging"
+        "deploy:staging": "npm run build:staging && firebase deploy -P staging",
+        "postinstall": "husky install",
+        "prepack": "pinst --disable",
+        "postpack": "pinst --enable"
     },
     "author": "Entur AS",
     "license": "EUPL-1.2",
@@ -115,6 +118,8 @@
         "file-loader": "6.2.0",
         "firebase-tools": "11.22.0",
         "html-webpack-plugin": "5.5.0",
+        "husky": "^8.0.0",
+        "pinst": "^3.0.0",
         "postcss": "8.4.20",
         "postcss-loader": "7.0.2",
         "postcss-preset-env": "7.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9765,6 +9765,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^8.0.0":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
+  bin:
+    husky: lib/bin.js
+  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -12511,6 +12520,15 @@ __metadata:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 9c4e34278cb09987685fa5ef81499c82546c033713518f6441778fbec623fc708777fe8ac633097c72d88470d5963094076c7305cafc7ad340aae27cfacd856b
+  languageName: node
+  linkType: hard
+
+"pinst@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pinst@npm:3.0.0"
+  bin:
+    pinst: bin.js
+  checksum: 4ae48a6a60f79c37071233af51b4d91bfc85cfa3c12b66ccda60cdb642b4d14a4ab0cb3587afc55b1f6192cea1772a5e4822026a0d0d3528296edef00cc2d61f
   languageName: node
   linkType: hard
 
@@ -15469,7 +15487,9 @@ __metadata:
     google-polyline: 1.0.3
     graphql: 16.6.0
     html-webpack-plugin: 5.5.0
+    husky: ^8.0.0
     lodash: 4.17.21
+    pinst: ^3.0.0
     postcss: 8.4.20
     postcss-loader: 7.0.2
     postcss-preset-env: 7.8.3


### PR DESCRIPTION
`yarn install` now automatically installs husky, which runs pre-commit hooks validating linting and formatting