### PR TITLE
fix(firebase): removing board reference from user when board is deleted

### DIFF
--- a/next-tavla/src/Admin/utils/firebase.ts
+++ b/next-tavla/src/Admin/utils/firebase.ts
@@ -149,11 +149,11 @@ export async function deleteBoard(bid: TBoardID, uid: TUserID) {
             message: 'User does not have access to this board.',
         })
     }
-    return firestore()
-        .collection('boards')
-        .doc(bid)
-        .delete()
-        .then(() => removeBoardFromUser(bid, uid))
+
+    return Promise.all([
+        firestore().collection('boards').doc(bid).delete(),
+        removeBoardFromUser(bid, uid),
+    ])
 }
 
 export async function removeBoardFromUser(bid: TBoardID, uid: TUserID) {

--- a/next-tavla/src/Admin/utils/firebase.ts
+++ b/next-tavla/src/Admin/utils/firebase.ts
@@ -149,7 +149,21 @@ export async function deleteBoard(bid: TBoardID, uid: TUserID) {
             message: 'User does not have access to this board.',
         })
     }
-    return firestore().collection('boards').doc(bid).delete()
+    return firestore()
+        .collection('boards')
+        .doc(bid)
+        .delete()
+        .then(() => removeBoardFromUser(bid, uid))
+}
+
+export async function removeBoardFromUser(bid: TBoardID, uid: TUserID) {
+    return firestore()
+        .collection('users')
+        .doc(uid)
+        .update({
+            owner: admin.firestore.FieldValue.arrayRemove(bid),
+            editor: admin.firestore.FieldValue.arrayRemove(bid),
+        })
 }
 
 export async function userCanDeleteBoard(uid: TUserID, bid: TBoardID) {


### PR DESCRIPTION
### Description

Removes the board reference from a user when the board is deleted.

Should also be done to organizations when their datatypes are more mature.