### PR TITLE
fix(typo): typo in ShareTable heading

### DIFF
--- a/next-tavla/src/Admin/scenarios/ShareTable/index.tsx
+++ b/next-tavla/src/Admin/scenarios/ShareTable/index.tsx
@@ -5,9 +5,9 @@ import classes from './styles.module.css'
 function ShareTable({ text }: { text: string }) {
     return (
         <div>
-            <Heading1 className={classes.heading}>Del avganstavla</Heading1>
+            <Heading1 className={classes.heading}>Del avgangstavla</Heading1>
             <Paragraph className={classes.paragraph}>
-                Trykk på knappen for å kopiere linken til avganstavla.
+                Trykk på knappen for å kopiere linken til avgangstavla.
             </Paragraph>
             <CopyText text={text} toastText="Kopiert lenke" />
         </div>


### PR DESCRIPTION
from:
![Screenshot 2023-07-19 at 13 35 42](https://github.com/entur/tavla/assets/69514522/b2a70e6c-4478-40be-b856-f895b14cd0e2)

to:
<img width="452" alt="Screenshot 2023-07-19 at 13 37 48" src="https://github.com/entur/tavla/assets/69514522/58393446-c243-4032-9b20-e4a8607644c6">
