### PR TITLE
feat(edit): change and save title

### DIFF
--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -6,18 +6,18 @@ import { useSettingsDispatch } from 'Admin/utils/contexts'
 import { useState } from 'react'
 import classes from './styles.module.css'
 
-function BoardTitle({ title }: { title: string }) {
+function BoardTitle({ title }: { title?: string }) {
     const [isEditing, setIsEditing] = useState<boolean>(false)
     const dispatch = useSettingsDispatch()
+    const displayTitle = title || 'Tavla'
 
-    let newTitle = title
+                <Heading1 className={classes.title}>{displayTitle}</Heading1>
 
     return (
         <div className={classes.leftContainer}>
             {isEditing ? (
                 <>
                     <TextField
-                        defaultValue={title}
                         size="medium"
                         label="Tavlenavn"
                         className={classes.editInput}
@@ -52,7 +52,6 @@ function BoardTitle({ title }: { title: string }) {
                         className={classes.title}
                         onClick={() => setIsEditing(true)}
                     >
-                        {title}
                     </Heading1>
                     <SecondarySquareButton
                         className={classes.squareButton}
@@ -62,6 +61,7 @@ function BoardTitle({ title }: { title: string }) {
                     </SecondarySquareButton>
                 </>
             )}
+                defaultValue={displayTitle}
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -59,4 +59,4 @@ function BoardTitle({ title }: { title?: string }) {
     )
 }
 
-export default BoardTitle
+export { BoardTitle }

--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -10,6 +10,7 @@ function BoardTitle({ title }: { title?: string }) {
     const [isEditing, setIsEditing] = useState<boolean>(false)
     const dispatch = useSettingsDispatch()
     const displayTitle = title || 'Tavla'
+    const [tempTitle, setTempTitle] = useState<string>(displayTitle)
 
                 <Heading1 className={classes.title}>{displayTitle}</Heading1>
 
@@ -21,7 +22,6 @@ function BoardTitle({ title }: { title?: string }) {
                         size="medium"
                         label="Tavlenavn"
                         className={classes.editInput}
-                        onChange={(e) => (newTitle = e.target.value)}
                     />
 
                     <SecondarySquareButton
@@ -30,7 +30,6 @@ function BoardTitle({ title }: { title?: string }) {
                             setIsEditing(false)
                             dispatch({
                                 type: 'changeTitle',
-                                title: newTitle,
                             })
                         }}
                     >
@@ -39,7 +38,6 @@ function BoardTitle({ title }: { title?: string }) {
                     <SecondarySquareButton
                         className={classes.squareButton}
                         onClick={() => {
-                            newTitle = title
                             setIsEditing(false)
                         }}
                     >
@@ -62,6 +60,9 @@ function BoardTitle({ title }: { title?: string }) {
                 </>
             )}
                 defaultValue={displayTitle}
+                onChange={(e) => setTempTitle(e.target.value)}
+                        title: tempTitle,
+                    setTempTitle(displayTitle)
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -1,0 +1,69 @@
+import { SecondarySquareButton } from '@entur/button'
+import { TextField } from '@entur/form'
+import { CheckIcon, CloseIcon, EditIcon } from '@entur/icons'
+import { Heading1 } from '@entur/typography'
+import { useSettingsDispatch } from 'Admin/utils/contexts'
+import { useState } from 'react'
+import classes from './styles.module.css'
+
+function BoardTitle({ title }: { title: string }) {
+    const [isEditing, setIsEditing] = useState<boolean>(false)
+    const dispatch = useSettingsDispatch()
+
+    let newTitle = title
+
+    return (
+        <div className={classes.leftContainer}>
+            {isEditing ? (
+                <>
+                    <TextField
+                        defaultValue={title}
+                        size="medium"
+                        label="Tavlenavn"
+                        className={classes.editInput}
+                        onChange={(e) => (newTitle = e.target.value)}
+                    />
+
+                    <SecondarySquareButton
+                        className={classes.squareButton}
+                        onClick={() => {
+                            setIsEditing(false)
+                            dispatch({
+                                type: 'changeTitle',
+                                title: newTitle,
+                            })
+                        }}
+                    >
+                        <CheckIcon aria-label="Bekreft tittelendring" />
+                    </SecondarySquareButton>
+                    <SecondarySquareButton
+                        className={classes.squareButton}
+                        onClick={() => {
+                            newTitle = title
+                            setIsEditing(false)
+                        }}
+                    >
+                        <CloseIcon aria-label="Avbryt tittelendring" />
+                    </SecondarySquareButton>
+                </>
+            ) : (
+                <>
+                    <Heading1
+                        className={classes.title}
+                        onClick={() => setIsEditing(true)}
+                    >
+                        {title}
+                    </Heading1>
+                    <SecondarySquareButton
+                        className={classes.squareButton}
+                        onClick={() => setIsEditing(true)}
+                    >
+                        <EditIcon aria-label="Rediger tittel" />
+                    </SecondarySquareButton>
+                </>
+            )}
+        </div>
+    )
+}
+
+export default BoardTitle

--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -48,7 +48,6 @@ function BoardTitle({ title }: { title?: string }) {
                 <>
                     <Heading1
                         className={classes.title}
-                        onClick={() => setIsEditing(true)}
                     >
                     </Heading1>
                     <SecondarySquareButton

--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -7,15 +7,15 @@ import { useState } from 'react'
 import classes from './styles.module.css'
 
 function BoardTitle({ title }: { title?: string }) {
-    const [isEditing, setIsEditing] = useState<boolean>(false)
+    const [isEditing, setIsEditing] = useState(false)
     const dispatch = useSettingsDispatch()
-    const displayTitle = title || 'Tavla'
-    const [tempTitle, setTempTitle] = useState<string>(displayTitle)
+    const boardTitle = title || 'Tavla'
+    const [tempTitle, setTempTitle] = useState(boardTitle)
 
     if (!isEditing) {
         return (
-            <div className={classes.leftContainer}>
-                <Heading1 className={classes.title}>{displayTitle}</Heading1>
+            <div className={classes.editTitle}>
+                <Heading1 className={classes.title}>{boardTitle}</Heading1>
                 <SecondarySquareButton
                     className={classes.squareButton}
                     onClick={() => setIsEditing(true)}
@@ -27,12 +27,11 @@ function BoardTitle({ title }: { title?: string }) {
     }
 
     return (
-        <div className={classes.leftContainer}>
+        <div className={classes.editTitle}>
             <TextField
-                defaultValue={displayTitle}
+                defaultValue={boardTitle}
                 size="medium"
-                label="Tavlenavn"
-                className={classes.editInput}
+                label="Navn på tavlen"
                 onChange={(e) => setTempTitle(e.target.value)}
             />
             <SecondarySquareButton
@@ -40,7 +39,7 @@ function BoardTitle({ title }: { title?: string }) {
                 onClick={() => {
                     setIsEditing(false)
                     dispatch({
-                        type: 'changeTitle',
+                        type: 'setTitle',
                         title: tempTitle,
                     })
                 }}
@@ -50,7 +49,7 @@ function BoardTitle({ title }: { title?: string }) {
             <SecondarySquareButton
                 className={classes.squareButton}
                 onClick={() => {
-                    setTempTitle(displayTitle)
+                    setTempTitle(boardTitle)
                     setIsEditing(false)
                 }}
             >

--- a/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/index.tsx
@@ -12,56 +12,50 @@ function BoardTitle({ title }: { title?: string }) {
     const displayTitle = title || 'Tavla'
     const [tempTitle, setTempTitle] = useState<string>(displayTitle)
 
+    if (!isEditing) {
+        return (
+            <div className={classes.leftContainer}>
                 <Heading1 className={classes.title}>{displayTitle}</Heading1>
+                <SecondarySquareButton
+                    className={classes.squareButton}
+                    onClick={() => setIsEditing(true)}
+                >
+                    <EditIcon aria-label="Rediger tittel" />
+                </SecondarySquareButton>
+            </div>
+        )
+    }
 
     return (
         <div className={classes.leftContainer}>
-            {isEditing ? (
-                <>
-                    <TextField
-                        size="medium"
-                        label="Tavlenavn"
-                        className={classes.editInput}
-                    />
-
-                    <SecondarySquareButton
-                        className={classes.squareButton}
-                        onClick={() => {
-                            setIsEditing(false)
-                            dispatch({
-                                type: 'changeTitle',
-                            })
-                        }}
-                    >
-                        <CheckIcon aria-label="Bekreft tittelendring" />
-                    </SecondarySquareButton>
-                    <SecondarySquareButton
-                        className={classes.squareButton}
-                        onClick={() => {
-                            setIsEditing(false)
-                        }}
-                    >
-                        <CloseIcon aria-label="Avbryt tittelendring" />
-                    </SecondarySquareButton>
-                </>
-            ) : (
-                <>
-                    <Heading1
-                        className={classes.title}
-                    >
-                    </Heading1>
-                    <SecondarySquareButton
-                        className={classes.squareButton}
-                        onClick={() => setIsEditing(true)}
-                    >
-                        <EditIcon aria-label="Rediger tittel" />
-                    </SecondarySquareButton>
-                </>
-            )}
+            <TextField
                 defaultValue={displayTitle}
+                size="medium"
+                label="Tavlenavn"
+                className={classes.editInput}
                 onChange={(e) => setTempTitle(e.target.value)}
+            />
+            <SecondarySquareButton
+                className={classes.squareButton}
+                onClick={() => {
+                    setIsEditing(false)
+                    dispatch({
+                        type: 'changeTitle',
                         title: tempTitle,
+                    })
+                }}
+            >
+                <CheckIcon aria-label="Bekreft tittelendring" />
+            </SecondarySquareButton>
+            <SecondarySquareButton
+                className={classes.squareButton}
+                onClick={() => {
                     setTempTitle(displayTitle)
+                    setIsEditing(false)
+                }}
+            >
+                <CloseIcon aria-label="Avbryt tittelendring" />
+            </SecondarySquareButton>
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/BoardTitle/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/styles.module.css
@@ -1,19 +1,11 @@
-.leftContainer {
+.editTitle {
     display: flex;
     height: 3rem;
     align-items: center;
-}
-
-.saveButton {
-    font-size: 1em;
-    font-weight: 400;
+    gap: 1em;
 }
 
 .title {
     margin: auto;
     line-height: 3rem;
-}
-
-.squareButton {
-    margin-left: 1rem;
 }

--- a/next-tavla/src/Admin/scenarios/BoardTitle/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/BoardTitle/styles.module.css
@@ -1,0 +1,19 @@
+.leftContainer {
+    display: flex;
+    height: 3rem;
+    align-items: center;
+}
+
+.saveButton {
+    font-size: 1em;
+    font-weight: 400;
+}
+
+.title {
+    margin: auto;
+    line-height: 3rem;
+}
+
+.squareButton {
+    margin-left: 1rem;
+}

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -1,21 +1,32 @@
 import { TSettings } from 'types/settings'
 import { TilesOverview } from '../TilesOverview'
-import { useReducer } from 'react'
+import { useReducer, useState } from 'react'
 import classes from './styles.module.css'
 import dynamic from 'next/dynamic'
 import { AddTile } from '../AddTile'
 import { SettingsDispatchContext } from 'Admin/utils/contexts'
 import { settingsReducer } from './reducer'
-import { PrimaryButton, SecondaryButton } from '@entur/button'
+import {
+    PrimaryButton,
+    SecondaryButton,
+    SecondarySquareButton,
+} from '@entur/button'
 import { useAutoSaveSettings } from './hooks/useAutoSaveSettings'
 import { Heading1 } from '@entur/typography'
-import { CopyIcon, SaveIcon } from '@entur/icons'
+import {
+    CheckIcon,
+    CloseIcon,
+    CopyIcon,
+    EditIcon,
+    SaveIcon,
+} from '@entur/icons'
 import { SecondaryLink } from 'components/SecondaryLink'
 import { useToast } from '@entur/alert'
 import { Login } from '../Login'
 import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier'
 
 const LOGIN_ENABLED = false
+import { TextField } from '@entur/form'
 
 function Edit({
     initialSettings,
@@ -29,6 +40,9 @@ function Edit({
     const [settings, dispatch] = useReducer(settingsReducer, initialSettings)
     const { addToast } = useToast()
 
+    const [editingTitle, setEditingTitle] = useState<boolean>(false)
+    const [title, setTitle] = useState<string>(initialSettings.title || 'Tavla')
+
     const linkUrl = window.location.host + '/' + documentId
 
     const saveSettings = useAutoSaveSettings(documentId, settings)
@@ -37,7 +51,53 @@ function Edit({
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>
                 <div className="flexBetween">
-                    <Heading1>Tavla</Heading1>
+                    <div className={classes.leftContainer}>
+                        {editingTitle ? (
+                            <>
+                                <TextField
+                                    defaultValue={title}
+                                    size="medium"
+                                    label="Tavlenavn"
+                                    className={classes.editInput}
+                                    onChange={(e) => setTitle(e.target.value)}
+                                />
+
+                                <SecondarySquareButton
+                                    className={classes.squareButton}
+                                    onClick={() => {
+                                        settings.title = title
+                                        setEditingTitle(false)
+                                    }}
+                                >
+                                    <CheckIcon aria-label="Bekreft tittelendring" />
+                                </SecondarySquareButton>
+                                <SecondarySquareButton
+                                    className={classes.squareButton}
+                                    onClick={() => {
+                                        setTitle(settings.title || 'Tavla')
+                                        setEditingTitle(false)
+                                    }}
+                                >
+                                    <CloseIcon aria-label="Avbryt tittelendring" />
+                                </SecondarySquareButton>
+                            </>
+                        ) : (
+                            <>
+                                <Heading1
+                                    className={classes.title}
+                                    onClick={() => setEditingTitle(true)}
+                                >
+                                    {settings.title || 'Tavla'}
+                                </Heading1>
+                                <SecondarySquareButton
+                                    className={classes.squareButton}
+                                    onClick={() => setEditingTitle(true)}
+                                >
+                                    <EditIcon aria-label="Rediger tittel" />
+                                </SecondarySquareButton>
+                            </>
+                        )}
+                    </div>
                     <div className="flexGap">
                         <SecondaryButton
                             onClick={() => {

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -13,7 +13,7 @@ import { SecondaryLink } from 'components/SecondaryLink'
 import { useToast } from '@entur/alert'
 import { Login } from '../Login'
 import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier'
-import BoardTitle from '../BoardTitle'
+import { BoardTitle } from '../BoardTitle'
 
 const LOGIN_ENABLED = false
 

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -37,7 +37,7 @@ function Edit({
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>
                 <div className="flexBetween">
-                    <BoardTitle title={settings.title || 'Tavla'} />
+                    <BoardTitle title={settings.title} />
                     <div className="flexGap">
                         <SecondaryButton
                             onClick={() => {

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -1,32 +1,21 @@
 import { TSettings } from 'types/settings'
 import { TilesOverview } from '../TilesOverview'
-import { useReducer, useState } from 'react'
+import { useReducer } from 'react'
 import classes from './styles.module.css'
 import dynamic from 'next/dynamic'
 import { AddTile } from '../AddTile'
 import { SettingsDispatchContext } from 'Admin/utils/contexts'
 import { settingsReducer } from './reducer'
-import {
-    PrimaryButton,
-    SecondaryButton,
-    SecondarySquareButton,
-} from '@entur/button'
+import { PrimaryButton, SecondaryButton } from '@entur/button'
 import { useAutoSaveSettings } from './hooks/useAutoSaveSettings'
-import { Heading1 } from '@entur/typography'
-import {
-    CheckIcon,
-    CloseIcon,
-    CopyIcon,
-    EditIcon,
-    SaveIcon,
-} from '@entur/icons'
+import { CopyIcon, SaveIcon } from '@entur/icons'
 import { SecondaryLink } from 'components/SecondaryLink'
 import { useToast } from '@entur/alert'
 import { Login } from '../Login'
 import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier'
+import BoardTitle from '../BoardTitle'
 
 const LOGIN_ENABLED = false
-import { TextField } from '@entur/form'
 
 function Edit({
     initialSettings,
@@ -40,9 +29,6 @@ function Edit({
     const [settings, dispatch] = useReducer(settingsReducer, initialSettings)
     const { addToast } = useToast()
 
-    const [editingTitle, setEditingTitle] = useState<boolean>(false)
-    const [title, setTitle] = useState<string>(initialSettings.title || 'Tavla')
-
     const linkUrl = window.location.host + '/' + documentId
 
     const saveSettings = useAutoSaveSettings(documentId, settings)
@@ -51,53 +37,7 @@ function Edit({
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>
                 <div className="flexBetween">
-                    <div className={classes.leftContainer}>
-                        {editingTitle ? (
-                            <>
-                                <TextField
-                                    defaultValue={title}
-                                    size="medium"
-                                    label="Tavlenavn"
-                                    className={classes.editInput}
-                                    onChange={(e) => setTitle(e.target.value)}
-                                />
-
-                                <SecondarySquareButton
-                                    className={classes.squareButton}
-                                    onClick={() => {
-                                        settings.title = title
-                                        setEditingTitle(false)
-                                    }}
-                                >
-                                    <CheckIcon aria-label="Bekreft tittelendring" />
-                                </SecondarySquareButton>
-                                <SecondarySquareButton
-                                    className={classes.squareButton}
-                                    onClick={() => {
-                                        setTitle(settings.title || 'Tavla')
-                                        setEditingTitle(false)
-                                    }}
-                                >
-                                    <CloseIcon aria-label="Avbryt tittelendring" />
-                                </SecondarySquareButton>
-                            </>
-                        ) : (
-                            <>
-                                <Heading1
-                                    className={classes.title}
-                                    onClick={() => setEditingTitle(true)}
-                                >
-                                    {settings.title || 'Tavla'}
-                                </Heading1>
-                                <SecondarySquareButton
-                                    className={classes.squareButton}
-                                    onClick={() => setEditingTitle(true)}
-                                >
-                                    <EditIcon aria-label="Rediger tittel" />
-                                </SecondarySquareButton>
-                            </>
-                        )}
-                    </div>
+                    <BoardTitle title={settings.title || 'Tavla'} />
                     <div className="flexGap">
                         <SecondaryButton
                             onClick={() => {

--- a/next-tavla/src/Admin/scenarios/Edit/reducer.ts
+++ b/next-tavla/src/Admin/scenarios/Edit/reducer.ts
@@ -23,7 +23,7 @@ export type Action =
       }
     | { type: 'deleteLines'; tileId: string }
     | { type: 'setColumn'; tileId: string; column: TColumn }
-    | { type: 'changeTitle'; title: string }
+    | { type: 'setTitle'; title: string }
 
 export function settingsReducer(
     settings: TSettings,
@@ -50,7 +50,7 @@ export function settingsReducer(
 
     switch (action.type) {
         // Title operations
-        case 'changeTitle':
+        case 'setTitle':
             return { ...settings, title: action.title }
         // Theme operations
         case 'changeTheme': {

--- a/next-tavla/src/Admin/scenarios/Edit/reducer.ts
+++ b/next-tavla/src/Admin/scenarios/Edit/reducer.ts
@@ -23,6 +23,7 @@ export type Action =
       }
     | { type: 'deleteLines'; tileId: string }
     | { type: 'setColumn'; tileId: string; column: TColumn }
+    | { type: 'changeTitle'; title: string }
 
 export function settingsReducer(
     settings: TSettings,
@@ -48,6 +49,9 @@ export function settingsReducer(
     }
 
     switch (action.type) {
+        // Title operations
+        case 'changeTitle':
+            return { ...settings, title: action.title }
         // Theme operations
         case 'changeTheme': {
             return { ...settings, theme: action.theme }

--- a/next-tavla/src/Admin/scenarios/Edit/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/styles.module.css
@@ -13,23 +13,3 @@
     bottom: 1.25em;
     right: 5em;
 }
-
-.saveButton {
-    font-size: 1em;
-    font-weight: 400;
-}
-
-.leftContainer {
-    display: flex;
-    height: 3rem;
-    align-items: center;
-}
-
-.title {
-    margin: auto;
-    line-height: 3rem;
-}
-
-.squareButton {
-    margin-left: 1rem;
-}

--- a/next-tavla/src/Admin/scenarios/Edit/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/styles.module.css
@@ -18,3 +18,18 @@
     font-size: 1em;
     font-weight: 400;
 }
+
+.leftContainer {
+    display: flex;
+    height: 3rem;
+    align-items: center;
+}
+
+.title {
+    margin: auto;
+    line-height: 3rem;
+}
+
+.squareButton {
+    margin-left: 1rem;
+}

--- a/next-tavla/src/Shared/types/settings.ts
+++ b/next-tavla/src/Shared/types/settings.ts
@@ -3,6 +3,7 @@ import { TTile } from './tile'
 export type TTheme = 'entur' | 'dark' | 'light'
 
 export type TSettings = {
+    title?: string
     tiles: TTile[]
     version?: number
     theme?: TTheme


### PR DESCRIPTION
### Description

Made it possible to edit and save the name of a table. For tables without a name, this will default to "Tavla". Changes will not be saved to Firebase unless the "Save table"-button is clicked.

### Before

![Screenshot 2023-08-21 at 12 02 07](https://github.com/entur/tavla/assets/61384979/4de56189-02fb-466a-871a-d8951326cd40)

### After
![Screenshot 2023-08-21 at 12 03 35](https://github.com/entur/tavla/assets/61384979/aeacbf6b-78c7-4d94-b471-641988201208)
![Screenshot 2023-08-21 at 12 03 53](https://github.com/entur/tavla/assets/61384979/d44668ee-bd6b-44b6-9595-6c64b995a1ba)

