### PR TITLE
feat(boards): create board from "my boards" 

### DIFF
--- a/next-tavla/src/Admin/scenarios/Boards/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/index.tsx
@@ -3,14 +3,18 @@ import classes from './styles.module.css'
 import { BoardList } from '../BoardList'
 import { TBoard } from 'types/settings'
 import dynamic from 'next/dynamic'
+import { CreateBoard } from '../CreateBoard'
 
 function Boards({ boards }: { boards: TBoard[] }) {
     return (
         <div className={classes.adminWrapper}>
-            <Heading1>Mine Tavler</Heading1>
-            <div>
-                <BoardList boards={boards} />
+            <div className={classes.header}>
+                <Heading1>Mine Tavler</Heading1>
+                <div>
+                    <CreateBoard />
+                </div>
             </div>
+            <BoardList boards={boards} />
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/Boards/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/index.tsx
@@ -10,9 +10,7 @@ function Boards({ boards }: { boards: TBoard[] }) {
         <div className={classes.adminWrapper}>
             <div className={classes.header}>
                 <Heading1>Mine Tavler</Heading1>
-                <div>
-                    <CreateBoard />
-                </div>
+                <CreateBoard />
             </div>
             <BoardList boards={boards} />
         </div>

--- a/next-tavla/src/Admin/scenarios/Boards/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Boards/styles.module.css
@@ -4,3 +4,8 @@
     gap: 5em;
     margin: 1.25em 0;
 }
+
+.header {
+    display: flex;
+    justify-content: space-between;
+}

--- a/next-tavla/src/Admin/scenarios/CreateBoard/index.tsx
+++ b/next-tavla/src/Admin/scenarios/CreateBoard/index.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@entur/button'
+import { useState } from 'react'
+import Link from 'next/link'
+
+function CreateBoard() {
+    const [loading, isLoading] = useState(false)
+    return (
+        <Button
+            as={Link}
+            href="/api/board"
+            replace
+            onClick={() => isLoading(true)}
+            variant="primary"
+            width="fluid"
+            disabled={loading}
+            loading={loading}
+        >
+            Opprett ny tavle
+        </Button>
+    )
+}
+export { CreateBoard }

--- a/next-tavla/src/Admin/scenarios/CreateBoard/index.tsx
+++ b/next-tavla/src/Admin/scenarios/CreateBoard/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@entur/button'
 import { useState } from 'react'
 import Link from 'next/link'
 
-function CreateBoard() {
+function CreateBoard({ width }: { width?: 'auto' | 'fluid' }) {
     const [loading, isLoading] = useState(false)
     return (
         <Button
@@ -11,7 +11,7 @@ function CreateBoard() {
             replace
             onClick={() => isLoading(true)}
             variant="primary"
-            width="fluid"
+            width={width || 'auto'}
             disabled={loading}
             loading={loading}
         >

--- a/next-tavla/src/Admin/scenarios/CreateBoard/index.tsx
+++ b/next-tavla/src/Admin/scenarios/CreateBoard/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@entur/button'
 import { useState } from 'react'
 import Link from 'next/link'
 
-function CreateBoard({ width }: { width?: 'auto' | 'fluid' }) {
+function CreateBoard() {
     const [loading, isLoading] = useState(false)
     return (
         <Button
@@ -11,7 +11,6 @@ function CreateBoard({ width }: { width?: 'auto' | 'fluid' }) {
             replace
             onClick={() => isLoading(true)}
             variant="primary"
-            width={width || 'auto'}
             disabled={loading}
             loading={loading}
         >

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -5,12 +5,8 @@ import landingImage from 'assets/illustrations/Tavla-illustration.png'
 import tavla from 'assets/illustrations/Tavla-screenshot.png'
 import { Contrast } from '@entur/layout'
 import classNames from 'classnames'
-import Link from 'next/link'
-import { useState } from 'react'
-import { Button } from '@entur/button'
 
 function Landing() {
-    const [loading, isLoading] = useState(false)
     return (
         <div className={classes.container}>
             <Contrast className={classes.centeredContainer}>
@@ -19,18 +15,6 @@ function Landing() {
                     <Heading1 className={classes.subheading}>
                         for reisende
                     </Heading1>
-
-                    <Button
-                        as={Link}
-                        href="api/board"
-                        onClick={() => isLoading(true)}
-                        variant="primary"
-                        disabled={loading}
-                        loading={loading}
-                        className={classes.button}
-                    >
-                        Opprett ny tavle
-                    </Button>
                 </div>
                 <div className={classNames(classes.content, classes.topImage)}>
                     <Image

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -17,8 +17,8 @@ function Landing() {
                         for reisende
                     </Heading1>
                     <div className={classes.button}>
-                        <CreateBoard width="fluid" />
                     </div>
+                    <CreateBoard />
                 </div>
                 <div className={classNames(classes.content, classes.topImage)}>
                     <Image

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -16,8 +16,6 @@ function Landing() {
                     <Heading1 className={classes.subheading}>
                         for reisende
                     </Heading1>
-                    <div className={classes.button}>
-                    </div>
                     <CreateBoard />
                 </div>
                 <div className={classNames(classes.content, classes.topImage)}>

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -5,6 +5,7 @@ import landingImage from 'assets/illustrations/Tavla-illustration.png'
 import tavla from 'assets/illustrations/Tavla-screenshot.png'
 import { Contrast } from '@entur/layout'
 import classNames from 'classnames'
+import { CreateBoard } from '../CreateBoard'
 
 function Landing() {
     return (
@@ -15,6 +16,9 @@ function Landing() {
                     <Heading1 className={classes.subheading}>
                         for reisende
                     </Heading1>
+                    <div className={classes.button}>
+                        <CreateBoard />
+                    </div>
                 </div>
                 <div className={classNames(classes.content, classes.topImage)}>
                     <Image

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -17,7 +17,7 @@ function Landing() {
                         for reisende
                     </Heading1>
                     <div className={classes.button}>
-                        <CreateBoard />
+                        <CreateBoard width="fluid" />
                     </div>
                 </div>
                 <div className={classNames(classes.content, classes.topImage)}>

--- a/next-tavla/src/Admin/scenarios/Landing/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Landing/styles.module.css
@@ -36,10 +36,6 @@
     flex: 1;
 }
 
-.button {
-    width: 50%;
-}
-
 .list {
     padding-left: 2em;
     color: var(--primary-text-color); /* Variabel fra designsystemet */


### PR DESCRIPTION
### Description:
- moved Button that creates a board from landing page to its own component that can now be reused multiple places
- added new "Create Board" component to Landing page 
- added new "Create Board" component to Boards
### Image:
<img width="1679" alt="image" src="https://github.com/entur/tavla/assets/64562118/44040379-c48d-41c5-8cce-ef915b9160f6">
