### PR TITLE
feat(edit): adds toggle to tileoverview

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -11,7 +11,6 @@ import { ToastProvider } from '@entur/alert'
 import { FloatingButton } from '@entur/button'
 import { StyledLink } from 'Admin/components/StyledLink'
 import { ShareTable } from '../ShareTable'
-import { ToggleColumns } from '../ToggleColumns'
 
 function Edit({
     initialSettings,
@@ -29,7 +28,6 @@ function Edit({
                     <AddTile />
                     <TilesOverview tiles={settings.tiles} />
                     <ShareTable text={linkUrl} />
-                    <ToggleColumns tile={settings.tiles[0]} />
                     <div className={classes.floatingButtonWrapper}>
                         <FloatingButton
                             className={classes.saveButton}

--- a/next-tavla/src/Admin/scenarios/TileSettings/components/QuaySettings.tsx
+++ b/next-tavla/src/Admin/scenarios/TileSettings/components/QuaySettings.tsx
@@ -4,6 +4,7 @@ import { useQuery } from 'graphql/utils'
 import { TQuayTile } from 'types/tile'
 import { fieldsNotNull } from 'utils/typeguards'
 import { TileSettingsWrapper } from './TileSettingsWrapper'
+import { ToggleColumns } from 'Admin/scenarios/ToggleColumns'
 
 function QuaySettings({ tile }: { tile: TQuayTile }) {
     const { data } = useQuery(GetQuayQuery, { quayId: tile.placeId })
@@ -19,6 +20,7 @@ function QuaySettings({ tile }: { tile: TQuayTile }) {
     return (
         <TileSettingsWrapper name={name}>
             <SelectLines tile={tile} lines={lines} />
+            <ToggleColumns tile={tile} />
         </TileSettingsWrapper>
     )
 }

--- a/next-tavla/src/Admin/scenarios/TileSettings/components/StopPlaceSettings.tsx
+++ b/next-tavla/src/Admin/scenarios/TileSettings/components/StopPlaceSettings.tsx
@@ -4,6 +4,7 @@ import { useQuery } from 'graphql/utils'
 import { TStopPlaceTile } from 'types/tile'
 import { fieldsNotNull } from 'utils/typeguards'
 import { TileSettingsWrapper } from './TileSettingsWrapper'
+import { ToggleColumns } from 'Admin/scenarios/ToggleColumns'
 
 function StopPlaceSettings({ tile }: { tile: TStopPlaceTile }) {
     const { data } = useQuery(StopPlaceSettingsQuery, { id: tile.placeId })
@@ -18,6 +19,7 @@ function StopPlaceSettings({ tile }: { tile: TStopPlaceTile }) {
     return (
         <TileSettingsWrapper name={name}>
             <SelectLines tile={tile} lines={lines} />
+            <ToggleColumns tile={tile} />
         </TileSettingsWrapper>
     )
 }

--- a/next-tavla/src/Admin/scenarios/TileSettings/components/TileSettingsWrapper/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/TileSettings/components/TileSettingsWrapper/styles.module.css
@@ -15,4 +15,5 @@
 
 .content {
     overflow: auto;
+    position: relative;
 }

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -21,7 +21,7 @@ function ToggleColumns({ tile }: { tile: TTile }) {
     const columns = { ...DefaultColumns, ...tile.columns }
     return (
         <div>
-            <Heading4>Legg til ekstra detaljer til holdeplassen</Heading4>
+            <Heading4>Legg til ekstra detaljer om holdeplassen</Heading4>
             <Label className={classes.toggleLable}>
                 Denne ekstra informasjonen vil bli lagt til i denne spesifikke
                 holdeplassen, dersom du krysser den av. <br /> Fra før av vises:

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,4 +1,4 @@
-import { Heading3 } from '@entur/typography'
+import { Heading3, Heading4 } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
 import { DefaultColumns, TColumn } from 'types/column'
 import { TTile } from 'types/tile'
@@ -20,7 +20,7 @@ function ToggleColumns({ tile }: { tile: TTile }) {
     const columns = { ...DefaultColumns, ...tile.columns }
     return (
         <div>
-            <Heading3>Legg til informasjon</Heading3>
+            <Heading4>Legg til informasjon</Heading4>
 
             {optionalColumns.map((col) => {
                 return (

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,4 +1,4 @@
-import { Heading4, Label } from '@entur/typography'
+import { Heading4, Label, SubParagraph } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
 import { Columns, DefaultColumns, TColumn } from 'types/column'
 import { TTile } from 'types/tile'
@@ -22,11 +22,11 @@ function ToggleColumns({ tile }: { tile: TTile }) {
     return (
         <div>
             <Heading4>Legg til ekstra detaljer om holdeplassen</Heading4>
-            <Label className={classes.toggleLable}>
+            <SubParagraph>
                 Denne ekstra informasjonen vil bli lagt til i denne spesifikke
                 holdeplassen, dersom du krysser den av. <br /> Fra før av vises:
                 linje, destinasjon, avvik og avgangstid
-            </Label>
+            </SubParagraph>
             <div className={classes.columnToggleWrapper}>
                 {optionalColumns.map((col) => {
                     return (

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -21,11 +21,12 @@ function ToggleColumns({ tile }: { tile: TTile }) {
     const columns = { ...DefaultColumns, ...tile.columns }
     return (
         <div>
-            <Heading4>Legg til ekstra detaljer om holdeplassen</Heading4>
+            <Heading4>Legg til ekstra detaljer i tabellen</Heading4>
             <SubParagraph>
-                Denne ekstra informasjonen vil bli lagt til i denne spesifikke
-                holdeplassen, dersom du krysser den av. <br /> Fra før av vises:
-                linje, destinasjon, avvik og avgangstid
+                Linje, destinasjon, avvik og avgangstid vil alltid vises i
+                tabellen. <br />
+                Her kan du legge til ekstra detaljer i denne holdeplassen sin
+                tabell.
             </SubParagraph>
             <div className={classes.columnToggleWrapper}>
                 {optionalColumns.map((col) => {

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,8 +1,9 @@
-import { Heading3, Heading4 } from '@entur/typography'
+import { Heading4, Label } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
-import { DefaultColumns, TColumn } from 'types/column'
+import { Columns, DefaultColumns, TColumn } from 'types/column'
 import { TTile } from 'types/tile'
 import { Switch } from '@entur/form'
+import classes from './styles.module.css'
 
 function ToggleColumns({ tile }: { tile: TTile }) {
     const dispatch = useSettingsDispatch()
@@ -20,19 +21,24 @@ function ToggleColumns({ tile }: { tile: TTile }) {
     const columns = { ...DefaultColumns, ...tile.columns }
     return (
         <div>
-            <Heading4>Legg til informasjon</Heading4>
-
-            {optionalColumns.map((col) => {
-                return (
-                    <Switch
-                        key={col}
-                        checked={columns[col]}
-                        onChange={() => handleSwitch(col, !columns[col])}
-                    >
-                        {col}
-                    </Switch>
-                )
-            })}
+            <Heading4>Legg til ekstra detaljer til holdeplassen</Heading4>
+            <Label>
+                Denne ekstra informasjonen vil bli lagt til i denne spesifikke
+                holdeplassen, dersom du krysser den av.
+            </Label>
+            <div className={classes.columnToggleWrapper}>
+                {optionalColumns.map((col) => {
+                    return (
+                        <Switch
+                            key={col}
+                            checked={columns[col]}
+                            onChange={() => handleSwitch(col, !columns[col])}
+                        >
+                            {Columns[col]}
+                        </Switch>
+                    )
+                })}
+            </div>
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -1,4 +1,4 @@
-import { Heading4, Label, SubParagraph } from '@entur/typography'
+import { Heading4, SubParagraph } from '@entur/typography'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
 import { Columns, DefaultColumns, TColumn } from 'types/column'
 import { TTile } from 'types/tile'

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/index.tsx
@@ -22,9 +22,10 @@ function ToggleColumns({ tile }: { tile: TTile }) {
     return (
         <div>
             <Heading4>Legg til ekstra detaljer til holdeplassen</Heading4>
-            <Label>
+            <Label className={classes.toggleLable}>
                 Denne ekstra informasjonen vil bli lagt til i denne spesifikke
-                holdeplassen, dersom du krysser den av.
+                holdeplassen, dersom du krysser den av. <br /> Fra før av vises:
+                linje, destinasjon, avvik og avgangstid
             </Label>
             <div className={classes.columnToggleWrapper}>
                 {optionalColumns.map((col) => {

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/styles.module.css
@@ -1,0 +1,4 @@
+.columnToggleWrapper {
+    display: flex;
+    gap: 1em;
+}

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/styles.module.css
@@ -3,7 +3,3 @@
     gap: 1em;
     margin: 1em;
 }
-
-.toggleLable {
-    color: var(--main-text-color);
-}

--- a/next-tavla/src/Admin/scenarios/ToggleColumns/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/ToggleColumns/styles.module.css
@@ -1,4 +1,9 @@
 .columnToggleWrapper {
     display: flex;
     gap: 1em;
+    margin: 1em;
+}
+
+.toggleLable {
+    color: var(--main-text-color);
 }


### PR DESCRIPTION
Added the toggle column component to the tileoverview component. Fixes error when creating a new board by using the button on the landing page and doesn't use the first tile in the list but the certain tile tiles overview. 

<img width="899" alt="Screenshot 2023-07-14 at 12 23 12" src="https://github.com/entur/tavla/assets/64434819/06b1cdb8-607b-4feb-83e3-99aee170fbfd">


