### PR TITLE
feat(transport icon): added icon for carferries

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/components/SelectLines/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/SelectLines/index.tsx
@@ -30,7 +30,7 @@ function SelectLines({
                     <div key={transportMode}>
                         <div className={classes.transportTitle}>
                             <TransportIcon
-                                transport={transportMode}
+                                transportMode={transportMode}
                                 className={classes.icon}
                             />
                             {transportModeNames[transportMode]}

--- a/next-tavla/src/Board/scenarios/Table/components/Line/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/components/Line/index.tsx
@@ -10,6 +10,8 @@ function Line() {
 
     const lines = departures.map((departure) => ({
         transportMode: departure.serviceJourney.transportMode ?? 'unknown',
+        transportSubmode:
+            departure.serviceJourney.transportSubmode ?? undefined,
         publicCode: departure.serviceJourney.line.publicCode ?? '',
         key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
     }))
@@ -21,6 +23,7 @@ function Line() {
                     <div className={classes.row}>
                         <TravelTag
                             transportMode={line.transportMode}
+                            transportSubmode={line.transportSubmode}
                             publicCode={line.publicCode}
                         />
                     </div>

--- a/next-tavla/src/Shared/components/TransportIcon/index.tsx
+++ b/next-tavla/src/Shared/components/TransportIcon/index.tsx
@@ -1,18 +1,20 @@
-import { TTransportMode } from 'types/graphql-schema'
+import { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
 import { SVGProps } from 'react'
 
 function TransportIcon({
-    transport,
+    transportMode,
+    transportSubmode,
     className,
     color,
 }: {
-    transport: TTransportMode | null
+    transportMode: TTransportMode | null
+    transportSubmode?: TTransportSubmode
     className?: string
     color?: string
 }) {
-    const mode = transport ? transport : 'unknown'
+    const mode = transportMode ?? 'unknown'
 
-    const Component = getTransportIcon(mode)
+    const Component = getTransportIcon(mode, transportSubmode)
     return (
         <Component
             className={className ?? 'w-100 h-100'}
@@ -21,7 +23,15 @@ function TransportIcon({
     )
 }
 
-export function getTransportIcon(transportMode: TTransportMode) {
+export function getTransportIcon(
+    transportMode: TTransportMode,
+    transportSubmode?: TTransportSubmode,
+) {
+    switch (transportSubmode) {
+        case 'localCarFerry' || 'nationalCarFerry' || 'regionalCarFerry':
+            return CarferryIcon
+    }
+
     switch (transportMode) {
         case 'metro':
             return MetroIcon

--- a/next-tavla/src/Shared/components/TransportIcon/index.tsx
+++ b/next-tavla/src/Shared/components/TransportIcon/index.tsx
@@ -27,10 +27,7 @@ export function getTransportIcon(
     transportMode: TTransportMode,
     transportSubmode?: TTransportSubmode,
 ) {
-    switch (transportSubmode) {
-        case 'localCarFerry' || 'nationalCarFerry' || 'regionalCarFerry':
-            return CarferryIcon
-    }
+    if (transportSubmode?.includes('CarFerry')) return CarferryIcon
 
     switch (transportMode) {
         case 'metro':

--- a/next-tavla/src/Shared/components/TravelTag/index.tsx
+++ b/next-tavla/src/Shared/components/TravelTag/index.tsx
@@ -1,14 +1,16 @@
 import { transportModeNames } from 'Admin/utils/transport'
-import { TTransportMode } from 'types/graphql-schema'
+import { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
 import classes from './styles.module.css'
 import { TransportIcon } from 'components/TransportIcon'
 
 function TravelTag({
     transportMode,
     publicCode,
+    transportSubmode,
 }: {
     transportMode: TTransportMode
     publicCode: string
+    transportSubmode?: TTransportSubmode
 }) {
     return (
         <div
@@ -22,7 +24,8 @@ function TravelTag({
         >
             <TransportIcon
                 className={classes.icon}
-                transport={transportMode}
+                transportMode={transportMode}
+                transportSubmode={transportSubmode}
                 color="var(--main-background-color)"
             />
             <div className="flexRow alignCenter justifyCenter w-100 h-100">


### PR DESCRIPTION
### Description

Uses `transportSubmode` to render a more precise icon in certain scenarios, i.e. for car ferries vs high speed ferries.

![image](https://github.com/entur/tavla/assets/61384979/e1313fbc-fc30-4fc5-8ed0-7aa61cfcaab0)
