### PR TITLE
feat(admin): delete board-button

### DIFF
--- a/next-tavla/cypress.config.ts
+++ b/next-tavla/cypress.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
         viewportHeight: 1080,
         viewportWidth: 1920,
     },
+    retries: 2,
 })

--- a/next-tavla/pages/edit/boards/[id].tsx
+++ b/next-tavla/pages/edit/boards/[id].tsx
@@ -3,9 +3,9 @@ import { Contrast } from '@entur/layout'
 import { ToastProvider } from '@entur/alert'
 import { Header } from 'components/Header'
 import { Admin } from 'Admin/scenarios/Boards'
-import { TSettings } from 'types/settings'
 import { checkFeatureFlags } from 'utils/featureFlags'
 import { getBoards } from 'utils/firebase'
+import { Board } from 'types/board'
 
 export async function getServerSideProps() {
     const featureFlag = await checkFeatureFlags('BOARDS')
@@ -27,11 +27,7 @@ export async function getServerSideProps() {
     }
 }
 
-function OverviewPage({
-    boards,
-}: {
-    boards: { id: string; settings?: TSettings }[]
-}) {
+function OverviewPage({ boards }: { boards: Board[] }) {
     return (
         <Contrast className={classes.root}>
             <ToastProvider>

--- a/next-tavla/src/Admin/scenarios/Boards/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/index.tsx
@@ -1,9 +1,9 @@
 import { Heading2 } from '@entur/typography'
 import classes from './styles.module.css'
 import { List } from '../List'
-import { TSettings } from 'types/settings'
+import { Board } from 'types/board'
 
-function Admin({ boards }: { boards: { id: string; settings?: TSettings }[] }) {
+function Admin({ boards }: { boards: Board[] }) {
     return (
         <div className={classes.adminWrapper}>
             <Heading2>Mine Tavler</Heading2>

--- a/next-tavla/src/Admin/scenarios/DeleteBoardButton/index.tsx
+++ b/next-tavla/src/Admin/scenarios/DeleteBoardButton/index.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { IconButton, PrimaryButton, SecondaryButton } from '@entur/button'
+import { DeleteIcon } from '@entur/icons'
+import { Modal } from '@entur/modal'
+import { Heading1, LeadParagraph } from '@entur/typography'
+import classes from './styles.module.css'
+import { deleteBoard } from 'utils/firebase'
+import { useToast } from '@entur/alert'
+import { useFeatureFlags } from 'hooks/useFeatureFlags'
+
+function DeleteBoardButton({
+    boardId,
+    boardName,
+}: {
+    boardId: string
+    boardName?: string
+}) {
+    const [showModal, setShowModal] = useState(false)
+
+    const { addToast } = useToast()
+
+    const DELETE_BOARD_ENABLED = useFeatureFlags('DELETE_BOARD')
+
+    const closeModal = () => {
+        setShowModal(false)
+    }
+
+    const deleteBoardHandler = async () => {
+        if (!DELETE_BOARD_ENABLED) {
+            console.log('dummy delete ', boardId)
+            closeModal()
+            return
+        }
+        deleteBoard('').then(() => {
+            closeModal()
+            addToast('Tavle slettet')
+        })
+    }
+
+    return (
+        <IconButton aira-label="Slett tavle" onClick={() => setShowModal(true)}>
+            <Modal
+                open={showModal}
+                size="small"
+                onDismiss={closeModal}
+                closeLabel="Avbryt sletting"
+                className={classes.deleteModal}
+            >
+                <Heading1>Slett tavle</Heading1>
+                <LeadParagraph>
+                    {boardName
+                        ? `Er du sikker på at du vil slette tavlen "${boardName}"?`
+                        : 'Er du sikker på at du vil slette denne tavlen?'}
+                </LeadParagraph>
+                <div className={classes.actions}>
+                    <SecondaryButton
+                        onClick={closeModal}
+                        aria-label="Avbryt sletting"
+                    >
+                        Avbryt
+                    </SecondaryButton>
+                    <PrimaryButton
+                        aria-label="Slett tavle"
+                        onClick={deleteBoardHandler}
+                    >
+                        Ja, slett!
+                    </PrimaryButton>
+                </div>
+            </Modal>
+            <DeleteIcon />
+        </IconButton>
+    )
+}
+
+export { DeleteBoardButton }

--- a/next-tavla/src/Admin/scenarios/DeleteBoardButton/index.tsx
+++ b/next-tavla/src/Admin/scenarios/DeleteBoardButton/index.tsx
@@ -38,7 +38,7 @@ function DeleteBoardButton({
     }
 
     return (
-        <IconButton aira-label="Slett tavle" onClick={() => setShowModal(true)}>
+        <IconButton aria-label="Slett tavle" onClick={() => setShowModal(true)}>
             <Modal
                 open={showModal}
                 size="small"

--- a/next-tavla/src/Admin/scenarios/DeleteBoardButton/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/DeleteBoardButton/styles.module.css
@@ -1,0 +1,15 @@
+.deleteModal {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    text-align: center;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
+    align-self: stretch;
+}

--- a/next-tavla/src/Admin/scenarios/List/index.tsx
+++ b/next-tavla/src/Admin/scenarios/List/index.tsx
@@ -1,9 +1,9 @@
 import { TableHeader } from '../TableHeader'
 import { Row } from '../Row'
-import { TSettings } from 'types/settings'
 import classes from './styles.module.css'
+import { Board } from 'types/board'
 
-function List({ boards }: { boards: { id: string; settings?: TSettings }[] }) {
+function List({ boards }: { boards: Board[] }) {
     return (
         <div>
             <div className={classes.table}>

--- a/next-tavla/src/Admin/scenarios/Row/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Row/index.tsx
@@ -5,6 +5,7 @@ import { useToast } from '@entur/alert'
 import { useRouter } from 'next/router'
 import classes from './styles.module.css'
 import { useEffect, useState } from 'react'
+import { DeleteBoardButton } from '../DeleteBoardButton'
 
 function Row({ board }: { board: { id: string; settings?: TSettings } }) {
     const { addToast } = useToast()
@@ -42,6 +43,12 @@ function Row({ board }: { board: { id: string; settings?: TSettings } }) {
                 <IconButton aria-label="Rediger tavle" onClick={editBoard}>
                     <EditIcon />
                 </IconButton>
+            </div>
+            <div className={classes.dataCell}>
+                <DeleteBoardButton
+                    boardId={board.id}
+                    boardName={board.settings?.title}
+                />
             </div>
         </div>
     )

--- a/next-tavla/src/Admin/scenarios/Row/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Row/index.tsx
@@ -1,13 +1,13 @@
 import { IconButton } from '@entur/button'
 import { CopyIcon, EditIcon } from '@entur/icons'
-import { TSettings } from 'types/settings'
 import { useToast } from '@entur/alert'
 import { useRouter } from 'next/router'
 import classes from './styles.module.css'
 import { useEffect, useState } from 'react'
 import { DeleteBoardButton } from '../DeleteBoardButton'
+import { Board } from 'types/board'
 
-function Row({ board }: { board: { id: string; settings?: TSettings } }) {
+function Row({ board }: { board: Board }) {
     const { addToast } = useToast()
     const router = useRouter()
     const [link, setLink] = useState('')

--- a/next-tavla/src/Admin/scenarios/Row/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Row/styles.module.css
@@ -1,6 +1,6 @@
 .tableRow {
     display: grid;
-    grid-template-columns: 3fr 5fr 1fr;
+    grid-template-columns: 3fr 5fr 1fr 1fr;
     padding: 1rem 0;
     border-bottom: var(--colors-blues-blue20) solid;
 }

--- a/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
@@ -3,10 +3,11 @@ import classes from './styles.module.css'
 function TableHeader() {
     return (
         <div className={classes.tableHead}>
-            <div className={classes.tableRow}>
-                <div className={classes.tableCell}>Navn på tavle</div>
-                <div className={classes.tableCell}>Link</div>
-                <div className={classes.tableCell}>Rediger</div>
+            <div className={classes.tableHeaderRow}>
+                <div className={classes.tableHeaderCell}>Navn på tavle</div>
+                <div className={classes.tableHeaderCell}>Link</div>
+                <div className={classes.tableHeaderCell}>Rediger</div>
+                <div className={classes.tableHeaderCell}>Slett</div>
             </div>
         </div>
     )

--- a/next-tavla/src/Admin/scenarios/TableHeader/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/TableHeader/styles.module.css
@@ -3,12 +3,12 @@
     border-bottom: var(--colors-blues-blue20) solid;
 }
 
-.tableRow {
+.tableHeaderRow {
     display: grid;
-    grid-template-columns: 3fr 5fr 1fr;
+    grid-template-columns: 3fr 5fr 1fr 1fr;
 }
 
-.tableCell {
+.tableHeaderCell {
     display: flex;
     align-items: center;
     justify-content: flex-start;

--- a/next-tavla/src/Shared/types/board.ts
+++ b/next-tavla/src/Shared/types/board.ts
@@ -1,0 +1,6 @@
+import { TSettings } from './settings'
+
+export type Board = {
+    id: string
+    settings?: TSettings
+}

--- a/next-tavla/src/Shared/types/featureFlag.ts
+++ b/next-tavla/src/Shared/types/featureFlag.ts
@@ -1,1 +1,1 @@
-export type Feature = 'LOGIN' | 'BOARDS'
+export type Feature = 'LOGIN' | 'BOARDS' | 'DELETE_BOARD'

--- a/next-tavla/src/Shared/utils/firebase.ts
+++ b/next-tavla/src/Shared/utils/firebase.ts
@@ -5,6 +5,7 @@ import {
     getDoc,
     addDoc,
     setDoc,
+    deleteDoc,
     doc,
     collection,
     getFirestore,
@@ -44,6 +45,12 @@ export async function setBoardSettings(boardId: string, settings: TSettings) {
 export async function addBoardSettings(settings: TSettings) {
     const firestore = safeGetFirestore()
     return await addDoc(collection(firestore, 'settings-v2'), settings)
+}
+
+export async function deleteBoard(boardId: string) {
+    const firestore = safeGetFirestore()
+    const docRef = doc(firestore, 'settings-v2', boardId)
+    await deleteDoc(docRef)
 }
 
 export async function getBoards() {


### PR DESCRIPTION
### Description

A delete-button in the boards-table that lets a user delete a board.


| Table | Confirmation modal |
|--------|--------|
| <img width="1016" alt="image" src="https://github.com/entur/tavla/assets/61384979/d6bd559a-918b-473d-b84e-07c3c3c010ea"> | <img width="1016" alt="image" src="https://github.com/entur/tavla/assets/61384979/208f1c3d-2ced-4050-93cb-b9bbc387bcee"> | 

### TODOs

The delete-function is disabled, unless the `DELETE_BOARD` feature flag is set. Default behavior is not to just consol log a message, as there is no currently no way to verify that a user is permitted to delete the board.