### PR TITLE
feat(edit): toggle optional columns

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -22,7 +22,6 @@ function Edit({
 }) {
     const [settings, dispatch] = useReducer(settingsReducer, initialSettings)
     const linkUrl = window.location.host + '/' + documentId
-
     return (
         <SettingsDispatchContext.Provider value={dispatch}>
             <ToastProvider>
@@ -30,7 +29,7 @@ function Edit({
                     <AddTile />
                     <TilesOverview tiles={settings.tiles} />
                     <ShareTable text={linkUrl} />
-                    <ToggelColumns tiles={settings.tiles} />
+                    <ToggelColumns tile={settings.tiles[0]} />
                     <div className={classes.floatingButtonWrapper}>
                         <FloatingButton
                             className={classes.saveButton}

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -11,6 +11,7 @@ import { ToastProvider } from '@entur/alert'
 import { FloatingButton } from '@entur/button'
 import { StyledLink } from 'Admin/components/StyledLink'
 import { ShareTable } from '../ShareTable'
+import { ToggelColumns } from '../ToggleColumns'
 
 function Edit({
     initialSettings,
@@ -28,9 +29,8 @@ function Edit({
                 <div className={classes.settings}>
                     <AddTile />
                     <TilesOverview tiles={settings.tiles} />
-
                     <ShareTable text={linkUrl} />
-
+                    <ToggelColumns tiles={settings.tiles} />
                     <div className={classes.floatingButtonWrapper}>
                         <FloatingButton
                             className={classes.saveButton}

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -11,7 +11,7 @@ import { ToastProvider } from '@entur/alert'
 import { FloatingButton } from '@entur/button'
 import { StyledLink } from 'Admin/components/StyledLink'
 import { ShareTable } from '../ShareTable'
-import { ToggelColumns } from '../ToggleColumns'
+import { ToggleColumns } from '../ToggleColumns'
 
 function Edit({
     initialSettings,
@@ -29,7 +29,7 @@ function Edit({
                     <AddTile />
                     <TilesOverview tiles={settings.tiles} />
                     <ShareTable text={linkUrl} />
-                    <ToggelColumns tile={settings.tiles[0]} />
+                    <ToggleColumns tile={settings.tiles[0]} />
                     <div className={classes.floatingButtonWrapper}>
                         <FloatingButton
                             className={classes.saveButton}

--- a/next-tavla/src/Admin/scenarios/Edit/reducer.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/reducer.tsx
@@ -13,7 +13,7 @@ export type Action =
     | { type: 'updateTile'; tileIndex: number; tile: TTile }
     | { type: 'swapTiles'; oldIndex: number; newIndex: number }
     | { type: 'toggleLine'; tileId: string; lineId: string }
-    | { type: 'toggleColumn'; tileId: string; column: TColumn; value: boolean }
+    | { type: 'setColumn'; tileId: string; column: TColumn; value: boolean }
 
 export function settingsReducer(
     settings: TSettings,
@@ -93,7 +93,7 @@ export function settingsReducer(
                 },
             )
         }
-        case 'toggleColumn': {
+        case 'setColumn': {
             return changeTile<TStopPlaceTile | TQuayTile>(
                 action.tileId,
                 (tile) => {

--- a/next-tavla/src/Admin/scenarios/Edit/reducer.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/reducer.tsx
@@ -2,7 +2,7 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { TAnonTiles } from 'Admin/types'
 import { clone, xor } from 'lodash'
 import { nanoid } from 'nanoid'
-import { TColumnSettings } from 'types/column'
+import { TColumn } from 'types/column'
 import { TSettings, TTheme } from 'types/settings'
 import { TQuayTile, TStopPlaceTile, TTile } from 'types/tile'
 
@@ -13,7 +13,7 @@ export type Action =
     | { type: 'updateTile'; tileIndex: number; tile: TTile }
     | { type: 'swapTiles'; oldIndex: number; newIndex: number }
     | { type: 'toggleLine'; tileId: string; lineId: string }
-    | { type: 'toggleColumn'; tileId: string; setting: TColumnSettings }
+    | { type: 'toggleColumn'; tileId: string; column: TColumn; value: boolean }
 
 export function settingsReducer(
     settings: TSettings,
@@ -97,12 +97,12 @@ export function settingsReducer(
             return changeTile<TStopPlaceTile | TQuayTile>(
                 action.tileId,
                 (tile) => {
-                    if (!tile.columns)
-                        return { ...tile, columns: action.setting }
-
                     return {
                         ...tile,
-                        columns: { ...tile.columns, ...action.setting },
+                        columns: {
+                            ...tile.columns,
+                            ...{ [action.column]: action.value },
+                        },
                     }
                 },
             )

--- a/next-tavla/src/Admin/scenarios/Edit/reducer.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/reducer.tsx
@@ -2,6 +2,7 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { TAnonTiles } from 'Admin/types'
 import { clone, xor } from 'lodash'
 import { nanoid } from 'nanoid'
+import { TColumnSettings } from 'types/column'
 import { TSettings, TTheme } from 'types/settings'
 import { TQuayTile, TStopPlaceTile, TTile } from 'types/tile'
 
@@ -12,6 +13,7 @@ export type Action =
     | { type: 'updateTile'; tileIndex: number; tile: TTile }
     | { type: 'swapTiles'; oldIndex: number; newIndex: number }
     | { type: 'toggleLine'; tileId: string; lineId: string }
+    | { type: 'toggleColumn'; tileId: string; setting: TColumnSettings }
 
 export function settingsReducer(
     settings: TSettings,
@@ -87,6 +89,20 @@ export function settingsReducer(
                         whitelistedLines: xor(tile.whitelistedLines, [
                             action.lineId,
                         ]),
+                    }
+                },
+            )
+        }
+        case 'toggleColumn': {
+            return changeTile<TStopPlaceTile | TQuayTile>(
+                action.tileId,
+                (tile) => {
+                    if (!tile.columns)
+                        return { ...tile, columns: action.setting }
+
+                    return {
+                        ...tile,
+                        columns: { ...tile.columns, ...action.setting },
                     }
                 },
             )

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,33 +1,45 @@
-import { Switch } from '@entur/form'
-import { Label } from '@entur/typography'
+import { Heading2 } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
-import { useState } from 'react'
-import { TColumn } from 'types/column'
+import { TColumn, TColumnSettings } from 'types/column'
 import { TTile } from 'types/tile'
+import { Switch } from '@entur/form'
+import { useState } from 'react'
 
-function ToggelColumns({ tiles }: { tiles: TTile[] }) {
-    const [checked, setChecked] = useState(false)
-
+function ToggelColumns({ tile }: { tile: TTile }) {
     const dispatch = useSettingsDispatch()
+    const [checked, setChecked] = useState(tile.columns?.platform)
 
-    function handleSwitch(column: TColumn) {
-        tiles.map((tile) => {
-            dispatch({
-                type: 'toggleColumn',
-                column: column,
-                value: !checked,
-                tileId: tile.uuid,
-            })
+    const optionalColumns: TColumn[] = ['platform', 'via']
+
+    function handleSwitch(column: TColumn, value: boolean) {
+        dispatch({
+            type: 'toggleColumn',
+            column: column,
+            value: value,
+            tileId: tile.uuid,
         })
-        setChecked(!checked)
     }
 
     return (
         <div>
-            <Label>Legg til informasjon</Label>
-            <Switch checked={checked} onChange={() => handleSwitch('platform')}>
-                Platform
-            </Switch>
+            <Heading2>Legg til informasjon</Heading2>
+
+            {optionalColumns.map((col) => {
+                return (
+                    <Switch
+                        key={col}
+                        checked={tile.columns && tile.columns[col]}
+                        onChange={() =>
+                            handleSwitch(
+                                col,
+                                !(tile.columns && tile.columns[col]),
+                            )
+                        }
+                    >
+                        {col}
+                    </Switch>
+                )
+            })}
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -4,7 +4,7 @@ import { DefaultColumns, TColumn } from 'types/column'
 import { TTile } from 'types/tile'
 import { Switch } from '@entur/form'
 
-function ToggelColumns({ tile }: { tile: TTile }) {
+function ToggleColumns({ tile }: { tile: TTile }) {
     const dispatch = useSettingsDispatch()
 
     const optionalColumns: TColumn[] = ['platform', 'via']
@@ -37,4 +37,4 @@ function ToggelColumns({ tile }: { tile: TTile }) {
     )
 }
 
-export { ToggelColumns }
+export { ToggleColumns }

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -11,7 +11,7 @@ function ToggleColumns({ tile }: { tile: TTile }) {
 
     function handleSwitch(column: TColumn, value: boolean) {
         dispatch({
-            type: 'toggleColumn',
+            type: 'setColumn',
             column: column,
             value: value,
             tileId: tile.uuid,

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -26,7 +26,7 @@ function ToggelColumns({ tile }: { tile: TTile }) {
                 return (
                     <Switch
                         key={col}
-                        checked={tile.columns && tile.columns[col]}
+                        checked={tile.columns ? tile?.columns[col] : false}
                         onChange={() =>
                             handleSwitch(
                                 col,

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,7 +1,35 @@
+import { Switch } from '@entur/form'
+import { Label } from '@entur/typography'
+import { useSettingsDispatch } from 'Admin/utils/contexts'
+import { useState } from 'react'
+import { TColumn } from 'types/column'
 import { TTile } from 'types/tile'
 
 function ToggelColumns({ tiles }: { tiles: TTile[] }) {
-    return <>{tiles}</>
+    const [checked, setChecked] = useState(false)
+
+    const dispatch = useSettingsDispatch()
+
+    function handleSwitch(column: TColumn) {
+        tiles.map((tile) => {
+            dispatch({
+                type: 'toggleColumn',
+                column: column,
+                value: !checked,
+                tileId: tile.uuid,
+            })
+        })
+        setChecked(!checked)
+    }
+
+    return (
+        <div>
+            <Label>Legg til informasjon</Label>
+            <Switch checked={checked} onChange={() => handleSwitch('platform')}>
+                Platform
+            </Switch>
+        </div>
+    )
 }
 
 export { ToggelColumns }

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,0 +1,7 @@
+import { TTile } from 'types/tile'
+
+function ToggelColumns({ tiles }: { tiles: TTile[] }) {
+    return <>{tiles}</>
+}
+
+export { ToggelColumns }

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,13 +1,11 @@
 import { Heading2 } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
-import { TColumn, TColumnSettings } from 'types/column'
+import { TColumn } from 'types/column'
 import { TTile } from 'types/tile'
 import { Switch } from '@entur/form'
-import { useState } from 'react'
 
 function ToggelColumns({ tile }: { tile: TTile }) {
     const dispatch = useSettingsDispatch()
-    const [checked, setChecked] = useState(tile.columns?.platform)
 
     const optionalColumns: TColumn[] = ['platform', 'via']
 

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,6 +1,6 @@
-import { Heading2 } from '@entur/typography'
+import { Heading3 } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
-import { TColumn } from 'types/column'
+import { DefaultColumns, TColumn } from 'types/column'
 import { TTile } from 'types/tile'
 import { Switch } from '@entur/form'
 
@@ -17,22 +17,17 @@ function ToggelColumns({ tile }: { tile: TTile }) {
             tileId: tile.uuid,
         })
     }
-
+    const columns = { ...DefaultColumns, ...tile.columns }
     return (
         <div>
-            <Heading2>Legg til informasjon</Heading2>
+            <Heading3>Legg til informasjon</Heading3>
 
             {optionalColumns.map((col) => {
                 return (
                     <Switch
                         key={col}
-                        checked={tile.columns ? tile?.columns[col] : false}
-                        onChange={() =>
-                            handleSwitch(
-                                col,
-                                !(tile.columns && tile.columns[col]),
-                            )
-                        }
+                        checked={columns[col]}
+                        onChange={() => handleSwitch(col, !columns[col])}
                     >
                         {col}
                     </Switch>

--- a/next-tavla/src/Shared/types/column.ts
+++ b/next-tavla/src/Shared/types/column.ts
@@ -16,7 +16,7 @@ export const DefaultColumns: TColumnSettings = {
     platform: false,
     situations: true,
     time: true,
-    via: true,
+    via: false,
 } as const
 
 export type TColumnSize = { type: TColumn; size: number }


### PR DESCRIPTION
Added toggle columns to the edit page. the component only changes the first tile in the tiles list and not the rest. Not supposed to be where its put but added to show functionality


<img width="313" alt="Screenshot 2023-07-13 at 12 18 10" src="https://github.com/entur/tavla/assets/64434819/cf07e97b-fdd9-4d6c-be42-6b34b4a03806">
