### PR TITLE
feat(edit): board title section

### DIFF
--- a/next-tavla/src/Admin/components/IllustratedInfo/styles.module.css
+++ b/next-tavla/src/Admin/components/IllustratedInfo/styles.module.css
@@ -2,6 +2,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    background-color: var(--secondary-background-color);
+    border-radius: 0.5em;
 }
 
 .infoHeading {

--- a/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
@@ -37,7 +37,7 @@ function AddTile() {
 
     return (
         <div>
-            <Heading1 className={classes.Heading1}>Holdeplasser</Heading1>
+            <Heading1>Holdeplasser i tavla</Heading1>
 
             <div className={classes.SearchContainer}>
                 <SearchableDropdown

--- a/next-tavla/src/Admin/scenarios/Edit/components/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/BoardTitle/index.tsx
@@ -1,69 +1,40 @@
-import { SecondarySquareButton } from '@entur/button'
 import { TextField } from '@entur/form'
-import { CheckIcon, CloseIcon, EditIcon } from '@entur/icons'
-import { Heading1 } from '@entur/typography'
+import { EditIcon } from '@entur/icons'
 import { useCallback, useState } from 'react'
 import classes from './styles.module.css'
-import { Tooltip } from '@entur/tooltip'
-import { DEFAULT_BOARD_NAME } from 'Admin/utils/constants'
 import { useEditSettingsDispatch } from '../../utils/contexts'
+import { DEFAULT_BOARD_NAME } from 'Admin/utils/constants'
 
 function BoardTitle({ title }: { title?: string }) {
-    const [isEditing, setIsEditing] = useState(false)
-    const dispatch = useEditSettingsDispatch()
     const boardTitle = title || DEFAULT_BOARD_NAME
     const [tempTitle, setTempTitle] = useState(boardTitle)
-
+    const dispatch = useEditSettingsDispatch()
     const autoSelect = useCallback((ref: HTMLInputElement) => {
         ref?.select()
     }, [])
 
-    if (!isEditing) {
-        return (
-            <div className={classes.editTitle}>
-                <Heading1 className={classes.title}>{boardTitle}</Heading1>
-                <Tooltip content="Rediger tittel" placement="right">
-                    <SecondarySquareButton
-                        className={classes.squareButton}
-                        onClick={() => setIsEditing(true)}
-                    >
-                        <EditIcon aria-label="Rediger tittel" />
-                    </SecondarySquareButton>
-                </Tooltip>
-            </div>
-        )
+    const dispatchTitle = () => {
+        dispatch({
+            type: 'setTitle',
+            title: tempTitle || DEFAULT_BOARD_NAME,
+        })
+        if (!tempTitle) {
+            setTempTitle(DEFAULT_BOARD_NAME)
+        }
     }
-
     return (
         <div className={classes.editTitle}>
             <TextField
-                defaultValue={boardTitle}
+                value={tempTitle}
+                className={classes.textField}
                 size="medium"
-                label="Navn på tavlen"
+                label="Navn på tavla"
+                placeholder="Navn på tavla"
+                prepend={<EditIcon />}
                 onChange={(e) => setTempTitle(e.target.value)}
+                onBlur={dispatchTitle}
                 ref={autoSelect}
-            />
-            <SecondarySquareButton
-                className={classes.squareButton}
-                onClick={() => {
-                    setIsEditing(false)
-                    dispatch({
-                        type: 'setTitle',
-                        title: tempTitle,
-                    })
-                }}
-            >
-                <CheckIcon aria-label="Bekreft tittelendring" />
-            </SecondarySquareButton>
-            <SecondarySquareButton
-                className={classes.squareButton}
-                onClick={() => {
-                    setTempTitle(boardTitle)
-                    setIsEditing(false)
-                }}
-            >
-                <CloseIcon aria-label="Avbryt tittelendring" />
-            </SecondarySquareButton>
+            ></TextField>
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/Edit/components/BoardTitle/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/components/BoardTitle/styles.module.css
@@ -1,11 +1,12 @@
 .editTitle {
     display: flex;
-    height: 3rem;
     align-items: center;
     gap: 1em;
+    background-color: var(--secondary-background-color);
+    border-radius: 0.5em;
+    padding: 1rem 3rem;
 }
 
-.title {
-    margin: auto;
-    line-height: 3rem;
+.textField {
+    width: max-content;
 }

--- a/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/index.tsx
@@ -33,7 +33,7 @@ function TilesOverview({ tiles }: { tiles: TTile[] }) {
                     <Tab key={tile.uuid}>{tile.name ?? tile.placeId}</Tab>
                 ))}
             </TabList>
-            <TabPanels>
+            <TabPanels className={classes.tabPanels}>
                 {tiles.map((tile) => (
                     <TabPanel key={tile.uuid}>
                         <TileSettings tile={tile} />

--- a/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/styles.module.css
@@ -1,3 +1,7 @@
 .tabs {
     width: 100%;
 }
+.tabPanels {
+    background-color: var(--secondary-background-color);
+    border-radius: 0.5em;
+}

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -33,7 +33,7 @@ function Edit({
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>
                 <div className="flexBetween">
-                    <BoardTitle title={board.meta?.title} />
+                    <Heading1>Tavla</Heading1>
                     <div className="flexGap">
                         <SecondaryButton
                             onClick={() => {

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -13,6 +13,7 @@ import { SettingsDispatchContext } from './utils/contexts'
 import { BoardTitle } from './components/BoardTitle'
 import { AddTile } from './components/AddTile'
 import { TilesOverview } from './components/TilesOverview'
+import { Heading1 } from '@entur/typography'
 
 function Edit({
     initialBoard,
@@ -55,6 +56,7 @@ function Edit({
                         </PrimaryButton>
                     </div>
                 </div>
+                <BoardTitle title={board.meta?.title} />
                 <AddTile />
                 <TilesOverview tiles={board.tiles} />
             </div>

--- a/next-tavla/src/Admin/scenarios/Edit/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/styles.module.css
@@ -1,7 +1,7 @@
 .settings {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 2em;
     margin: 1.25em 0;
 }
 

--- a/next-tavla/src/Shared/styles/global.css
+++ b/next-tavla/src/Shared/styles/global.css
@@ -13,6 +13,10 @@ html {
     line-height: 1.2;
 }
 
+.eds-h1 {
+    font-size: 2rem;
+}
+
 h3 {
     font-weight: 500;
 }


### PR DESCRIPTION
### Description: 
Create two sections in edit page: edit board title and select stop places. 
Textfield for setting board title is changed to work like textfield in google docs.

### Images: 
| Before |After   |
|-------|---|
| <img width="1600" alt="image" src="https://github.com/entur/tavla/assets/64562118/e1c5ec3c-e25f-4d71-afd1-f22b578e1a3e">|  <img width="1622" alt="image" src="https://github.com/entur/tavla/assets/64562118/8bee43bb-e418-49fa-8e87-d270f19d451e"> |