### PR TITLE
feat(edit): change direction of the tiles

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/reducer.ts
+++ b/next-tavla/src/Admin/scenarios/Edit/reducer.ts
@@ -63,12 +63,12 @@ export function boardReducer(settings: TBoard, action: Action): TBoard {
             return {
                 ...settings,
                 tiles: [
+                    ...settings.tiles,
                     {
                         ...action.tile,
                         uuid: nanoid(),
                         columns: ['line', 'destination', 'time'],
                     },
-                    ...settings.tiles,
                 ],
             }
         }


### PR DESCRIPTION
### Description: 
Changed direction of how the tiles are build up. The tiles and tabs will now be displayed from left to right (regular reading direction). 

### Images: 
|Before | After |
|--------|-----|
|<img width="682" alt="image" src="https://github.com/entur/tavla/assets/64562118/9eb4a454-9580-4a9b-8b93-1958f2c641cf"> | <img width="649" alt="image" src="https://github.com/entur/tavla/assets/64562118/eac39929-3a9e-4629-a79b-3569887e322c">|
|<img width="1708" alt="image" src="https://github.com/entur/tavla/assets/64562118/f55f91b8-de5c-4253-9442-11f228b2ace3">|<img width="1681" alt="image" src="https://github.com/entur/tavla/assets/64562118/2590ad7b-4c2f-4118-8392-2b617b17ec56">|
