### PR TITLE
styling(create): flexColumn for add stops in modal

### DIFF
--- a/next-tavla/src/Admin/scenarios/CreateBoard/components/AddStops.tsx
+++ b/next-tavla/src/Admin/scenarios/CreateBoard/components/AddStops.tsx
@@ -67,7 +67,7 @@ export function AddStops({
                 retninger, eller flere enkelte retninger.
             </Paragraph>
 
-            <AddTile addTile={addTile} flexDirection="column" />
+            <AddTile addTile={addTile} flexDirection="flexColumn" />
             <div className="flexRow g-2 pt-2 pb-2">
                 {board.tiles.map((tile) => (
                     <StopPlaceChip tile={tile} key={tile.uuid} />

--- a/next-tavla/src/Admin/scenarios/CreateBoard/components/AddStops.tsx
+++ b/next-tavla/src/Admin/scenarios/CreateBoard/components/AddStops.tsx
@@ -67,7 +67,7 @@ export function AddStops({
                 retninger, eller flere enkelte retninger.
             </Paragraph>
 
-            <AddTile addTile={addTile} />
+            <AddTile addTile={addTile} flexDirection="column" />
             <div className="flexRow g-2 pt-2 pb-2">
                 {board.tiles.map((tile) => (
                     <StopPlaceChip tile={tile} key={tile.uuid} />

--- a/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@entur/button'
 import { Dropdown, MultiSelect, SearchableDropdown } from '@entur/dropdown'
 import { SearchIcon } from '@entur/icons'
-import { Heading1 } from '@entur/typography'
 import { useStopPlaceSearch } from '../../hooks/useStopPlaceSearch'
 import { useCountiesSearch } from '../../hooks/useCountiesSearch'
 import { useQuaySearch } from '../../hooks/useQuaySearch'
@@ -9,12 +8,14 @@ import { useToast } from '@entur/alert'
 
 function AddTile({
     addTile,
+    flexDirection,
 }: {
     addTile: (
         name: string,
         placeId: string,
         type: 'quay' | 'stop_place',
     ) => void
+    flexDirection?: 'row' | 'column'
 }) {
     const { addToast } = useToast()
 
@@ -53,8 +54,11 @@ function AddTile({
 
     return (
         <div>
-            <Heading1>Holdeplasser i tavla</Heading1>
-            <div className="flexRow g-2 pt-2 pb-2">
+            <div
+                className={`flex${
+                    flexDirection === 'column' ? 'Column' : 'Row'
+                } g-2 pt-2 pb-2`}
+            >
                 <MultiSelect
                     label="Velg fylker"
                     items={counties}

--- a/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
@@ -8,14 +8,14 @@ import { useToast } from '@entur/alert'
 
 function AddTile({
     addTile,
-    flexDirection,
+    flexDirection = 'flexRow',
 }: {
     addTile: (
         name: string,
         placeId: string,
         type: 'quay' | 'stop_place',
     ) => void
-    flexDirection?: 'row' | 'column'
+    flexDirection?: 'flexRow' | 'flexColumn'
 }) {
     const { addToast } = useToast()
 
@@ -53,40 +53,34 @@ function AddTile({
     }
 
     return (
-        <div>
-            <div
-                className={`flex${
-                    flexDirection === 'column' ? 'Column' : 'Row'
-                } g-2 pt-2 pb-2`}
-            >
-                <MultiSelect
-                    label="Velg fylker"
-                    items={counties}
-                    selectedItems={selectedCounties}
-                    onChange={setSelectedCounties}
-                    prepend={<SearchIcon />}
-                    maxChips={2}
-                    hideSelectAll
-                />
-                <SearchableDropdown
-                    items={stopPlaceItems}
-                    label="Søk etter holdeplass..."
-                    clearable
-                    prepend={<SearchIcon />}
-                    selectedItem={selectedStopPlace}
-                    onChange={setSelectedStopPlace}
-                />
-                <Dropdown
-                    items={quays}
-                    label="Velg plattform/retning"
-                    clearable
-                    selectedItem={selectedQuay}
-                    onChange={setSelectedQuay}
-                />
-                <Button variant="primary" onClick={handleAddTile}>
-                    Legg til
-                </Button>
-            </div>
+        <div className={`${flexDirection} g-2 pt-2 pb-2`}>
+            <MultiSelect
+                label="Velg fylker"
+                items={counties}
+                selectedItems={selectedCounties}
+                onChange={setSelectedCounties}
+                prepend={<SearchIcon />}
+                maxChips={2}
+                hideSelectAll
+            />
+            <SearchableDropdown
+                items={stopPlaceItems}
+                label="Søk etter holdeplass..."
+                clearable
+                prepend={<SearchIcon />}
+                selectedItem={selectedStopPlace}
+                onChange={setSelectedStopPlace}
+            />
+            <Dropdown
+                items={quays}
+                label="Velg plattform/retning"
+                clearable
+                selectedItem={selectedQuay}
+                onChange={setSelectedQuay}
+            />
+            <Button variant="primary" onClick={handleAddTile}>
+                Legg til
+            </Button>
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -72,6 +72,7 @@ function Edit({
                 </div>
                 <SaveStatus board={board} />
                 <BoardSettings board={board} />
+                <Heading1>Holdeplasser i tavla</Heading1>
                 <AddTile addTile={addTile} />
                 <TilesOverview tiles={board.tiles} />
             </div>


### PR DESCRIPTION
Display the input fields in columns instead of in rows in the modal. This resolves the "dancing" issue and overflow. 

![Screenshot 2023-11-07 at 07-12-47 Entur Tavla](https://github.com/entur/tavla/assets/32832996/dc58db9b-fc35-4896-9eb7-99a31bbe395a)
