### PR TITLE
fix(edit): update autosave

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/components/AutoSave/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AutoSave/index.tsx
@@ -1,12 +1,12 @@
 import { TBoard } from 'types/settings'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { formatTimestamp } from 'Admin/utils/time'
 
 function AutoSave({ board }: { board: TBoard }) {
     const [status, setStatus] = useState(
         `Sist lagret: ${formatTimestamp(board.meta?.dateModified, true)}`,
     )
-    const prevBoardRef = useRef<TBoard | null>(null)
+    const [initialLoad, setInitialLoad] = useState(true)
 
     const setBoard = (board: TBoard) =>
         fetch('/api/board', {
@@ -15,15 +15,10 @@ function AutoSave({ board }: { board: TBoard }) {
         })
 
     useEffect(() => {
-        if (
-            prevBoardRef.current !== null &&
-            JSON.stringify(prevBoardRef.current) !== JSON.stringify(board)
-        ) {
-            setBoard(board)
-            setStatus(`Sist lagret: ${formatTimestamp(Date.now(), true)}`)
-        }
-        prevBoardRef.current = board
-    }, [board])
+        if (initialLoad) return () => setInitialLoad(false)
+        setBoard(board)
+        setStatus(`Sist lagret: ${formatTimestamp(Date.now(), true)}`)
+    }, [initialLoad, board])
 
     return <div>{status}</div>
 }

--- a/next-tavla/src/Admin/scenarios/Edit/components/AutoSave/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AutoSave/index.tsx
@@ -1,12 +1,12 @@
 import { TBoard } from 'types/settings'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatTimestamp } from 'Admin/utils/time'
 
 function AutoSave({ board }: { board: TBoard }) {
     const [status, setStatus] = useState(
         `Sist lagret: ${formatTimestamp(board.meta?.dateModified, true)}`,
     )
-    const [initialLoad, setInitialLoad] = useState(true)
+    const initialLoad = useRef(true)
 
     const setBoard = (board: TBoard) =>
         fetch('/api/board', {
@@ -15,7 +15,10 @@ function AutoSave({ board }: { board: TBoard }) {
         })
 
     useEffect(() => {
-        if (initialLoad) return () => setInitialLoad(false)
+        if (initialLoad.current) {
+            initialLoad.current = false
+            return
+        }
         setBoard(board)
         setStatus(`Sist lagret: ${formatTimestamp(Date.now(), true)}`)
     }, [initialLoad, board])

--- a/next-tavla/src/Admin/scenarios/Edit/components/AutoSave/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AutoSave/index.tsx
@@ -1,9 +1,12 @@
 import { TBoard } from 'types/settings'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatTimestamp } from 'Admin/utils/time'
 
 function AutoSave({ board }: { board: TBoard }) {
-    const [status, setStatus] = useState('')
+    const [status, setStatus] = useState(
+        `Sist lagret: ${formatTimestamp(board.meta?.dateModified, true)}`,
+    )
+    const prevBoardRef = useRef<TBoard | null>(null)
 
     const setBoard = (board: TBoard) =>
         fetch('/api/board', {
@@ -12,8 +15,14 @@ function AutoSave({ board }: { board: TBoard }) {
         })
 
     useEffect(() => {
-        setBoard(board)
-        setStatus(`Sist lagret: ${formatTimestamp(Date.now(), true)}`)
+        if (
+            prevBoardRef.current !== null &&
+            JSON.stringify(prevBoardRef.current) !== JSON.stringify(board)
+        ) {
+            setBoard(board)
+            setStatus(`Sist lagret: ${formatTimestamp(Date.now(), true)}`)
+        }
+        prevBoardRef.current = board
     }, [board])
 
     return <div>{status}</div>


### PR DESCRIPTION
### Description: 
Fixed autosave:
- if user edits "edit board" page, the last modified date will not be updated
- save the board only when changes were made, and not when the page was opened