### PR TITLE
feat(edit): global preview

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/components/BoardSettings/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/BoardSettings/index.tsx
@@ -2,12 +2,20 @@ import { TBoard } from 'types/settings'
 import { BoardTitle } from '../BoardTitle'
 import { FontsizeSelector } from '../FontsizeSelector'
 import classes from './styles.module.css'
+import { Heading3 } from '@entur/typography'
+import { SaveStatus } from '../SaveStatus'
 
 function BoardSettings({ board }: { board: TBoard }) {
     return (
-        <div className={classes.settings}>
-            <BoardTitle title={board.meta?.title} />
-            <FontsizeSelector board={board} />
+        <div>
+            <div className="flexRow justifyBetween alignCenter">
+                <Heading3 className="mt-0">Innstillinger for tavla</Heading3>
+                <SaveStatus board={board} />
+            </div>
+            <div className={classes.settings}>
+                <BoardTitle title={board.meta?.title} />
+                <FontsizeSelector board={board} />
+            </div>
         </div>
     )
 }

--- a/next-tavla/src/Admin/scenarios/Edit/components/BoardSettings/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/components/BoardSettings/styles.module.css
@@ -2,7 +2,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 1em;
     background-color: var(--secondary-background-color);
     border-radius: 0.5em;
     padding: 2em;

--- a/next-tavla/src/Admin/scenarios/Edit/components/BoardTitle/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/BoardTitle/index.tsx
@@ -3,6 +3,7 @@ import { EditIcon } from '@entur/icons'
 import { ChangeEventHandler, useCallback } from 'react'
 import { useEditSettingsDispatch } from '../../utils/contexts'
 import { selectInput } from 'Admin/utils/selectInput'
+import { Heading4 } from '@entur/typography'
 
 function BoardTitle({ title }: { title?: string }) {
     const dispatch = useEditSettingsDispatch()
@@ -18,16 +19,19 @@ function BoardTitle({ title }: { title?: string }) {
     )
 
     return (
-        <TextField
-            value={title ?? ''}
-            className="w-30"
-            label="Navn på tavla"
-            placeholder="Navn på tavla"
-            aria-label="Endre navn på tavla"
-            prepend={<EditIcon aria-hidden="true" />}
-            onChange={dispatchTitle}
-            ref={selectInput}
-        />
+        <div className="w-100">
+            <Heading4 className="m-0">Hva skal tavla hete?</Heading4>
+            <TextField
+                value={title ?? ''}
+                className="w-30"
+                label="Navn på tavla"
+                placeholder="Navn på tavla"
+                aria-label="Endre navn på tavla"
+                prepend={<EditIcon aria-hidden="true" />}
+                onChange={dispatchTitle}
+                ref={selectInput}
+            />
+        </div>
     )
 }
 

--- a/next-tavla/src/Admin/scenarios/Edit/components/FontsizeSelector/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/FontsizeSelector/index.tsx
@@ -1,29 +1,31 @@
 import { ChoiceChip, ChoiceChipGroup } from '@entur/chip'
 import { TBoard } from 'types/settings'
-import classes from './styles.module.css'
 import { useEditSettingsDispatch } from '../../utils/contexts'
 import { TFontSize } from 'types/meta'
 import { defaultFontSize } from 'Board/scenarios/Board/utils'
+import { Heading4 } from '@entur/typography'
 
 function FontsizeSelector({ board }: { board: TBoard }) {
     const dispatch = useEditSettingsDispatch()
     return (
-        <ChoiceChipGroup
-            className={classes.choiceChipGroup}
-            name="city"
-            label="Velg tekststørrelse:"
-            value={board.meta?.fontSize || defaultFontSize(board)}
-            onChange={(e) => {
-                dispatch({
-                    type: 'changeFontSize',
-                    fontSize: e.target.value as TFontSize,
-                })
-            }}
-        >
-            <ChoiceChip value="small">Liten</ChoiceChip>
-            <ChoiceChip value="medium">Medium</ChoiceChip>
-            <ChoiceChip value="large">Stor</ChoiceChip>
-        </ChoiceChipGroup>
+        <div className="flexColumn g-1">
+            <Heading4 className="m-0">Velg tekststørrelse: </Heading4>
+            <ChoiceChipGroup
+                className="flexRow"
+                name="city"
+                value={board.meta?.fontSize || defaultFontSize(board)}
+                onChange={(e) => {
+                    dispatch({
+                        type: 'changeFontSize',
+                        fontSize: e.target.value as TFontSize,
+                    })
+                }}
+            >
+                <ChoiceChip value="small">Liten</ChoiceChip>
+                <ChoiceChip value="medium">Medium</ChoiceChip>
+                <ChoiceChip value="large">Stor</ChoiceChip>
+            </ChoiceChipGroup>
+        </div>
     )
 }
 export { FontsizeSelector }

