### PR TITLE
fix(admin): better handling of duplicate stopplaces

### DIFF
--- a/tavla/src/tiles/admin/StopPlaceTile/components/StopPlacePanel/PanelRow/index.tsx
+++ b/tavla/src/tiles/admin/StopPlaceTile/components/StopPlacePanel/PanelRow/index.tsx
@@ -93,6 +93,11 @@ function PanelRow({ stopPlaceId }: { stopPlaceId: string }) {
                 <Paragraph>
                     Fant ikke informasjon om stoppestedet med id {stopPlaceId}
                 </Paragraph>
+                {settings.newStops.includes(stopPlaceId) && (
+                    <IconButton onClick={handleRemoveStopPlaceFromPanel}>
+                        <CloseSmallIcon />
+                    </IconButton>
+                )}
             </div>
         )
     }

--- a/tavla/src/tiles/admin/StopPlaceTile/components/StopPlaceSearch/index.tsx
+++ b/tavla/src/tiles/admin/StopPlaceTile/components/StopPlaceSearch/index.tsx
@@ -4,40 +4,23 @@ import {
     fetchAutocomplete,
 } from 'utils/geocoder/fetchAutocomplete'
 import { useSettings } from 'settings/SettingsProvider'
-import { useStopPlaceIds } from 'hooks/useStopPlaceIds'
 import { Dropdown } from '@entur/dropdown'
 import classes from './StopPlaceSearch.module.scss'
 
 function StopPlaceSearch() {
     const [settings, setSettings] = useSettings()
 
-    const { stopPlaceIds } = useStopPlaceIds({
-        distance: settings.distance,
-        filterHidden: false,
-    })
-
     const handleChange = useCallback(
         (item: AutocompleteItem | null) => {
-            if (item) {
+            if (item && !settings.newStops.includes(item.value)) {
                 const stopId = item.value
 
-                const numberOfDuplicates = [
-                    ...stopPlaceIds,
-                    ...settings.newStops,
-                ]
-                    .map((id) => id.replace(/-\d+$/, ''))
-                    .filter((id) => id === stopId).length
-
-                const id = !numberOfDuplicates
-                    ? stopId
-                    : `${stopId}-${numberOfDuplicates}`
-
                 setSettings({
-                    newStops: [...settings.newStops, id],
+                    newStops: [...settings.newStops, stopId],
                 })
             }
         },
-        [stopPlaceIds, settings.newStops, setSettings],
+        [settings.newStops, setSettings],
     )
 
     return (


### PR DESCRIPTION
Before
![image](https://github.com/entur/tavla/assets/18345134/09038908-40b3-481b-8dfa-e5cc038cd606)

After
![image](https://github.com/entur/tavla/assets/18345134/860bf113-fd77-48c8-a611-1db2b346c649)
