### PR TITLE
feat(boards): update default sorting to be by the last updated

### DIFF
--- a/next-tavla/src/Admin/scenarios/Boards/hooks/useSortBoardFunction.ts
+++ b/next-tavla/src/Admin/scenarios/Boards/hooks/useSortBoardFunction.ts
@@ -26,7 +26,7 @@ function useSortBoardFunction() {
                         const titleB =
                             boardB?.meta?.title?.toLowerCase() ??
                             DEFAULT_BOARD_NAME
-                        return titleA.localeCompare(titleB)
+                        return titleB.localeCompare(titleA)
                     }
                     break
             }

--- a/next-tavla/src/Admin/scenarios/Boards/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/index.tsx
@@ -40,7 +40,7 @@ import {
 function Boards({ boards }: { boards: TBoard[] }) {
     const [settings, dispatch] = useReducer(settingsReducer, {
         search: '',
-        sort: { type: 'ascending', column: 'name' },
+        sort: { type: 'descending', column: 'lastModified' },
         columns: ['name', 'url', 'actions', 'lastModified'],
         boards: boards,
     })


### PR DESCRIPTION
### Description: 
Updated default sorting of my boards to be by the last modified. 
_"Som bruker av tavla antar jeg når jeg lagrer en ny tavle - at den havner på toppen, sortert etter sist oppdatert - ikke etter navn."_