### PR TITLE
fix(create): fix warning when name is undefined

### DIFF
--- a/next-tavla/src/Admin/scenarios/CreateBoard/components/Name.tsx
+++ b/next-tavla/src/Admin/scenarios/CreateBoard/components/Name.tsx
@@ -26,7 +26,7 @@ function Name({
                 name="name"
                 label="Navn på tavla"
                 placeholder="Navn på tavla"
-                value={board?.meta?.title}
+                value={board?.meta?.title ?? ''}
                 aria-label="Sett navn på tavla"
                 ref={selectInput}
                 onChange={(e) => {

--- a/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/AddTile/index.tsx
@@ -75,6 +75,7 @@ function AddTile({
                 items={quays}
                 label="Velg plattform/retning"
                 clearable
+                prepend={<SearchIcon />}
                 selectedItem={selectedQuay}
                 onChange={setSelectedQuay}
             />

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -45,8 +45,6 @@ function Edit({
         })
     }
 
-    console.log(board)
-
     return (
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>


### PR DESCRIPTION
Fix a warning when the name field value changes from ```undefined```.  Also search icon in quay dropdown. Remove console log.