--- a/next-tavla/src/Admin/scenarios/Edit/components/FontsizeSelector/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/components/FontsizeSelector/styles.module.css
@@ -1,3 +1,0 @@
-.choiceChipGroup {
-    font-size: xx-large;
-}

--- a/next-tavla/src/Admin/scenarios/Edit/components/Preview/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/Preview/index.tsx
@@ -1,16 +1,10 @@
-import { Table } from 'Board/scenarios/Table'
-import { TDepartureFragment } from 'graphql/index'
-import { TQuayTile, TStopPlaceTile } from 'types/tile'
+import { Heading3 } from '@entur/typography'
 import classes from './styles.module.css'
+import { Board } from 'Board/scenarios/Board'
+import { TBoard } from 'types/settings'
 
-function Preview({
-    tile,
-    departures,
-}: {
-    tile: TStopPlaceTile | TQuayTile
-    departures?: TDepartureFragment[]
-}) {
-    if (!departures)
+function Preview({ board }: { board: TBoard }) {
+    if (!board)
         return (
             <div>
                 <div className={classes.preview}>
@@ -21,8 +15,9 @@ function Preview({
 
     return (
         <div>
-            <div data-theme="default" className={classes.preview}>
-                <Table departures={departures} columns={tile.columns} />
+            <Heading3 className="mt-0">Forhåndsvisning</Heading3>
+            <div className={classes.preview}>
+                <Board board={board} preview />
             </div>
         </div>
     )

--- a/next-tavla/src/Admin/scenarios/Edit/components/Preview/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/components/Preview/styles.module.css
@@ -1,7 +1,6 @@
 .preview {
-    background-color: var(--main-background-color);
+    background-color: var(--secondary-background-color);
     border-radius: 1em;
-    padding: 1em;
-    margin-top: 2em;
-    height: 18em;
+    height: 24em;
+    padding: 2em;
 }

--- a/next-tavla/src/Admin/scenarios/Edit/components/TileSettings/QuaySettings.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/TileSettings/QuaySettings.tsx
@@ -5,7 +5,6 @@ import { TQuayTile } from 'types/tile'
 import classes from './styles.module.css'
 import { Heading3 } from '@entur/typography'
 import { DeleteTile } from '../DeleteTile'
-import { Preview } from '../Preview'
 import { ToggleColumns } from '../ToggleColumns'
 import { SelectLines } from '../SelectLines'
 
@@ -15,20 +14,12 @@ function QuaySettings({ tile }: { tile: TQuayTile }) {
             quayId: tile.placeId,
         }).data?.quay?.lines.filter(fieldsNotNull) ?? []
 
-    const departures = useQuery(GetQuayQuery, {
-        quayId: tile.placeId,
-        whitelistedLines: tile.whitelistedLines,
-        whitelistedTransportModes: tile.whitelistedTransportModes,
-        numberOfDepartures: 5,
-    }).data?.quay?.estimatedCalls
-
     return (
         <div className={classes.tileSettingsWrapper}>
             <div className="flexRow alignCenter g-3">
                 <DeleteTile uuid={tile.uuid} />
                 <Heading3 className="m-0">{tile.name}</Heading3>
             </div>
-            <Preview tile={tile} departures={departures} />
             <ToggleColumns tile={tile} />
             <SelectLines tile={tile} lines={lines} />
         </div>

--- a/next-tavla/src/Admin/scenarios/Edit/components/TileSettings/StopPlaceSettings.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/TileSettings/StopPlaceSettings.tsx
@@ -1,4 +1,4 @@
-import { StopPlaceQuery, StopPlaceSettingsQuery } from 'graphql/index'
+import { StopPlaceSettingsQuery } from 'graphql/index'
 import { useQuery } from 'graphql/utils'
 import { fieldsNotNull } from 'utils/typeguards'
 import { TStopPlaceTile } from 'types/tile'
@@ -6,7 +6,6 @@ import React from 'react'
 import classes from './styles.module.css'
 import { Heading3 } from '@entur/typography'
 import { DeleteTile } from '../DeleteTile'
-import { Preview } from '../Preview'
 import { ToggleColumns } from '../ToggleColumns'
 import { SelectLines } from '../SelectLines'
 
@@ -18,20 +17,12 @@ function StopPlaceSettings({ tile }: { tile: TStopPlaceTile }) {
             .data?.stopPlace?.quays?.flatMap((q) => q?.lines)
             .filter(fieldsNotNull) || []
 
-    const departures = useQuery(StopPlaceQuery, {
-        stopPlaceId: tile.placeId,
-        whitelistedLines: tile.whitelistedLines,
-        whitelistedTransportModes: tile.whitelistedTransportModes,
-        numberOfDepartures: 5,
-    }).data?.stopPlace?.estimatedCalls
-
     return (
         <div className={classes.tileSettingsWrapper}>
             <div className="flexRow alignCenter g-3">
                 <DeleteTile uuid={tile.uuid} />
                 <Heading3 className="m-0">{tile.name}</Heading3>
             </div>
-            <Preview tile={tile} departures={departures} />
             <ToggleColumns tile={tile} />
             <SelectLines tile={tile} lines={lines} />
         </div>

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -4,17 +4,16 @@ import classes from './styles.module.css'
 import dynamic from 'next/dynamic'
 import { SecondaryButton } from '@entur/button'
 import { CopyIcon } from '@entur/icons'
-import { SecondaryLink } from 'components/SecondaryLink'
 import { useToast } from '@entur/alert'
 import { boardReducer } from './utils/reducer'
 import { SettingsDispatchContext } from './utils/contexts'
 import { AddTile } from './components/AddTile'
 import { DeleteBoard } from './components/DeleteBoard'
 import { TilesOverview } from './components/TilesOverview'
-import { Heading1 } from '@entur/typography'
+import { Heading1, Heading3 } from '@entur/typography'
 import { BoardSettings } from './components/BoardSettings'
 import { useAutoSaveBoard } from './hooks/useAutoSaveBoard'
-import { SaveStatus } from './components/SaveStatus'
+import { Preview } from './components/Preview'
 
 function Edit({
     initialBoard,
@@ -48,8 +47,8 @@ function Edit({
     return (
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>
-                <div className="flexRow justifyBetween">
-                    <Heading1>Innstillinger for tavla</Heading1>
+                <div className="flexRow justifyBetween mt-4">
+                    <Heading1 className="m-0">Rediger tavlevisning</Heading1>
                     <div className="flexRow g-2">
                         <SecondaryButton
                             onClick={() => {
@@ -60,18 +59,15 @@ function Edit({
                             Kopier lenke til Tavla
                             <CopyIcon />
                         </SecondaryButton>
-                        <SecondaryLink
-                            external
-                            href={'/' + documentId}
-                            text="Se Tavla"
-                        />
                         <DeleteBoard board={board} />
                     </div>
                 </div>
-                <SaveStatus board={board} />
                 <BoardSettings board={board} />
-                <Heading1>Holdeplasser i tavla</Heading1>
-                <AddTile addTile={addTile} />
+                <Preview board={board} />
+                <div>
+                    <Heading3 className="m-0">Stoppesteder i tavla</Heading3>
+                    <AddTile addTile={addTile} />
+                </div>
                 <TilesOverview tiles={board.tiles} />
             </div>
         </SettingsDispatchContext.Provider>

--- a/next-tavla/src/Admin/scenarios/Edit/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Edit/styles.module.css
@@ -1,7 +1,7 @@
 .settings {
     display: flex;
     flex-direction: column;
-    gap: 2em;
+    gap: 4em;
     margin: 1.25em 0;
 }
 

--- a/next-tavla/src/Board/scenarios/Board/index.tsx
+++ b/next-tavla/src/Board/scenarios/Board/index.tsx
@@ -5,17 +5,24 @@ import { QuayTile } from '../QuayTile'
 import classes from './styles.module.css'
 import { Tile } from 'components/Tile'
 import { defaultFontSize, getFontScale } from 'Board/scenarios/Board/utils'
+import { boardStyles, previewStyles } from 'types/board'
 
-function BoardTile({ tileSpec }: { tileSpec: TTile }) {
+function BoardTile({
+    tileSpec,
+    preview,
+}: {
+    tileSpec: TTile
+    preview?: boolean
+}) {
     switch (tileSpec.type) {
         case 'stop_place':
-            return <StopPlaceTile {...tileSpec} />
+            return <StopPlaceTile {...tileSpec} preview={preview} />
         case 'quay':
-            return <QuayTile {...tileSpec} />
+            return <QuayTile {...tileSpec} preview={preview} />
     }
 }
 
-function Board({ board }: { board: TBoard }) {
+function Board({ board, preview }: { board: TBoard; preview?: boolean }) {
     if (!board.tiles || !board.tiles.length)
         return (
             <Tile className={classes.emptyTile}>
@@ -26,6 +33,9 @@ function Board({ board }: { board: TBoard }) {
         <div
             className={classes.board}
             style={{
+                gridTemplateColumns: `repeat(auto-fit, minmax(${
+                    preview ? previewStyles.grid : boardStyles.grid
+                }vmin, 1fr))`,
                 fontSize:
                     100 *
                         getFontScale(
@@ -35,7 +45,9 @@ function Board({ board }: { board: TBoard }) {
             }}
         >
             {board.tiles.map((tile, index) => {
-                return <BoardTile key={index} tileSpec={tile} />
+                return (
+                    <BoardTile key={index} tileSpec={tile} preview={preview} />
+                )
             })}
         </div>
     )

--- a/next-tavla/src/Board/scenarios/Board/styles.module.css
+++ b/next-tavla/src/Board/scenarios/Board/styles.module.css
@@ -7,7 +7,6 @@
 
 .board {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(60vmin, 1fr));
     gap: 10px;
     height: 100%;
     overflow: hidden;

--- a/next-tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/next-tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -6,13 +6,15 @@ import { GetQuayQuery } from 'graphql/index'
 import { Tile } from 'components/Tile'
 import { TableHeader } from '../Table/components/TableHeader'
 import { isNotNullOrUndefined } from 'utils/typeguards'
+import { boardStyles, previewStyles } from 'types/board'
 
 export function QuayTile({
     placeId,
     whitelistedLines,
     whitelistedTransportModes,
     columns,
-}: TQuayTile) {
+    preview,
+}: TQuayTile & { preview?: boolean }) {
     const { data } = useQuery(
         GetQuayQuery,
         {
@@ -40,7 +42,14 @@ export function QuayTile({
         .join(' ')
 
     return (
-        <Tile className={classes.quayTile}>
+        <Tile
+            className={classes.quayTile}
+            style={{
+                backgroundColor: preview
+                    ? previewStyles.background
+                    : boardStyles.background,
+            }}
+        >
             <TableHeader heading={heading} />
             <Table columns={columns} departures={data.quay.estimatedCalls} />
         </Tile>

--- a/next-tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/next-tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -5,13 +5,15 @@ import { useQuery } from 'graphql/utils'
 import { StopPlaceQuery } from 'graphql/index'
 import { Tile } from 'components/Tile'
 import { TableHeader } from '../Table/components/TableHeader'
+import { boardStyles, previewStyles } from 'types/board'
 
 export function StopPlaceTile({
     placeId,
     whitelistedLines,
     whitelistedTransportModes,
     columns,
-}: TStopPlaceTile) {
+    preview,
+}: TStopPlaceTile & { preview?: boolean }) {
     const { data } = useQuery(
         StopPlaceQuery,
         { stopPlaceId: placeId, whitelistedTransportModes, whitelistedLines },
@@ -27,7 +29,14 @@ export function StopPlaceTile({
     }
 
     return (
-        <Tile className={classes.stopPlaceTile}>
+        <Tile
+            className={classes.stopPlaceTile}
+            style={{
+                backgroundColor: preview
+                    ? previewStyles.background
+                    : boardStyles.background,
+            }}
+        >
             <TableHeader heading={data.stopPlace.name} />
             <Table
                 departures={data.stopPlace.estimatedCalls}

--- a/next-tavla/src/Shared/components/Tile/styles.module.css
+++ b/next-tavla/src/Shared/components/Tile/styles.module.css
@@ -1,7 +1,6 @@
 .tile {
     height: 100%;
     width: 100%;
-    background-color: var(--secondary-background-color);
     color: var(--main-text-color);
     padding: 1em;
     border-radius: 0.5em;

--- a/next-tavla/src/Shared/styles/spacing.css
+++ b/next-tavla/src/Shared/styles/spacing.css
@@ -18,6 +18,10 @@
     margin: 2em;
 }
 
+.mt-0 {
+    margin-top: 0;
+}
+
 .mt-1 {
     margin-top: 0.5em;
 }

--- a/next-tavla/src/Shared/types/board.ts
+++ b/next-tavla/src/Shared/types/board.ts
@@ -1,0 +1,9 @@
+export const boardStyles = {
+    background: 'var(--secondary-background-color)',
+    grid: 60,
+} as const
+
+export const previewStyles = {
+    background: 'var(--main-background-color)',
+    grid: 40,
+} as const


### PR DESCRIPTION
### Description:
- removed preview for each tile
- show preview for the entire board
- update styling of edit page
- styling for tile/board will depend on whether it is preview or regular board

### Images:
<img width="1693" alt="image" src="https://github.com/entur/tavla/assets/64562118/0ab741c3-a44a-4fed-838e-7a2fac5d10d5">
<img width="1698" alt="image" src="https://github.com/entur/tavla/assets/64562118/056283d8-db2c-48cd-8977-9df35b19d5c7">
