### PR TITLE
feat(edit): added tableheader to the quaytile

### DIFF
--- a/next-tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/next-tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -29,9 +29,9 @@ export function QuayTile({
     if (!data.quay) {
         return <Tile>Data not found</Tile>
     }
-    const transportModes = data.quay.lines
-        .map((line) => line.transportMode)
-        .filter((transporMode, pos, ar) => ar.indexOf(transporMode) === pos)
+    const transportModes = Array.from(
+        new Set(data.quay.lines.map((line) => line.transportMode)),
+    )
 
     const heading: string = [
         data.quay.name,

--- a/next-tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/next-tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -4,6 +4,7 @@ import classes from './styles.module.css'
 import { useQuery } from 'graphql/utils'
 import { GetQuayQuery } from 'graphql/index'
 import { Tile } from 'components/Tile'
+import { TableHeader } from '../Table/components/TableHeader'
 
 export function QuayTile({
     placeId,
@@ -27,15 +28,21 @@ export function QuayTile({
     if (!data.quay) {
         return <Tile>Data not found</Tile>
     }
-
+    const transportModes = data.quay.lines
+        .map((line) => line.transportMode)
+        .filter((transporMode, pos, ar) => ar.indexOf(transporMode) === pos)
+    console.log(data.quay.publicCode)
+    console.log(data.quay.description)
     return (
         <Tile className={classes.quayTile}>
-            <div className={classes.heading}>
-                <h3>{data.quay.name}</h3>
-                <h4>
-                    {data.quay.publicCode} {data.quay.description}
-                </h4>
-            </div>
+            <TableHeader
+                heading={
+                    data.quay.publicCode
+                        ? data.quay.name + ' ' + data.quay.publicCode
+                        : data.quay.name
+                }
+                transportModes={transportModes}
+            />
             <Table departures={data.quay.estimatedCalls} />
         </Tile>
     )

--- a/next-tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/next-tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -5,6 +5,7 @@ import { useQuery } from 'graphql/utils'
 import { GetQuayQuery } from 'graphql/index'
 import { Tile } from 'components/Tile'
 import { TableHeader } from '../Table/components/TableHeader'
+import { isNotNullOrUndefined } from 'utils/typeguards'
 
 export function QuayTile({
     placeId,
@@ -31,18 +32,18 @@ export function QuayTile({
     const transportModes = data.quay.lines
         .map((line) => line.transportMode)
         .filter((transporMode, pos, ar) => ar.indexOf(transporMode) === pos)
-    console.log(data.quay.publicCode)
-    console.log(data.quay.description)
+
+    const heading: string = [
+        data.quay.name,
+        data.quay.publicCode,
+        data.quay.description,
+    ]
+        .filter(isNotNullOrUndefined)
+        .join(' ')
+
     return (
         <Tile className={classes.quayTile}>
-            <TableHeader
-                heading={
-                    data.quay.publicCode
-                        ? data.quay.name + ' ' + data.quay.publicCode
-                        : data.quay.name
-                }
-                transportModes={transportModes}
-            />
+            <TableHeader heading={heading} transportModes={transportModes} />
             <Table departures={data.quay.estimatedCalls} />
         </Tile>
     )

--- a/next-tavla/src/Shared/graphql/fragments/lines.graphql
+++ b/next-tavla/src/Shared/graphql/fragments/lines.graphql
@@ -3,5 +3,6 @@ fragment lines on Quay {
         id
         publicCode
         name
+        transportMode
     }
 }

--- a/next-tavla/src/Shared/graphql/index.ts
+++ b/next-tavla/src/Shared/graphql/index.ts
@@ -52,6 +52,7 @@ export type TLinesFragment = {
         id: string
         publicCode: string | null
         name: string | null
+        transportMode: Types.TTransportMode | null
     }>
 }
 
@@ -135,6 +136,7 @@ export type TGetQuayQuery = {
             id: string
             publicCode: string | null
             name: string | null
+            transportMode: Types.TTransportMode | null
         }>
     } | null
 }
@@ -234,6 +236,7 @@ export type TStopPlaceSettingsQuery = {
                 id: string
                 publicCode: string | null
                 name: string | null
+                transportMode: Types.TTransportMode | null
             }>
         } | null> | null
     } | null
@@ -319,6 +322,7 @@ export const LinesFragment = new TypedDocumentString(
     id
     publicCode
     name
+    transportMode
   }
 }
     `,
@@ -373,6 +377,7 @@ fragment lines on Quay {
     id
     publicCode
     name
+    transportMode
   }
 }
 fragment situation on PtSituationElement {
@@ -467,6 +472,7 @@ export const StopPlaceSettingsQuery = new TypedDocumentString(`
     id
     publicCode
     name
+    transportMode
   }
 }`) as unknown as TypedDocumentString<
     TStopPlaceSettingsQuery,


### PR DESCRIPTION
Added tableheader with transporticons  to the quaytile. Shows public code and description if they are defined

<img width="795" alt="Screenshot 2023-07-13 at 14 31 00" src="https://github.com/entur/tavla/assets/64434819/66cd4ea0-707c-43f3-9095-b2a2824e6e3f">
