### PR TITLE
fix(board): fixed bug where tablerows spread if there are few rows

### DIFF
--- a/next-tavla/src/Board/scenarios/Table/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/styles.module.css
@@ -11,7 +11,6 @@
 }
 
 .table {
-    max-height: 100%;
     border-collapse: collapse;
     width: 100%;
     table-layout: fixed;

--- a/next-tavla/src/Board/scenarios/Table/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/styles.module.css
@@ -11,7 +11,7 @@
 }
 
 .table {
-    height: 100%;
+    max-height: 100%;
     border-collapse: collapse;
     width: 100%;
     table-layout: fixed;


### PR DESCRIPTION
after
<img width="1457" alt="Screenshot 2023-07-18 at 13 14 28" src="https://github.com/entur/tavla/assets/64434819/6a2cc0a9-07b4-4382-90ea-2daa4b89c5b1">

before: 
<img width="1619" alt="Screenshot 2023-07-18 at 13 17 33" src="https://github.com/entur/tavla/assets/64434819/224526e6-374d-44da-9958-86e4ace05ee7">
