### PR TITLE
feat(boards): show additional board information

### DIFF
--- a/next-tavla/package.json
+++ b/next-tavla/package.json
@@ -40,6 +40,7 @@
         "@entur/modal": "1.7.3",
         "@entur/tab": "0.4.51",
         "@entur/tokens": "3.8.1",
+        "@entur/tooltip": "2.6.26",
         "@entur/travel": "6.0.18",
         "@entur/typography": "1.8.0",
         "@firebase/database-types": "0.10.4",

--- a/next-tavla/src/Admin/scenarios/BoardList/components/Row/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/components/Row/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import classes from './styles.module.css'
 import { useEffect, useState } from 'react'
 import { Cell } from 'Admin/scenarios/BoardList/components/Cell'
-import { Info } from '../../../Info'
+import { Info } from 'Admin/scenarios/Info'
 
 function Row({ board }: { board: { id: string; settings?: TSettings } }) {
     const { addToast } = useToast()

--- a/next-tavla/src/Admin/scenarios/BoardList/components/Row/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/components/Row/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import classes from './styles.module.css'
 import { useEffect, useState } from 'react'
 import { Cell } from 'Admin/scenarios/BoardList/components/Cell'
+import { Info } from '../../../Info'
 
 function Row({ board }: { board: { id: string; settings?: TSettings } }) {
     const { addToast } = useToast()
@@ -36,6 +37,7 @@ function Row({ board }: { board: { id: string; settings?: TSettings } }) {
                 </IconButton>
             </Cell>
             <Cell>
+                <Info board={board} />
                 <IconButton aria-label="Rediger tavle" onClick={editBoard}>
                     <EditIcon />
                 </IconButton>

--- a/next-tavla/src/Admin/scenarios/Boards/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/index.tsx
@@ -1,4 +1,4 @@
-import { Heading2 } from '@entur/typography'
+import { Heading1 } from '@entur/typography'
 import classes from './styles.module.css'
 import { BoardList } from '../BoardList'
 import { TSettings } from 'types/settings'
@@ -11,7 +11,7 @@ function Boards({
 }) {
     return (
         <div className={classes.adminWrapper}>
-            <Heading2>Mine Tavler</Heading2>
+            <Heading1>Mine Tavler</Heading1>
             <div>
                 <BoardList boards={boards} />
             </div>

--- a/next-tavla/src/Admin/scenarios/Info/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Info/index.tsx
@@ -7,7 +7,7 @@ import {
     PopoverTrigger,
 } from '@entur/tooltip'
 import { CloseIcon, OutlinedValidationInfoIcon } from '@entur/icons'
-import { Heading5 } from '@entur/typography'
+import { Heading2 } from '@entur/typography'
 import classes from './styles.module.css'
 function Info({ board }: { board: { id: string; settings?: TSettings } }) {
     return (
@@ -20,9 +20,9 @@ function Info({ board }: { board: { id: string; settings?: TSettings } }) {
             <PopoverContent>
                 <div className={classes.popover}>
                     <div className={classes.header}>
-                        <Heading5 className={classes.heading}>
+                        <Heading2 className={classes.heading}>
                             {board.settings?.tiles.length} holdeplasser i Tavla
-                        </Heading5>
+                        </Heading2>
                         <PopoverCloseButton>
                             <IconButton aria-label="Lukk popover">
                                 <CloseIcon aria-hidden="true" />

--- a/next-tavla/src/Admin/scenarios/Info/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Info/index.tsx
@@ -9,7 +9,6 @@ import {
 import { CloseIcon, OutlinedValidationInfoIcon } from '@entur/icons'
 import { Heading5 } from '@entur/typography'
 import classes from './styles.module.css'
-import { useState } from 'react'
 function Info({ board }: { board: { id: string; settings?: TSettings } }) {
     return (
         <Popover>

--- a/next-tavla/src/Admin/scenarios/Info/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Info/index.tsx
@@ -1,19 +1,19 @@
 import { TSettings } from 'types/settings'
 import { IconButton } from '@entur/button'
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-    PopoverCloseButton,
-} from '@entur/tooltip'
+import { Popover, PopoverContent, PopoverTrigger } from '@entur/tooltip'
 import { CloseIcon, OutlinedValidationInfoIcon } from '@entur/icons'
 import { Heading5 } from '@entur/typography'
 import classes from './styles.module.css'
+import { useState } from 'react'
 function Info({ board }: { board: { id: string; settings?: TSettings } }) {
+    const [show, setShow] = useState(false)
     return (
-        <Popover>
+        <Popover showPopover={show} setShowPopover={setShow}>
             <PopoverTrigger>
-                <IconButton aria-label="Se mer informasjon om tavle">
+                <IconButton
+                    aria-label="Se mer informasjon om tavle"
+                    onClick={() => setShow(true)}
+                >
                     <OutlinedValidationInfoIcon />
                 </IconButton>
             </PopoverTrigger>
@@ -23,11 +23,13 @@ function Info({ board }: { board: { id: string; settings?: TSettings } }) {
                         <Heading5 className={classes.heading}>
                             {board.settings?.tiles.length} holdeplasser i Tavla
                         </Heading5>
-                        <PopoverCloseButton>
-                            <IconButton aria-label="Lukk popover">
-                                <CloseIcon aria-hidden="true" />
-                            </IconButton>
-                        </PopoverCloseButton>
+                        <IconButton
+                            aria-label="Lukk popover"
+                            onClick={() => setShow(false)}
+                            className={classes.closeButton}
+                        >
+                            <CloseIcon aria-hidden="true" />
+                        </IconButton>
                     </div>
                     <div className={classes.list}>
                         {board.settings?.tiles.map((tile) => (

--- a/next-tavla/src/Admin/scenarios/Info/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Info/index.tsx
@@ -1,19 +1,20 @@
 import { TSettings } from 'types/settings'
 import { IconButton } from '@entur/button'
-import { Popover, PopoverContent, PopoverTrigger } from '@entur/tooltip'
+import {
+    Popover,
+    PopoverCloseButton,
+    PopoverContent,
+    PopoverTrigger,
+} from '@entur/tooltip'
 import { CloseIcon, OutlinedValidationInfoIcon } from '@entur/icons'
 import { Heading5 } from '@entur/typography'
 import classes from './styles.module.css'
 import { useState } from 'react'
 function Info({ board }: { board: { id: string; settings?: TSettings } }) {
-    const [show, setShow] = useState(false)
     return (
-        <Popover showPopover={show} setShowPopover={setShow}>
+        <Popover>
             <PopoverTrigger>
-                <IconButton
-                    aria-label="Se mer informasjon om tavle"
-                    onClick={() => setShow(true)}
-                >
+                <IconButton aria-label="Se mer informasjon om tavle">
                     <OutlinedValidationInfoIcon />
                 </IconButton>
             </PopoverTrigger>
@@ -23,13 +24,11 @@ function Info({ board }: { board: { id: string; settings?: TSettings } }) {
                         <Heading5 className={classes.heading}>
                             {board.settings?.tiles.length} holdeplasser i Tavla
                         </Heading5>
-                        <IconButton
-                            aria-label="Lukk popover"
-                            onClick={() => setShow(false)}
-                            className={classes.closeButton}
-                        >
-                            <CloseIcon aria-hidden="true" />
-                        </IconButton>
+                        <PopoverCloseButton>
+                            <IconButton aria-label="Lukk popover">
+                                <CloseIcon aria-hidden="true" />
+                            </IconButton>
+                        </PopoverCloseButton>
                     </div>
                     <div className={classes.list}>
                         {board.settings?.tiles.map((tile) => (

--- a/next-tavla/src/Admin/scenarios/Info/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Info/index.tsx
@@ -1,0 +1,43 @@
+import { TSettings } from 'types/settings'
+import { IconButton } from '@entur/button'
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    PopoverCloseButton,
+} from '@entur/tooltip'
+import { CloseIcon, OutlinedValidationInfoIcon } from '@entur/icons'
+import { Heading5 } from '@entur/typography'
+import classes from './styles.module.css'
+function Info({ board }: { board: { id: string; settings?: TSettings } }) {
+    return (
+        <Popover>
+            <PopoverTrigger>
+                <IconButton aria-label="Se mer informasjon om tavle">
+                    <OutlinedValidationInfoIcon />
+                </IconButton>
+            </PopoverTrigger>
+            <PopoverContent>
+                <div className={classes.popover}>
+                    <div className={classes.header}>
+                        <Heading5 className={classes.heading}>
+                            {board.settings?.tiles.length} holdeplasser i Tavla
+                        </Heading5>
+                        <PopoverCloseButton>
+                            <IconButton aria-label="Lukk popover">
+                                <CloseIcon aria-hidden="true" />
+                            </IconButton>
+                        </PopoverCloseButton>
+                    </div>
+                    <div className={classes.list}>
+                        {board.settings?.tiles.map((tile) => (
+                            <div key={tile.uuid}>{tile.name}</div>
+                        ))}
+                    </div>
+                </div>
+            </PopoverContent>
+        </Popover>
+    )
+}
+
+export { Info }

--- a/next-tavla/src/Admin/scenarios/Info/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Info/styles.module.css
@@ -25,3 +25,7 @@
     gap: 0.3rem;
     font-size: small;
 }
+
+.closeButton:hover {
+    background-color: var(--colors-blues-blue70) !important;
+}

--- a/next-tavla/src/Admin/scenarios/Info/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Info/styles.module.css
@@ -14,7 +14,8 @@
 }
 
 .heading {
-    margin-top: 0rem;
+    margin: 0rem;
+    font-size: large;
 }
 
 .list {

--- a/next-tavla/src/Admin/scenarios/Info/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Info/styles.module.css
@@ -3,7 +3,7 @@
     flex-direction: column;
     background-color: var(--colors-brand-white);
     color: var(--colors-misc-black);
-    width: 18rem;
+    width: 100%;
     height: 100%;
     padding: 1rem;
 }
@@ -11,6 +11,7 @@
 .header {
     display: inline-flex;
     justify-content: space-between;
+    gap: 3rem;
     align-items: center;
 }
 

--- a/next-tavla/src/Admin/scenarios/Info/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Info/styles.module.css
@@ -1,8 +1,6 @@
 .popover {
     display: flex;
     flex-direction: column;
-    background-color: var(--colors-brand-white);
-    color: var(--colors-misc-black);
     width: 100%;
     height: 100%;
     padding: 1rem;
@@ -16,7 +14,6 @@
 }
 
 .heading {
-    color: var(--colors-misc-black);
     margin-top: 0rem;
 }
 
@@ -25,8 +22,4 @@
     flex-direction: column;
     gap: 0.3rem;
     font-size: small;
-}
-
-.closeButton:hover {
-    background-color: var(--colors-blues-blue70) !important;
 }

--- a/next-tavla/src/Admin/scenarios/Info/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Info/styles.module.css
@@ -1,0 +1,27 @@
+.popover {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--colors-brand-white);
+    color: var(--colors-misc-black);
+    width: 18rem;
+    height: 100%;
+    padding: 1rem;
+}
+
+.header {
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.heading {
+    color: var(--colors-misc-black);
+    margin-top: 0rem;
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: small;
+}

--- a/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
@@ -6,7 +6,7 @@ function TableHeader() {
             <div className={classes.tableRow}>
                 <div className={classes.tableCell}>Navn på tavle</div>
                 <div className={classes.tableCell}>Link</div>
-                <div className={classes.tableCell}>Rediger</div>
+                <div className={classes.tableCell}>Valg</div>
             </div>
         </div>
     )

--- a/next-tavla/yarn.lock
+++ b/next-tavla/yarn.lock
@@ -1461,6 +1461,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@entur/tooltip@npm:2.6.26":
+  version: 2.6.26
+  resolution: "@entur/tooltip@npm:2.6.26"
+  dependencies:
+    "@entur/button": ^3.1.1
+    "@entur/icons": ^6.4.2
+    "@entur/layout": ^2.1.40
+    "@entur/tokens": ^3.10.0
+    "@entur/utils": ^0.9.4
+    "@popperjs/core": ^2.10.1
+    classnames: ^2.3.1
+    react-popper: ~2.2.5
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: fe9f692dcd30c17603829ddf851ce3d13eacb95b99981689ec2fa159da897920b5d36817cfaa11c2798e17eccc6ff16926518ae026eebc146916691e6055e671
+  languageName: node
+  linkType: hard
+
 "@entur/tooltip@npm:^2.6.19":
   version: 2.6.19
   resolution: "@entur/tooltip@npm:2.6.19"
@@ -12517,6 +12536,7 @@ __metadata:
     "@entur/modal": 1.7.3
     "@entur/tab": 0.4.51
     "@entur/tokens": 3.8.1
+    "@entur/tooltip": 2.6.26
     "@entur/travel": 6.0.18
     "@entur/typography": 1.8.0
     "@firebase/database-types": 0.10.4


### PR DESCRIPTION
### Description: 
Created a component with a popover that shows information about which stops the board contains.

### Image:

![image](https://github.com/entur/tavla/assets/64562118/2726b306-cfe9-4099-924a-1750e9f8129c)
