### PR TITLE
fix(headings): removed h1 styling

### DIFF
--- a/next-tavla/src/Admin/components/DeleteModal/index.tsx
+++ b/next-tavla/src/Admin/components/DeleteModal/index.tsx
@@ -1,6 +1,6 @@
 import { PrimaryButton, SecondaryButton } from '@entur/button'
 import { Modal } from '@entur/modal'
-import { Heading1, LeadParagraph } from '@entur/typography'
+import { Heading2, LeadParagraph } from '@entur/typography'
 import { TBoard } from 'types/settings'
 
 function DeleteModal({
@@ -22,7 +22,7 @@ function DeleteModal({
             closeLabel="Avbryt sletting"
             className="flexColumn justifyStart alignCenter textCenter"
         >
-            <Heading1>Slett tavle</Heading1>
+            <Heading2 as="h1">Slett tavle</Heading2>
             <LeadParagraph>
                 {board?.meta?.title
                     ? `Er du sikker på at du vil slette tavlen "${board.meta.title}"?`

--- a/next-tavla/src/Admin/scenarios/Boards/components/SelectOrganization/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/SelectOrganization/index.tsx
@@ -1,7 +1,7 @@
 import { TOrganization, TOrganizationID } from 'types/settings'
 import { SideNavigation, SideNavigationItem } from '@entur/menu'
 import classes from './styles.module.css'
-import { Heading1 } from '@entur/typography'
+import { Heading2 } from '@entur/typography'
 
 function SelectOrganization({
     organizations,
@@ -12,7 +12,7 @@ function SelectOrganization({
 }) {
     return (
         <SideNavigation className={classes.sideNav}>
-            <Heading1>Tavler</Heading1>
+            <Heading2 as="h1">Tavler</Heading2>
             <div>
                 <SideNavigationItem
                     href="/boards"

--- a/next-tavla/src/Admin/scenarios/Boards/components/SelectOrganization/styles.module.css
+++ b/next-tavla/src/Admin/scenarios/Boards/components/SelectOrganization/styles.module.css
@@ -2,6 +2,6 @@
     display: flex;
     flex-direction: column;
     width: 20%;
-    gap: 2em;
-    margin-top: 1em;
+    gap: 3.5em;
+    margin-top: 1.5em;
 }

--- a/next-tavla/src/Admin/scenarios/Edit/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/index.tsx
@@ -10,7 +10,7 @@ import { SettingsDispatchContext } from './utils/contexts'
 import { AddTile } from './components/AddTile'
 import { DeleteBoard } from './components/DeleteBoard'
 import { TilesOverview } from './components/TilesOverview'
-import { Heading1, Heading3 } from '@entur/typography'
+import { Heading2, Heading3 } from '@entur/typography'
 import { BoardSettings } from './components/BoardSettings'
 import { useAutoSaveBoard } from './hooks/useAutoSaveBoard'
 import { Preview } from './components/Preview'
@@ -48,7 +48,9 @@ function Edit({
         <SettingsDispatchContext.Provider value={dispatch}>
             <div className={classes.settings}>
                 <div className="flexRow justifyBetween mt-4">
-                    <Heading1 className="m-0">Rediger tavlevisning</Heading1>
+                    <Heading2 as="h1" className="m-0">
+                        Rediger tavlevisning
+                    </Heading2>
                     <div className="flexRow g-2">
                         <SecondaryButton
                             onClick={() => {

--- a/next-tavla/src/Admin/scenarios/Landing/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Landing/index.tsx
@@ -1,4 +1,10 @@
-import { Heading1, ListItem, Paragraph, UnorderedList } from '@entur/typography'
+import {
+    Heading1,
+    Heading2,
+    ListItem,
+    Paragraph,
+    UnorderedList,
+} from '@entur/typography'
 import classes from './styles.module.css'
 import Image from 'next/image'
 import landingImage from 'assets/illustrations/Tavla-illustration.png'
@@ -41,7 +47,7 @@ function Landing({ loggedIn }: { loggedIn: boolean }) {
                         />
                     </div>
                     <div className={classes.content}>
-                        <Heading1>Hva er Tavla?</Heading1>
+                        <Heading2>Hva er Tavla?</Heading2>
 
                         <Paragraph>
                             Tavla er et verktøy som hjelper deg å lage

--- a/next-tavla/src/Admin/scenarios/Organizations/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Organizations/index.tsx
@@ -11,7 +11,7 @@ function Organizations(props: {
         <div>
             <div className="mt-4">
                 <Heading1>Organisasjoner</Heading1>
-                <Heading3 className="mb-2">
+                <Heading3 as="h2" className="mb-2">
                     Oversikt over organisasjoner
                 </Heading3>
                 <div className="flexRow justifyBetween">
@@ -19,8 +19,8 @@ function Organizations(props: {
                         Dette er en oversikt over hvilke organisasjoner du er en
                         del av. Her kan du også klikke deg inn på organisasjoner
                         og sette innstillinger for tavler som er lagt til i en
-                        organisasjon. Administrer også hvem som har tilgang til
-                        tavlene i organisasjonen.
+                        organisasjon. Du kan også administrere hvem som har
+                        tilgang til tavlene i organisasjonen.
                     </Paragraph>
                     <CreateOrganization />
                 </div>

--- a/next-tavla/src/Shared/styles/global.css
+++ b/next-tavla/src/Shared/styles/global.css
@@ -13,10 +13,6 @@ html {
     line-height: 1.2;
 }
 
-.eds-h1 {
-    font-size: 2rem;
-}
-
 h3 {
     font-weight: 500;
 }

--- a/next-tavla/src/Shared/styles/reset.css
+++ b/next-tavla/src/Shared/styles/reset.css
@@ -38,6 +38,7 @@ a.eds-button > .eds-icon {
     top: 0;
 }
 
+.eds-h2,
 .eds-h5 {
     margin: 0;
 }


### PR DESCRIPTION
#### Description

Removed some styling on the `eds-h1` class that resulted in `<Heading1>` being rendered as smaller than it should be in some places. In the components where `<Heading1>` should actually be rendered smaller, it was replaced by `<Heading2 as='h1'>`, giving it the same size but correct semantics.