### PR TITLE
fix(styling): change column names, less padding and smaller logo

### DIFF
--- a/next-tavla/src/Shared/components/Header/styles.module.css
+++ b/next-tavla/src/Shared/components/Header/styles.module.css
@@ -1,9 +1,10 @@
 .logo {
     height: auto;
-    width: 7em;
+    width: 6em;
 }
 
 .tagText {
-    font-size: 0.5em;
+    font-size: 0.4em;
     color: var(--main-text-color);
+    margin: 0;
 }

--- a/next-tavla/src/Shared/components/Tile/styles.module.css
+++ b/next-tavla/src/Shared/components/Tile/styles.module.css
@@ -3,7 +3,7 @@
     width: 100%;
     background-color: var(--secondary-background-color);
     color: var(--main-text-color);
-    padding: 1em;
+    padding: 0.5em 1em;
     border-radius: 0.5em;
     overflow: hidden;
 }

--- a/next-tavla/src/Shared/types/tile.ts
+++ b/next-tavla/src/Shared/types/tile.ts
@@ -3,8 +3,8 @@ import { TTransportMode } from './graphql-schema'
 export const Columns = {
     destination: 'Destinasjon',
     line: 'Linje',
-    platform: 'Plattform',
-    time: 'Avgangstid',
+    platform: 'Plf.',
+    time: 'Avgang',
     situations: 'Avvik',
 } as const
 


### PR DESCRIPTION
Small fixes on column names on board, less padding and the "Entur" logo is made smaller. 

<img width="1760" alt="Screenshot 2023-07-03 at 15 31 23" src="https://github.com/entur/tavla/assets/108051660/91bc484e-4cb5-4f77-b0d1-3925e5a01d4e">
