### PR TITLE
fix(theming): do not set logo based on theme on admin

### DIFF
--- a/next-tavla/pages/admin/[id].tsx
+++ b/next-tavla/pages/admin/[id].tsx
@@ -34,7 +34,7 @@ export async function getServerSideProps({
 function AdminPage({ settings, id }: { settings: TSettings; id: string }) {
     return (
         <Contrast className={classes.root}>
-            <Header theme={settings.theme} />
+            <Header />
             <Admin initialSettings={settings} documentId={id} />
         </Contrast>
     )


### PR DESCRIPTION
The header logo has different colors in dark and light themes. The Admin-page uses Entur colors regardless of theme, and should not change the header logo based on theme in settings.

Before:
![image](https://github.com/entur/tavla/assets/18345134/06ecce69-2a8a-4d14-a067-a25a13f4b58a)

After:
![image](https://github.com/entur/tavla/assets/18345134/c9475bed-ef43-4ab3-a1cd-3e18a2f0bc30)
