### PR TITLE
fix(code quality): clarified component name

### DIFF
--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/Actions.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/Actions.tsx
@@ -6,20 +6,20 @@ import { TBoard } from 'types/settings'
 import { useLink } from '../../hooks/useLink'
 import { useToast } from '@entur/alert'
 import classes from './styles.module.css'
-import { SortableColumn } from './SortableColumn'
+import { DraggableColumn } from './DraggableColumn'
 import { Delete } from './Delete'
 
 function Actions({ board }: { board: TBoard }) {
     const link = useLink(board.id)
     return (
-        <SortableColumn column="actions">
+        <DraggableColumn column="actions">
             <div className={classes.actions}>
                 <Edit bid={board.id} />
                 <Copy link={link} />
                 <Open link={link} />
                 <Delete board={board} />
             </div>
-        </SortableColumn>
+        </DraggableColumn>
     )
 }
 

--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/DraggableColumn.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/DraggableColumn.tsx
@@ -2,7 +2,7 @@ import { TBoardsColumn } from 'Admin/types/boards'
 import classes from './styles.module.css'
 import { useSortableColumnAttributes } from '../../hooks/useSortableColumnAttributes'
 
-function SortableColumn({
+function DraggableColumn({
     column,
     children,
 }: {
@@ -23,4 +23,4 @@ function SortableColumn({
     )
 }
 
-export { SortableColumn }
+export { DraggableColumn }

--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/LastModified.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/LastModified.tsx
@@ -1,11 +1,11 @@
 import { formatTimestamp } from 'Admin/utils/time'
-import { SortableColumn } from './SortableColumn'
+import { DraggableColumn } from './DraggableColumn'
 
 function LastModified({ timestamp }: { timestamp?: number }) {
     return (
-        <SortableColumn column="lastModified">
+        <DraggableColumn column="lastModified">
             {formatTimestamp(timestamp)}
-        </SortableColumn>
+        </DraggableColumn>
     )
 }
 

--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/Link.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/Link.tsx
@@ -1,9 +1,9 @@
 import { useLink } from '../../hooks/useLink'
-import { SortableColumn } from './SortableColumn'
+import { DraggableColumn } from './DraggableColumn'
 
 function Link({ bid }: { bid?: string }) {
     const link = useLink(bid)
 
-    return <SortableColumn column="url">{link}</SortableColumn>
+    return <DraggableColumn column="url">{link}</DraggableColumn>
 }
 export { Link }

--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/Name.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/Name.tsx
@@ -1,8 +1,8 @@
 import { DEFAULT_BOARD_NAME } from 'Admin/utils/constants'
-import { SortableColumn } from './SortableColumn'
+import { DraggableColumn } from './DraggableColumn'
 
 function Name({ name = DEFAULT_BOARD_NAME }: { name?: string }) {
-    return <SortableColumn column="name">{name}</SortableColumn>
+    return <DraggableColumn column="name">{name}</DraggableColumn>
 }
 
 export { Name }


### PR DESCRIPTION
### Description

Found that the `SortableColumn`-component's name was easy to confuse with the `SortableColumn`-type which indicates if a column can be sorted in an ascending or descending order. Switched to `DraggableColumn`, which is more accurate.