### PR TITLE
feat(table): alternates between deviations in table

### DIFF
--- a/next-tavla/src/Board/scenarios/Table/components/Situation/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situation/index.tsx
@@ -26,9 +26,10 @@ function ValidationExclamation(props: SVGProps<SVGSVGElement>) {
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
-            width={16}
-            height={16}
+            width={'1em'}
+            height={'1em'}
             xmlSpace="preserve"
+            viewBox="0 0 16 16"
             {...props}
         >
             <circle fill="transparent" cx={8} cy={8} r={4.4} />

--- a/next-tavla/src/Board/scenarios/Table/components/Situation/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/components/Situation/styles.module.css
@@ -3,6 +3,7 @@
     font-size: 0.875em;
     display: flex;
     align-items: center;
+    white-space: pre-line;
 }
 
 .situationText {

--- a/next-tavla/src/Board/scenarios/Table/components/Situation/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/components/Situation/styles.module.css
@@ -16,4 +16,5 @@
     display: flex;
     align-items: center;
     margin-right: 0.1em;
+    font-size: 1.8em;
 }

--- a/next-tavla/src/Board/scenarios/Table/components/Situation/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/components/Situation/styles.module.css
@@ -3,7 +3,7 @@
     font-size: 0.875em;
     display: flex;
     align-items: center;
-    white-space: pre-line;
+    white-space: normal;
 }
 
 .situationText {

--- a/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
@@ -1,16 +1,33 @@
 import { Situation } from '../Situation'
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { DepartureContext } from '../../contexts'
+import { useEffect, useState } from 'react'
 
 function Situations() {
     const departure = useNonNullContext(DepartureContext)
 
+    const situations = departure.situations.map((situation) => (
+        <Situation key={situation.id} situation={situation} />
+    ))
+
+    const nSituations = situations.length
+    const [index, setIndex] = useState(0)
+
+    useEffect(() => {
+        if (nSituations < 1) {
+            return
+        }
+        const interval = setInterval(
+            () => setIndex((i) => (i + 1) % nSituations),
+            5000,
+        )
+        return () => clearInterval(interval)
+    }, [nSituations])
+
     return (
         <td>
             <div>
-                {departure.situations.map((situation) => (
-                    <Situation key={situation.id} situation={situation} />
-                ))}
+                {situations.length > 1 ? situations[index] : situations[0]}
             </div>
         </td>
     )

--- a/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
@@ -13,17 +13,16 @@ function Situations() {
         if (numberOfSituations <= 1) {
             return
         }
-        const interval = setInterval(
-            () => setIndex((i) => (i + 1) % numberOfSituations),
-            5000,
-        )
+        const interval = setInterval(() => setIndex((i) => i + 1), 5000)
         return () => clearInterval(interval)
     }, [numberOfSituations])
 
     return (
         <td>
             {numberOfSituations ? (
-                <Situation situation={departure.situations[index]} />
+                <Situation
+                    situation={departure.situations[index % numberOfSituations]}
+                />
             ) : null}
         </td>
     )

--- a/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
@@ -22,7 +22,9 @@ function Situations() {
 
     return (
         <td>
-            <Situation situation={departure.situations[index]} />
+            {numberOfSituations ? (
+                <Situation situation={departure.situations[index]} />
+            ) : null}
         </td>
     )
 }

--- a/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
@@ -22,9 +22,7 @@ function Situations() {
 
     return (
         <td>
-            <div>
-                <Situation situation={departure.situations[index]} />
-            </div>
+            <Situation situation={departure.situations[index]} />
         </td>
     )
 }

--- a/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
@@ -10,25 +10,23 @@ function Situations() {
         <Situation key={situation.id} situation={situation} />
     ))
 
-    const nSituations = situations.length
+    const numberOfSituations = situations.length
     const [index, setIndex] = useState(0)
 
     useEffect(() => {
-        if (nSituations < 1) {
+        if (numberOfSituations <= 1) {
             return
         }
         const interval = setInterval(
-            () => setIndex((i) => (i + 1) % nSituations),
+            () => setIndex((i) => (i + 1) % numberOfSituations),
             5000,
         )
         return () => clearInterval(interval)
-    }, [nSituations])
+    }, [numberOfSituations])
 
     return (
         <td>
-            <div>
-                {situations.length > 1 ? situations[index] : situations[0]}
-            </div>
+            <div>{situations[index]}</div>
         </td>
     )
 }

--- a/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Situations/index.tsx
@@ -6,11 +6,7 @@ import { useEffect, useState } from 'react'
 function Situations() {
     const departure = useNonNullContext(DepartureContext)
 
-    const situations = departure.situations.map((situation) => (
-        <Situation key={situation.id} situation={situation} />
-    ))
-
-    const numberOfSituations = situations.length
+    const numberOfSituations = departure.situations.length
     const [index, setIndex] = useState(0)
 
     useEffect(() => {
@@ -26,7 +22,9 @@ function Situations() {
 
     return (
         <td>
-            <div>{situations[index]}</div>
+            <div>
+                <Situation situation={departure.situations[index]} />
+            </div>
         </td>
     )
 }


### PR DESCRIPTION
Added functionality to the table such that if a line has more than 1 deviation it alternates between each deviation. Each is shown for 5 seconds before it switches to the next one. 

<img width="1486" alt="Screenshot 2023-07-17 at 14 27 51" src="https://github.com/entur/tavla/assets/64434819/0af46148-ef1a-4223-95be-c481596bb070">

<img width="1519" alt="Screenshot 2023-07-17 at 14 27 47" src="https://github.com/entur/tavla/assets/64434819/70f1b53c-65ca-4459-9278-133da6267047">

Can for example use line 81, "jernbanetorget" to test
