### PR TITLE
feat(error-handling): implements app error boundary

### DIFF
--- a/next-tavla/pages/_app.tsx
+++ b/next-tavla/pages/_app.tsx
@@ -8,6 +8,7 @@ import 'styles/fonts.css'
 import 'styles/spacing.css'
 import Head from 'next/head'
 import type { AppProps } from 'next/app'
+import { AppErrorBoundary } from 'components/AppErrorBoundary'
 
 export default function App({ Component, pageProps }: AppProps) {
     return (
@@ -33,7 +34,9 @@ export default function App({ Component, pageProps }: AppProps) {
                 <link rel="manifest" href="/site.webmanifest" />
                 <title>Entur Tavla</title>
             </Head>
-            <Component {...pageProps} />
+            <AppErrorBoundary>
+                <Component {...pageProps} />
+            </AppErrorBoundary>
         </>
     )
 }

--- a/next-tavla/src/Shared/components/AppErrorBoundary/index.tsx
+++ b/next-tavla/src/Shared/components/AppErrorBoundary/index.tsx
@@ -1,0 +1,40 @@
+import React, { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { Header } from 'components/Header'
+import classes from 'styles/pages/board.module.css'
+
+interface State {
+    hasError: boolean
+}
+
+class AppErrorBoundary extends Component<{ children?: ReactNode }, State> {
+    public state: State = {
+        hasError: false,
+    }
+
+    public static getDerivedStateFromError(): State {
+        // Update state so the next render will show the fallback UI.
+        return { hasError: true }
+    }
+
+    public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        console.error('Uncaught error:', error, errorInfo)
+    }
+
+    public render() {
+        if (this.state.hasError) {
+            return (
+                <div className={classes.root}>
+                    <div className={classes.rootContainer}>
+                        <Header />
+                        <p className="pl-2">Feil ved visning av tavla</p>
+                    </div>
+                </div>
+            )
+        }
+
+        return this.props.children
+    }
+}
+
+export { AppErrorBoundary }


### PR DESCRIPTION
Gets rid of generic error message displayed when client side errors occurs

From:
<img width="813" alt="Screenshot 2023-06-22 at 14 14 12" src="https://github.com/entur/tavla/assets/69514522/bee63d7c-59f0-4d86-ad48-d2c7c6920b81">
To:
<img width="888" alt="Screenshot 2023-06-22 at 14 15 05" src="https://github.com/entur/tavla/assets/69514522/12456825-8715-4865-a8c6-7ef92fe97685">
