### PR TITLE
fix(theme): dark as default theme and add converter

### DIFF
--- a/next-tavla/pages/[id].tsx
+++ b/next-tavla/pages/[id].tsx
@@ -31,7 +31,7 @@ export async function getServerSideProps({
 
 function BoardPage({ settings }: { settings: TSettings }) {
     return (
-        <div className={classes.root} data-theme={settings.theme}>
+        <div className={classes.root} data-theme={settings.theme || 'dark'}>
             <div className={classes.rootContainer}>
                 <Header theme={settings.theme} />
                 <Board settings={settings} />

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -11,7 +11,10 @@ function Landing() {
 
     async function handleCreateNewBoard() {
         setLoading(true)
-        const createdBoard = await addBoardSettings({ tiles: [] })
+        const createdBoard = await addBoardSettings({
+            tiles: [],
+            theme: 'dark',
+        })
         await router.push('/edit/' + createdBoard.id)
     }
 

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -13,7 +13,6 @@ function Landing() {
         setLoading(true)
         const createdBoard = await addBoardSettings({
             tiles: [],
-            theme: 'dark',
         })
         await router.push('/edit/' + createdBoard.id)
     }

--- a/next-tavla/src/Admin/scenarios/ThemeSettings/ThemeSettings.cy.tsx
+++ b/next-tavla/src/Admin/scenarios/ThemeSettings/ThemeSettings.cy.tsx
@@ -24,12 +24,12 @@ describe('<ThemeSettings />', () => {
 
     it('can change theme', () => {
         cy.mount(<TestComponent />)
-        cy.findByRole('radio', { name: 'Entur' }).should('be.checked')
+        cy.findByRole('radio', { name: 'Mørk' }).should('be.checked')
         cy.findByRole('radio', { name: 'Lyst' }).should('not.be.checked')
 
         cy.findByRole('radio', { name: 'Lyst' }).parent().click()
 
-        cy.findByRole('radio', { name: 'Entur' }).should('not.be.checked')
+        cy.findByRole('radio', { name: 'Mørk' }).should('not.be.checked')
         cy.findByRole('radio', { name: 'Lyst' }).should('be.checked')
     })
 })

--- a/next-tavla/src/Admin/scenarios/ThemeSettings/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ThemeSettings/index.tsx
@@ -4,12 +4,12 @@ import { TTheme } from 'types/settings'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
 
 const themes: Record<TTheme, string> = {
-    default: 'Entur',
+    entur: 'Entur',
     dark: 'Mørk',
     light: 'Lyst',
 }
 
-function ThemeSettings({ theme = 'default' }: { theme?: TTheme }) {
+function ThemeSettings({ theme = 'dark' }: { theme?: TTheme }) {
     const dispatch = useSettingsDispatch()
     return (
         <RadioGroup

--- a/next-tavla/src/Shared/types/settings.ts
+++ b/next-tavla/src/Shared/types/settings.ts
@@ -5,5 +5,5 @@ export type TTheme = 'entur' | 'dark' | 'light'
 export type TSettings = {
     tiles: TTile[]
     version?: number
-    theme?: TTheme
+    theme: TTheme
 }

--- a/next-tavla/src/Shared/types/settings.ts
+++ b/next-tavla/src/Shared/types/settings.ts
@@ -5,5 +5,5 @@ export type TTheme = 'entur' | 'dark' | 'light'
 export type TSettings = {
     tiles: TTile[]
     version?: number
-    theme: TTheme
+    theme?: TTheme
 }

--- a/next-tavla/src/Shared/types/settings.ts
+++ b/next-tavla/src/Shared/types/settings.ts
@@ -1,6 +1,6 @@
 import { TTile } from './tile'
 
-export type TTheme = 'default' | 'dark' | 'light'
+export type TTheme = 'entur' | 'dark' | 'light'
 
 export type TSettings = {
     tiles: TTile[]

--- a/next-tavla/src/Shared/utils/converters.test.ts
+++ b/next-tavla/src/Shared/utils/converters.test.ts
@@ -214,7 +214,6 @@ test('upgrade from base to latest version', () => {
 
     const end = {
         version: currentVersion,
-        theme: 'dark',
         tiles: [
             {
                 type: 'stop_place',

--- a/next-tavla/src/Shared/utils/converters.test.ts
+++ b/next-tavla/src/Shared/utils/converters.test.ts
@@ -1,4 +1,10 @@
-import { V1, V2, convertSettingsVersion, currentVersion } from './converters'
+import {
+    V1,
+    V2,
+    V3,
+    convertSettingsVersion,
+    currentVersion,
+} from './converters'
 import { expect, test } from '@jest/globals'
 
 test('upgrade from base to v1', () => {
@@ -118,6 +124,78 @@ test('upgrade from v1 to v2', () => {
     })
 })
 
+test('upgrade from v2 to v3', () => {
+    const v3 = V3({
+        theme: 'default',
+        tiles: [
+            {
+                type: 'stop_place',
+                placeId: 'NSR:StopPlace:60066',
+                uuid: '1234',
+                columns: [
+                    {
+                        type: 'platform',
+                    },
+                    {
+                        type: 'line',
+                    },
+                    {
+                        type: 'destination',
+                    },
+                    {
+                        type: 'time',
+                    },
+                ],
+            },
+            {
+                uuid: '1234',
+                columns: [
+                    {
+                        type: 'time',
+                    },
+                ],
+                placeId: 'NSR:StopPlace:20123',
+                type: 'stop_place',
+            },
+        ],
+    })
+
+    expect(v3).toStrictEqual({
+        theme: 'entur',
+        tiles: [
+            {
+                type: 'stop_place',
+                placeId: 'NSR:StopPlace:60066',
+                uuid: '1234',
+                columns: [
+                    {
+                        type: 'platform',
+                    },
+                    {
+                        type: 'line',
+                    },
+                    {
+                        type: 'destination',
+                    },
+                    {
+                        type: 'time',
+                    },
+                ],
+            },
+            {
+                uuid: '1234',
+                columns: [
+                    {
+                        type: 'time',
+                    },
+                ],
+                placeId: 'NSR:StopPlace:20123',
+                type: 'stop_place',
+            },
+        ],
+    })
+})
+
 test('upgrade from base to latest version', () => {
     const start = {
         tiles: [
@@ -136,6 +214,7 @@ test('upgrade from base to latest version', () => {
 
     const end = {
         version: currentVersion,
+        theme: 'dark',
         tiles: [
             {
                 type: 'stop_place',

--- a/next-tavla/src/Shared/utils/converters.ts
+++ b/next-tavla/src/Shared/utils/converters.ts
@@ -23,10 +23,12 @@ export function convertSettingsVersion(settings: any): TSettings {
 const versions = [V3, V2, V1] as const
 
 export function V3(setting: ReturnType<typeof V2>) {
-    if (!setting.theme) setting.theme = 'dark'
+    const { theme, ...rest } = setting
+    if (!theme) return rest
+
     return {
         ...setting,
-        theme: setting.theme === 'default' ? ('entur' as const) : setting.theme,
+        theme: theme === 'default' ? ('entur' as const) : theme,
     }
 }
 

--- a/next-tavla/src/Shared/utils/converters.ts
+++ b/next-tavla/src/Shared/utils/converters.ts
@@ -23,13 +23,14 @@ export function convertSettingsVersion(settings: any): TSettings {
 const versions = [V3, V2, V1] as const
 
 export function V3(setting: ReturnType<typeof V2>) {
-    const { theme, ...rest } = setting
-    if (!theme) return rest
-
-    return {
+    const newSetting = {
         ...setting,
-        theme: theme === 'default' ? ('entur' as const) : theme,
+        theme: setting.theme === 'default' ? ('entur' as const) : setting.theme,
     }
+
+    if (!newSetting.theme) delete newSetting.theme
+
+    return newSetting
 }
 
 export function V2(setting: ReturnType<typeof V1>) {

--- a/next-tavla/src/Shared/utils/converters.ts
+++ b/next-tavla/src/Shared/utils/converters.ts
@@ -20,7 +20,18 @@ export function convertSettingsVersion(settings: any): TSettings {
     }
 }
 
-const versions = [V2, V1] as const
+const versions = [V3, V2, V1] as const
+
+export function V3(setting: ReturnType<typeof V2>) {
+    const newSetting = {
+        ...setting,
+        theme: setting.theme === 'default' ? ('entur' as const) : setting.theme,
+    }
+
+    if (!newSetting.theme) delete setting.theme
+
+    return newSetting
+}
 
 export function V2(setting: ReturnType<typeof V1>) {
     return {

--- a/next-tavla/src/Shared/utils/converters.ts
+++ b/next-tavla/src/Shared/utils/converters.ts
@@ -23,14 +23,11 @@ export function convertSettingsVersion(settings: any): TSettings {
 const versions = [V3, V2, V1] as const
 
 export function V3(setting: ReturnType<typeof V2>) {
-    const newSetting = {
+    if (!setting.theme) setting.theme = 'dark'
+    return {
         ...setting,
         theme: setting.theme === 'default' ? ('entur' as const) : setting.theme,
     }
-
-    if (!newSetting.theme) delete setting.theme
-
-    return newSetting
 }
 
 export function V2(setting: ReturnType<typeof V1>) {


### PR DESCRIPTION
Changed the default theme to be dark when creating a board. A field in the theme settings is changed from "default" to "entur" and therefor a converter was created. 