### PR TITLE
fix(board): show first tab's content when another tab is deleted

### DIFF
--- a/next-tavla/src/Admin/scenarios/TilesOverview/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TilesOverview/index.tsx
@@ -1,5 +1,5 @@
 import { TTile } from 'types/tile'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { TileSettings } from 'Admin/scenarios/TileSettings'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@entur/tab'
 import Image from 'next/image'
@@ -8,6 +8,12 @@ import classes from './styles.module.css'
 import { Heading2, LeadParagraph } from '@entur/typography'
 
 function TilesOverview({ tiles }: { tiles: TTile[] }) {
+    const [activeTab, setActiveTab] = useState(0)
+
+    useEffect(() => {
+        setActiveTab(0)
+    }, [tiles.length])
+
     if (tiles.length === 0)
         return (
             <div className={classes.info}>
@@ -23,7 +29,11 @@ function TilesOverview({ tiles }: { tiles: TTile[] }) {
         )
 
     return (
-        <Tabs className={classes.tabs}>
+        <Tabs
+            className={classes.tabs}
+            index={activeTab}
+            onChange={(newIndex) => setActiveTab(newIndex)}
+        >
             <TabList data-cy="tiles">
                 {tiles.map((tile) => (
                     <Tab key={tile.uuid}>{tile.name ?? tile.placeId}</Tab>


### PR DESCRIPTION
## Background:
When a tab is deleted, an empty screen is shown. 

## Solution:
Set a use state for the active tab and set it to the first tab when any tab is deleted. 

## Images:
| Before   |  After |
:-------------------------:|:-------------------------:
![Screenshot 2023-08-18 at 13 35 36](https://github.com/entur/tavla/assets/64562118/5bcb1b78-1422-4922-a2d0-fd95c095b94e)   |  ![Screenshot 2023-08-18 at 13 36 50](https://github.com/entur/tavla/assets/64562118/3b9ffc1d-937e-46f7-ae67-ddf1c0b35946) 
