### PR TITLE
feat(organizations): created organizations page and linked from header

### DIFF
--- a/next-tavla/pages/edit/organizations.tsx
+++ b/next-tavla/pages/edit/organizations.tsx
@@ -1,0 +1,44 @@
+import classes from 'styles/pages/admin.module.css'
+import { Contrast } from '@entur/layout'
+import { ToastProvider } from '@entur/alert'
+import { verifyUserSession } from 'Admin/utils/auth'
+import { IncomingNextMessage } from 'types/next'
+import { AdminHeader } from 'Admin/components/AdminHeader'
+import { Organizations } from 'Admin/scenarios/Organizations'
+
+export async function getServerSideProps({
+    req,
+}: {
+    req: IncomingNextMessage
+}) {
+    const user = await verifyUserSession(req)
+    if (!user) {
+        return {
+            redirect: {
+                destination: '/#login',
+                permanent: false,
+            },
+        }
+    }
+
+    return {
+        props: {
+            loggedIn: user !== null,
+        },
+    }
+}
+
+function OrganizationsPage({ loggedIn }: { loggedIn: boolean }) {
+    return (
+        <div className={classes.root}>
+            <AdminHeader loggedIn={loggedIn} />
+            <Contrast>
+                <ToastProvider>
+                    <Organizations />
+                </ToastProvider>
+            </Contrast>
+        </div>
+    )
+}
+
+export default OrganizationsPage

--- a/next-tavla/src/Admin/components/AdminHeader/index.tsx
+++ b/next-tavla/src/Admin/components/AdminHeader/index.tsx
@@ -6,7 +6,7 @@ import { PrimaryButton } from '@entur/button'
 import Link from 'next/link'
 import classes from './styles.module.css'
 import { CreateBoard } from '../CreateBoard'
-import { UserIcon } from '@entur/icons'
+import { OrganizationIcon, UserIcon } from '@entur/icons'
 
 function AdminHeader({ loggedIn }: { loggedIn: boolean }) {
     return (
@@ -28,6 +28,10 @@ function AdminHeader({ loggedIn }: { loggedIn: boolean }) {
                             <UserIcon />
                             Mine Tavler
                         </PrimaryButton>
+                            <PrimaryButton as={Link} href="/edit/organizations">
+                                <OrganizationIcon />
+                                Organisasjoner
+                            </PrimaryButton>
                     </>
                 )}
                 <Login loggedIn={loggedIn} />

--- a/next-tavla/src/Admin/components/AdminHeader/index.tsx
+++ b/next-tavla/src/Admin/components/AdminHeader/index.tsx
@@ -7,8 +7,10 @@ import Link from 'next/link'
 import classes from './styles.module.css'
 import { CreateBoard } from '../CreateBoard'
 import { OrganizationIcon, UserIcon } from '@entur/icons'
+import { checkFeatureFlags } from 'utils/featureFlags'
 
 function AdminHeader({ loggedIn }: { loggedIn: boolean }) {
+    const ORGANIZATIONS_ENABLED = checkFeatureFlags('ORGANIZATIONS')
     return (
         <div className={classes.header}>
             <Link href="/">
@@ -28,10 +30,12 @@ function AdminHeader({ loggedIn }: { loggedIn: boolean }) {
                             <UserIcon />
                             Mine Tavler
                         </PrimaryButton>
+                        {ORGANIZATIONS_ENABLED && (
                             <PrimaryButton as={Link} href="/edit/organizations">
                                 <OrganizationIcon />
                                 Organisasjoner
                             </PrimaryButton>
+                        )}
                     </>
                 )}
                 <Login loggedIn={loggedIn} />

--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/Tags.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/Tags.tsx
@@ -1,5 +1,4 @@
 import { TBoard } from 'types/settings'
-import { SortableColumn } from './SortableColumn'
 import { Badge } from '@entur/layout'
 import { colorsFromHash } from '../../utils/colorsFromHash'
 import { TagModal } from '../TagModal'
@@ -8,6 +7,7 @@ import { sortArrayByOverlap } from '../../utils/sortArrayByOverlap'
 import { Tooltip } from '@entur/tooltip'
 import { TTag } from 'types/meta'
 import { ReactNode } from 'react'
+import { DraggableColumn } from './DraggableColumn'
 
 function TagList({ tags, children }: { tags: TTag[]; children?: ReactNode }) {
     return (
@@ -42,7 +42,7 @@ function Tags({ board }: { board: TBoard }) {
     }
 
     return (
-        <SortableColumn column="tags">
+        <DraggableColumn column="tags">
             <div className="flexRow w-100 g-1">
                 <TagModal board={board} />
                 <TagList tags={tags.slice(0, displayNumber)}>
@@ -60,7 +60,7 @@ function Tags({ board }: { board: TBoard }) {
                     )}
                 </TagList>
             </div>
-        </SortableColumn>
+        </DraggableColumn>
     )
 }
 

--- a/next-tavla/src/Admin/scenarios/Organizations/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Organizations/index.tsx
@@ -1,0 +1,4 @@
+function Organizations() {
+    return <></>
+}
+export { Organizations }

--- a/next-tavla/src/Admin/scenarios/Organizations/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Organizations/index.tsx
@@ -1,4 +1,4 @@
 function Organizations() {
-    return <></>
+    return <div>Organisasjoner</div>
 }
 export { Organizations }

--- a/next-tavla/src/Shared/types/featureFlag.ts
+++ b/next-tavla/src/Shared/types/featureFlag.ts
@@ -1,1 +1,1 @@
-export type Feature = 'LOGIN' | 'BOARDS'
+export type Feature = 'LOGIN' | 'BOARDS' | 'ORGANIZATIONS'


### PR DESCRIPTION
### Description:
- created an empty page for organizations with link: /edit/organizations 
- button (link) in admin header that leads to organizations page
- put button that leads to organizations page behind feature flag

### Images:
![image](https://github.com/entur/tavla/assets/64562118/d3487e8d-f179-4f85-a9e9-51ab5ec6f452)
![image](https://github.com/entur/tavla/assets/64562118/ad762b26-f0f6-4ec2-9cda-995a33317220)
