### PR TITLE
feat(edit): set active tab to be the newest added tab

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/index.tsx
@@ -10,6 +10,7 @@ function TilesOverview({ tiles }: { tiles: TTile[] }) {
     const [activeTab, setActiveTab] = useState(0)
 
     useEffect(() => {
+        if (!tiles.length) return
         setActiveTab(tiles.length - 1)
     }, [tiles.length])
 

--- a/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/TilesOverview/index.tsx
@@ -10,7 +10,7 @@ function TilesOverview({ tiles }: { tiles: TTile[] }) {
     const [activeTab, setActiveTab] = useState(0)
 
     useEffect(() => {
-        setActiveTab(0)
+        setActiveTab(tiles.length - 1)
     }, [tiles.length])
 
     if (isEmpty(tiles))


### PR DESCRIPTION
### Description: 
When a new tab is added, it is expected that the newest tab will be opened. 
Has set the newest tab to be active.

### Image: 
| Before | After |
|--------|------|
| ![image](https://github.com/entur/tavla/assets/64562118/59807b1a-2e3c-4843-862b-c80563f1271f)| <img width="240" alt="image" src="https://github.com/entur/tavla/assets/64562118/347313a2-cd43-4010-9ec4-3eeda4a19284">|