### PR TITLE
feat(board): default behaviour for textsize

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/components/FontsizeSelector/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/FontsizeSelector/index.tsx
@@ -3,6 +3,7 @@ import { TBoard } from 'types/settings'
 import classes from './styles.module.css'
 import { useEditSettingsDispatch } from '../../utils/contexts'
 import { TFontSize } from 'types/meta'
+import { defaultFontSize } from 'Board/scenarios/Board/utils'
 
 function FontsizeSelector({ board }: { board: TBoard }) {
     const dispatch = useEditSettingsDispatch()
@@ -11,7 +12,7 @@ function FontsizeSelector({ board }: { board: TBoard }) {
             className={classes.choiceChipGroup}
             name="city"
             label="Velg tekststørrelse:"
-            value={board.meta?.fontSize || 'medium'}
+            value={board.meta?.fontSize || defaultFontSize(board)}
             onChange={(e) => {
                 dispatch({
                     type: 'changeFontSize',

--- a/next-tavla/src/Board/scenarios/Board/index.tsx
+++ b/next-tavla/src/Board/scenarios/Board/index.tsx
@@ -4,7 +4,7 @@ import { StopPlaceTile } from '../StopPlaceTile'
 import { QuayTile } from '../QuayTile'
 import classes from './styles.module.css'
 import { Tile } from 'components/Tile'
-import { getFontScale } from 'Board/scenarios/Board/utils'
+import { defaultFontSize, getFontScale } from 'Board/scenarios/Board/utils'
 
 function BoardTile({ tileSpec }: { tileSpec: TTile }) {
     switch (tileSpec.type) {
@@ -22,12 +22,16 @@ function Board({ board }: { board: TBoard }) {
                 <p>Du har ikke lagt til noen holdeplasser enda.</p>
             </Tile>
         )
-
     return (
         <div
             className={classes.board}
             style={{
-                fontSize: 100 * getFontScale(board.meta?.fontSize) + '%',
+                fontSize:
+                    100 *
+                        getFontScale(
+                            board.meta?.fontSize || defaultFontSize(board),
+                        ) +
+                    '%',
             }}
         >
             {board.tiles.map((tile, index) => {

--- a/next-tavla/src/Board/scenarios/Board/utils.ts
+++ b/next-tavla/src/Board/scenarios/Board/utils.ts
@@ -1,4 +1,5 @@
 import { TFontSize } from 'types/meta'
+import { TBoard } from 'types/settings'
 export function getFontScale(fontSize: TFontSize | undefined) {
     switch (fontSize) {
         case 'small':
@@ -9,5 +10,15 @@ export function getFontScale(fontSize: TFontSize | undefined) {
             return 1.3
         default:
             return 1
+    }
+}
+export function defaultFontSize(board: TBoard) {
+    switch (board.tiles.length) {
+        case 1:
+            return 'large'
+        case 2:
+            return 'medium'
+        default:
+            return 'small'
     }
 }

--- a/next-tavla/src/Board/scenarios/Board/utils.ts
+++ b/next-tavla/src/Board/scenarios/Board/utils.ts
@@ -13,7 +13,7 @@ export function getFontScale(fontSize: TFontSize | undefined) {
     }
 }
 export function defaultFontSize(board: TBoard) {
-    if (!board.tiles) return 'small'
+    if (!board.tiles || board.tiles.length === 0) return 'medium'
 
     switch (board.tiles.length) {
         case 1:

--- a/next-tavla/src/Board/scenarios/Board/utils.ts
+++ b/next-tavla/src/Board/scenarios/Board/utils.ts
@@ -13,6 +13,8 @@ export function getFontScale(fontSize: TFontSize | undefined) {
     }
 }
 export function defaultFontSize(board: TBoard) {
+    if (!board.tiles) return 'small'
+
     switch (board.tiles.length) {
         case 1:
             return 'large'


### PR DESCRIPTION
### Description:
If user has not chosen fontsize, the default textsize will be set depending on number of tiles in the board. 
1 tile - large text
2 tiles - medium text
3 tiles and more - small text