### PR TITLE
feat(edit): autofocus on searchfield

### DIFF
--- a/next-tavla/src/Admin/scenarios/AddTile/index.tsx
+++ b/next-tavla/src/Admin/scenarios/AddTile/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { createRef, useEffect, useState } from 'react'
 import { Button } from '@entur/button'
 import classes from './styles.module.css'
 import { useSettingsDispatch } from 'Admin/utils/contexts'
@@ -13,6 +13,13 @@ function AddTile() {
     const { addToast } = useToast()
     const [stopPlaceId, setStopPlaceId] = useState<string>()
     const [placeName, setPlaceName] = useState<string>('Ikke navngitt')
+    const dropdownRef = createRef<HTMLDivElement>()
+
+    useEffect(() => {
+        if (dropdownRef.current) {
+            dropdownRef.current.focus()
+        }
+    }, [dropdownRef])
 
     function handleAddTile() {
         if (!stopPlaceId) {
@@ -38,6 +45,7 @@ function AddTile() {
 
             <div className={classes.SearchContainer}>
                 <Dropdown
+                    ref={dropdownRef}
                     className={classes.DropDown}
                     items={fetchItems}
                     label="Søk etter holdeplass..."

--- a/next-tavla/src/Admin/scenarios/AddTile/index.tsx
+++ b/next-tavla/src/Admin/scenarios/AddTile/index.tsx
@@ -16,10 +16,10 @@ function AddTile() {
     const dropdownRef = createRef<HTMLDivElement>()
 
     useEffect(() => {
-        if (dropdownRef.current) {
+        if (dropdownRef.current && !stopPlaceId) {
             dropdownRef.current.focus()
         }
-    }, [dropdownRef])
+    }, [dropdownRef, stopPlaceId])
 
     function handleAddTile() {
         if (!stopPlaceId) {

--- a/next-tavla/src/Admin/scenarios/TilesOverview/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TilesOverview/index.tsx
@@ -1,5 +1,5 @@
 import { TTile } from 'types/tile'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { TileSettings } from 'Admin/scenarios/TileSettings'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@entur/tab'
 import Image from 'next/image'
@@ -8,6 +8,12 @@ import classes from './styles.module.css'
 import { Heading2, LeadParagraph } from '@entur/typography'
 
 function TilesOverview({ tiles }: { tiles: TTile[] }) {
+    const [activeTab, setActiveTab] = useState(0)
+
+    useEffect(() => {
+        setActiveTab(0)
+    }, [tiles.length])
+
     if (tiles.length === 0)
         return (
             <div className={classes.info}>
@@ -23,7 +29,11 @@ function TilesOverview({ tiles }: { tiles: TTile[] }) {
         )
 
     return (
-        <Tabs className={classes.tabs}>
+        <Tabs
+            className={classes.tabs}
+            index={activeTab}
+            onChange={(newIndex) => setActiveTab(newIndex)}
+        >
             <TabList data-cy="tiles">
                 {tiles.map((tile) => (
                     <Tab key={tile.uuid}>{tile.name ?? tile.placeId}</Tab>


### PR DESCRIPTION
### Solution: 
Autofocus on search for those who use keyboard for navigation (universal design)

### Images: 

| Before    |  After |
| -------- | ------- |
| <img width="541" alt="Screenshot 2023-08-21 at 12 24 18" src="https://github.com/entur/tavla/assets/64562118/790eedbf-1834-4980-9f3d-78a3c71f58ec">  |  <img width="573" alt="Screenshot 2023-08-21 at 12 25 49" src="https://github.com/entur/tavla/assets/64562118/17eaec18-e613-431d-a0c6-f8d4b91dba95"> |

