### PR TITLE
chore(boards): substitute sorting with one button by sorting with table headers

### DIFF
--- a/next-tavla/src/Admin/scenarios/BoardList/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/index.tsx
@@ -24,23 +24,21 @@ function BoardList({
         order: 'default',
     })
 
-        if (sortable) {
-            setSorting((prevSorting) => {
-                if (prevSorting.column === column) {
-                    switch (prevSorting.order) {
-                        case 'default':
-                            return { column, order: 'asc' }
-                        case 'asc':
-                            return { column, order: 'desc' }
-                        default:
-                            return { column: 'title', order: 'default' }
-                    }
-                } else {
-                    return { column, order: 'asc' }
     const handleHeaderClick = (column: TSortableColumn) => {
+        setSorting((prevSorting) => {
+            if (prevSorting.column === column) {
+                switch (prevSorting.order) {
+                    case 'default':
+                        return { column, order: 'asc' }
+                    case 'asc':
+                        return { column, order: 'desc' }
+                    default:
+                        return { column: 'title', order: 'default' }
                 }
-            })
-        }
+            } else {
+                return { column, order: 'asc' }
+            }
+        })
     }
 
     function sortBoards() {

--- a/next-tavla/src/Admin/scenarios/BoardList/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/index.tsx
@@ -5,6 +5,7 @@ import classes from './styles.module.css'
 import { TextField } from '@entur/form'
 import { SearchIcon } from '@entur/icons'
 import { useState } from 'react'
+import { TSortableColumn, TSorting } from 'Admin/types/sorting'
 
 function BoardList({
     boards,
@@ -18,12 +19,11 @@ function BoardList({
     ]
     const [filterSearch, setFilterSearch] = useState('')
     const textSearchRegex = new RegExp(filterSearch, 'i')
-    const [sorting, setSorting] = useState({
-        column: '',
+    const [sorting, setSorting] = useState<TSorting>({
+        column: 'title',
         order: 'default',
     })
 
-    const handleHeaderClick = (column: string, sortable: boolean) => {
         if (sortable) {
             setSorting((prevSorting) => {
                 if (prevSorting.column === column) {
@@ -37,6 +37,7 @@ function BoardList({
                     }
                 } else {
                     return { column, order: 'asc' }
+    const handleHeaderClick = (column: TSortableColumn) => {
                 }
             })
         }

--- a/next-tavla/src/Admin/scenarios/BoardList/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/index.tsx
@@ -3,10 +3,7 @@ import { Row } from './components/Row'
 import { TSettings } from 'types/settings'
 import classes from './styles.module.css'
 import { TextField } from '@entur/form'
-import { CheckIcon, SearchIcon } from '@entur/icons'
 import { useState } from 'react'
-import { OverflowMenu, OverflowMenuItem } from '@entur/menu'
-import { SecondaryButton } from '@entur/button'
 
 function BoardList({
     boards,
@@ -20,26 +17,7 @@ function BoardList({
     ]
     const [filterSearch, setFilterSearch] = useState('')
     const textSearchRegex = new RegExp(filterSearch, 'i')
-    const sortOptions = [
-        { label: 'Alfabetisk A-Å', value: 'alphabetical' },
-        { label: 'Omvendt alfabetisk Å-A', value: 'unalphabetical' },
-    ]
-    const [selectedSort, setSelectedSort] = useState(sortOptions[0])
 
-    const sortBoards = (
-        a: { settings?: TSettings },
-        b: { settings?: TSettings },
-    ) => {
-        const titleA = a.settings?.title?.toLowerCase() ?? ''
-        const titleB = b.settings?.title?.toLowerCase() ?? ''
-        if (!selectedSort) return 0
-        switch (selectedSort.value) {
-            case 'alphabetical':
-                return titleA.localeCompare(titleB)
-            case 'unalphabetical':
-                return titleB.localeCompare(titleA)
-            default:
-                return 0
         }
     }
 
@@ -53,25 +31,6 @@ function BoardList({
                     value={filterSearch}
                     onChange={(e) => setFilterSearch(e.target.value)}
                 />
-                <OverflowMenu
-                    className={classes.sort}
-                    button={<SecondaryButton>Sorter</SecondaryButton>}
-                >
-                    {sortOptions.map((option) => (
-                        <OverflowMenuItem
-                            className={classes.sortItem}
-                            key={option.value}
-                            onSelect={() => {
-                                setSelectedSort(option)
-                            }}
-                        >
-                            {option.label}
-                            {selectedSort?.value === option.value && (
-                                <CheckIcon inline />
-                            )}
-                        </OverflowMenuItem>
-                    ))}
-                </OverflowMenu>
             </div>
             <div className={classes.table}>
                 <TableHeader
@@ -81,7 +40,6 @@ function BoardList({
                         .filter((board) =>
                             textSearchRegex.test(board.settings?.title ?? ''),
                         )
-                        .sort(sortBoards)
                         .map((board) => (
                             <Row key={board.id} board={board} />
                         ))}

--- a/next-tavla/src/Admin/scenarios/BoardList/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/index.tsx
@@ -3,6 +3,7 @@ import { Row } from './components/Row'
 import { TSettings } from 'types/settings'
 import classes from './styles.module.css'
 import { TextField } from '@entur/form'
+import { SearchIcon } from '@entur/icons'
 import { useState } from 'react'
 
 function BoardList({
@@ -17,8 +18,42 @@ function BoardList({
     ]
     const [filterSearch, setFilterSearch] = useState('')
     const textSearchRegex = new RegExp(filterSearch, 'i')
+    const [sorting, setSorting] = useState({
+        column: '',
+        order: 'default',
+    })
 
+    const handleHeaderClick = (column: string, sortable: boolean) => {
+        if (sortable) {
+            setSorting((prevSorting) => {
+                if (prevSorting.column === column) {
+                    switch (prevSorting.order) {
+                        case 'default':
+                            return { column, order: 'asc' }
+                        case 'asc':
+                            return { column, order: 'desc' }
+                        default:
+                            return { column: 'title', order: 'default' }
+                    }
+                } else {
+                    return { column, order: 'asc' }
+                }
+            })
         }
+    }
+
+    function sortBoards() {
+        const sortedBoards = [...boards]
+        if (sorting.order !== 'default') {
+            sortedBoards.sort((a, b) => {
+                const columnValueA = a.settings?.title ?? ''
+                const columnValueB = b.settings?.title ?? ''
+                return sorting.order === 'asc'
+                    ? columnValueA.localeCompare(columnValueB)
+                    : columnValueB.localeCompare(columnValueA)
+            })
+        }
+        return sortedBoards
     }
 
     return (
@@ -39,7 +74,7 @@ function BoardList({
                     sorting={sorting}
                 />
                 <div className={classes.tableBody}>
-                    {boards
+                    {sortBoards()
                         .filter((board) =>
                             textSearchRegex.test(board.settings?.title ?? ''),
                         )

--- a/next-tavla/src/Admin/scenarios/BoardList/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/index.tsx
@@ -34,6 +34,9 @@ function BoardList({
             </div>
             <div className={classes.table}>
                 <TableHeader
+                    headerCells={headerCells}
+                    onHeaderClick={handleHeaderClick}
+                    sorting={sorting}
                 />
                 <div className={classes.tableBody}>
                     {boards

--- a/next-tavla/src/Admin/scenarios/BoardList/index.tsx
+++ b/next-tavla/src/Admin/scenarios/BoardList/index.tsx
@@ -13,6 +13,11 @@ function BoardList({
 }: {
     boards: { id: string; settings?: TSettings }[]
 }) {
+    const headerCells = [
+        { label: 'Navn på tavle', value: 'title', sortable: true },
+        { label: 'Link', value: 'link', sortable: false },
+        { label: 'Valg', value: 'options', sortable: false },
+    ]
     const [filterSearch, setFilterSearch] = useState('')
     const textSearchRegex = new RegExp(filterSearch, 'i')
     const sortOptions = [
@@ -69,7 +74,8 @@ function BoardList({
                 </OverflowMenu>
             </div>
             <div className={classes.table}>
-                <TableHeader />
+                <TableHeader
+                />
                 <div className={classes.tableBody}>
                     {boards
                         .filter((board) =>

--- a/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
@@ -2,6 +2,7 @@ import { IconButton } from '@entur/button'
 import classes from './styles.module.css'
 import { DownArrowIcon, UnsortedIcon, UpArrowIcon } from '@entur/icons'
 import { Cell } from '../BoardList/components/Cell'
+import { TSortableColumn } from 'Admin/types/sorting'
 
 function TableHeader({
     headerCells,
@@ -9,7 +10,7 @@ function TableHeader({
     sorting,
 }: {
     headerCells: { label: string; value: string; sortable: boolean }[]
-    onHeaderClick: (column: string, sortable: boolean) => void
+    onHeaderClick: (column: TSortableColumn) => void
     sorting: { column: string; order: string }
 }) {
     return (
@@ -21,7 +22,7 @@ function TableHeader({
                         {cell.sortable && (
                             <IconButton
                                 onClick={() =>
-                                    onHeaderClick(cell.value, cell.sortable)
+                                    onHeaderClick(cell.value as TSortableColumn)
                                 }
                             >
                                 {sorting.column === cell.value ? (

--- a/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
@@ -1,12 +1,16 @@
 import classes from './styles.module.css'
+import { Cell } from '../BoardList/components/Cell'
 
-function TableHeader() {
+function TableHeader({
+    headerCells,
     return (
         <div className={classes.tableHead}>
-            <div className={classes.tableRow}>
-                <div className={classes.tableCell}>Navn på tavle</div>
-                <div className={classes.tableCell}>Link</div>
-                <div className={classes.tableCell}>Valg</div>
+            <div className={classes.headerRow}>
+                {headerCells.map((cell) => (
+                    <Cell className={classes.headerCell} key={cell.value}>
+                        {cell.label}
+                    </Cell>
+                ))}
             </div>
         </div>
     )

--- a/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
+++ b/next-tavla/src/Admin/scenarios/TableHeader/index.tsx
@@ -1,14 +1,42 @@
+import { IconButton } from '@entur/button'
 import classes from './styles.module.css'
+import { DownArrowIcon, UnsortedIcon, UpArrowIcon } from '@entur/icons'
 import { Cell } from '../BoardList/components/Cell'
 
 function TableHeader({
     headerCells,
+    onHeaderClick,
+    sorting,
+}: {
+    headerCells: { label: string; value: string; sortable: boolean }[]
+    onHeaderClick: (column: string, sortable: boolean) => void
+    sorting: { column: string; order: string }
+}) {
     return (
         <div className={classes.tableHead}>
             <div className={classes.headerRow}>
                 {headerCells.map((cell) => (
                     <Cell className={classes.headerCell} key={cell.value}>
                         {cell.label}
+                        {cell.sortable && (
+                            <IconButton
+                                onClick={() =>
+                                    onHeaderClick(cell.value, cell.sortable)
+                                }
+                            >
+                                {sorting.column === cell.value ? (
+                                    sorting.order === 'asc' ? (
+                                        <UpArrowIcon />
+                                    ) : sorting.order === 'desc' ? (
+                                        <DownArrowIcon />
+                                    ) : (
+                                        <UnsortedIcon />
+                                    )
+                                ) : (
+                                    <UnsortedIcon />
+                                )}
+                            </IconButton>
+                        )}
                     </Cell>
                 ))}
             </div>

--- a/next-tavla/src/Admin/scenarios/TableHeader/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/TableHeader/styles.module.css
@@ -3,15 +3,12 @@
     border-bottom: var(--colors-blues-blue20) solid;
 }
 
-.tableRow {
+.headerRow {
     display: grid;
     grid-template-columns: 3fr 5fr 1fr;
+    color: var(--colors-brand-lavender);
 }
 
-.tableCell {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    font-weight: 500;
-    color: var(--colors-brand-lavender);
+.headerCell {
+    gap: 0.5rem;
 }

--- a/next-tavla/src/Admin/types/sorting.ts
+++ b/next-tavla/src/Admin/types/sorting.ts
@@ -1,0 +1,6 @@
+export type TSortingOrder = 'default' | 'asc' | 'desc'
+export type TSortableColumn = 'title'
+export type TSorting = {
+    column: TSortableColumn
+    order: TSortingOrder
+}


### PR DESCRIPTION
### Description:
- removed sort button and its functonalty
- refactored tableheader so there is now a const that has an overview over all table header cells and whether they are sortable
- added sorting by table headers with 3 sorting orders: ascending, descending and default

**NB!: sortboards function can only sort by board titles since it is the only sortable column available now. When date columns are implemented, sortboards function should be rewritten to suit that datastructure.** 

### Images: 

| Before | After |
|--------|------|
| <img width="500" alt="image" src="https://github.com/entur/tavla/assets/64562118/ed078693-deda-4714-8532-c016dd7b69da">| ![image](https://github.com/entur/tavla/assets/64562118/6ac23253-62a3-4359-aeeb-995996f3289f)|