### PR TITLE
fix(edit + board): clarify information 

### DIFF
--- a/next-tavla/pages/edit/[id].tsx
+++ b/next-tavla/pages/edit/[id].tsx
@@ -35,7 +35,7 @@ export async function getServerSideProps({
 function AdminPage({ settings, id }: { settings: TSettings; id: string }) {
     return (
         <Contrast className={classes.root}>
-            <ToastProvider>
+            <ToastProvider position={'top-right'}>
                 <Header />
                 <Edit initialSettings={settings} documentId={id} />
             </ToastProvider>

--- a/next-tavla/pages/edit/[id].tsx
+++ b/next-tavla/pages/edit/[id].tsx
@@ -35,7 +35,7 @@ export async function getServerSideProps({
 function AdminPage({ settings, id }: { settings: TSettings; id: string }) {
     return (
         <Contrast className={classes.root}>
-            <ToastProvider position={'top-right'}>
+            <ToastProvider position="top-right">
                 <Header />
                 <Edit initialSettings={settings} documentId={id} />
             </ToastProvider>

--- a/next-tavla/src/Board/scenarios/Table/components/TableHeader/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/components/TableHeader/styles.module.css
@@ -1,6 +1,5 @@
 .headerWrapper {
     display: flex;
-    justify-content: space-between;
     align-items: center;
 }
 

--- a/next-tavla/src/Board/scenarios/Table/components/Time/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Table/components/Time/styles.module.css
@@ -10,5 +10,4 @@
 
 .expectedDepartureTime {
     font-weight: 600;
-    color: var(--table-time-deviation-color);
 }

--- a/next-tavla/src/Shared/styles/themes/default.css
+++ b/next-tavla/src/Shared/styles/themes/default.css
@@ -12,8 +12,6 @@
     --table-border-color: var(--colors-blues-blue30);
     --table-situation-color: var(--colors-validation-canary-contrast);
 
-    --table-time-deviation-color: var(--colors-validation-lava-contrast);
-
     --table-transport-metro-color: var(--colors-transport-contrast-metro);
     --table-transport-bus-color: var(--colors-transport-contrast-bus);
     --table-transport-tram-color: var(--colors-transport-contrast-tram);

--- a/next-tavla/src/Shared/styles/themes/light.css
+++ b/next-tavla/src/Shared/styles/themes/light.css
@@ -13,8 +13,6 @@
     --table-border-color: var(--colors-greys-grey60);
     --table-situation-color: var(--colors-misc-black);
 
-    --table-time-deviation-color: var(--colors-validation-lava);
-
     --table-transport-metro-color: var(--colors-transport-default-metro);
     --table-transport-bus-color: var(--colors-transport-default-bus);
     --table-transport-tram-color: var(--colors-transport-default-tram);


### PR DESCRIPTION
Move transport icons next to header: 
![Screenshot 2023-07-20 at 15 19 28](https://github.com/entur/tavla/assets/108051660/d9d09fad-a925-4382-ab63-81978d1d623f)

Remove pink color on late departure: 
![Screenshot 2023-07-20 at 15 20 00](https://github.com/entur/tavla/assets/108051660/fd6db542-c967-421d-a48c-b53a137ba4f6)

Move toast to top: 
![Screenshot 2023-07-20 at 15 20 27](https://github.com/entur/tavla/assets/108051660/82c1b27e-7893-4a9b-ab90-aaad920cb1e1)
