### PR TITLE
feat(time): more accurately display timestamps that occurred yesterday

### DIFF
--- a/next-tavla/src/Admin/scenarios/Edit/components/SaveStatus/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/SaveStatus/index.tsx
@@ -2,7 +2,11 @@ import { TBoard } from 'types/settings'
 import { formatTimestamp } from 'Admin/utils/time'
 
 function SaveStatus({ board }: { board: TBoard }) {
-    return <div>Sist lagret: {formatTimestamp(board.meta?.dateModified)}</div>
+    return (
+        <div>
+            Sist lagret: {formatTimestamp(board.meta?.dateModified, true)}
+        </div>
+    )
 }
 
 export { SaveStatus }

--- a/next-tavla/src/Admin/scenarios/Edit/components/SaveStatus/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Edit/components/SaveStatus/index.tsx
@@ -2,11 +2,7 @@ import { TBoard } from 'types/settings'
 import { formatTimestamp } from 'Admin/utils/time'
 
 function SaveStatus({ board }: { board: TBoard }) {
-    return (
-        <div>
-            Sist lagret: {formatTimestamp(board.meta?.dateModified, true)}
-        </div>
-    )
+    return <div>Sist lagret: {formatTimestamp(board.meta?.dateModified)}</div>
 }
 
 export { SaveStatus }

--- a/next-tavla/src/Admin/utils/time.ts
+++ b/next-tavla/src/Admin/utils/time.ts
@@ -1,27 +1,38 @@
-export function formatTimestamp(timestamp?: number, seconds = false) {
+const SECOND = 1_000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+const MONTH = 30 * DAY
+const YEAR = 365 * DAY
+
+export function formatTimestamp(timestamp?: number) {
     if (!timestamp) return '-'
 
-    const shortFormat = Intl.DateTimeFormat('no-NB', {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: seconds ? '2-digit' : undefined,
-    }).format
+    const timeAgo = Date.now() - timestamp
 
-    const fullFormat = Intl.DateTimeFormat('no-NB', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-    }).format
+    if (timeAgo > YEAR) return getTimeSince(timeAgo, YEAR)
+    if (timeAgo > MONTH) return getTimeSince(timeAgo, MONTH)
+    if (timeAgo > DAY) return getTimeSince(timeAgo, DAY)
+    if (timeAgo > HOUR) return getTimeSince(timeAgo, HOUR)
+    if (timeAgo > MINUTE) return getTimeSince(timeAgo, MINUTE)
+    if (timeAgo > 10 * SECOND) return getTimeSince(timeAgo, SECOND)
+    return 'nettopp'
+}
 
-    const dayThen = new Date(timestamp).toDateString()
-    const dayNow = new Date().toDateString()
-    const dayYesterday = new Date(Date.now() - 86_400_000).toDateString()
+function getTimeSince(timeAgo: number, divisor: number) {
+    const count = Math.floor(timeAgo / divisor)
+    const plural = count !== 1
 
-    if (dayThen === dayNow) return shortFormat(timestamp)
+    const timeText = {
+        [SECOND]: plural ? 'sekunder' : 'sekund',
+        [MINUTE]: plural ? 'minutter' : 'minutt',
+        [HOUR]: plural ? 'timer' : 'time',
+        [DAY]: plural ? 'dager' : 'dag',
+        [MONTH]: plural ? 'måneder' : 'måned',
+        [YEAR]: 'år',
+    }
 
-    if (dayThen === dayYesterday) return 'i går, ' + shortFormat(timestamp)
-
-    return fullFormat(timestamp)
+    return timeText[divisor]
+        ? `${count} ${timeText[divisor]} siden`
+        : 'en stund siden'
 }

--- a/next-tavla/src/Admin/utils/time.ts
+++ b/next-tavla/src/Admin/utils/time.ts
@@ -5,7 +5,7 @@ export function formatTimestamp(timestamp?: number, seconds = false) {
         hour: '2-digit',
         minute: '2-digit',
         second: seconds ? '2-digit' : undefined,
-    })
+    }).format
 
     const fullFormat = Intl.DateTimeFormat('no-NB', {
         day: '2-digit',
@@ -13,16 +13,15 @@ export function formatTimestamp(timestamp?: number, seconds = false) {
         year: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
-    })
+    }).format
 
     const dayThen = new Date(timestamp).toDateString()
     const dayNow = new Date().toDateString()
     const dayYesterday = new Date(Date.now() - 86_400_000).toDateString()
 
-    if (dayThen === dayNow) return shortFormat.format(timestamp)
+    if (dayThen === dayNow) return shortFormat(timestamp)
 
-    if (dayThen === dayYesterday)
-        return 'i går, ' + shortFormat.format(timestamp)
+    if (dayThen === dayYesterday) return 'i går, ' + shortFormat(timestamp)
 
-    return fullFormat.format(timestamp)
+    return fullFormat(timestamp)
 }

--- a/next-tavla/src/Admin/utils/time.ts
+++ b/next-tavla/src/Admin/utils/time.ts
@@ -5,10 +5,27 @@ const DAY = 24 * HOUR
 const MONTH = 30 * DAY
 const YEAR = 365 * DAY
 
-export function formatTimestamp(timestamp?: number) {
-    if (!timestamp) return '-'
+const shortFormat = Intl.DateTimeFormat('no-NB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+}).format
 
-    const timeAgo = Date.now() - timestamp
+const fullFormat = Intl.DateTimeFormat('no-NB', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+}).format
+
+export function formatTimestamp(millis?: number, asTimestamp = false) {
+    if (!millis) return '-'
+
+    const timeAgo = Date.now() - millis
+
+    if (asTimestamp)
+        return timeAgo < DAY ? shortFormat(millis) : fullFormat(millis)
 
     if (timeAgo > YEAR) return getTimeSince(timeAgo, YEAR)
     if (timeAgo > MONTH) return getTimeSince(timeAgo, MONTH)

--- a/next-tavla/src/Admin/utils/time.ts
+++ b/next-tavla/src/Admin/utils/time.ts
@@ -1,20 +1,28 @@
 export function formatTimestamp(timestamp?: number, seconds = false) {
     if (!timestamp) return '-'
 
-    const timeDiff = Date.now() - timestamp
+    const shortFormat = Intl.DateTimeFormat('no-NB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: seconds ? '2-digit' : undefined,
+    })
 
-    if (timeDiff < 86_400_000)
-        return Intl.DateTimeFormat('no-NB', {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: seconds ? '2-digit' : undefined,
-        }).format(timestamp)
-
-    return Intl.DateTimeFormat('no-NB', {
+    const fullFormat = Intl.DateTimeFormat('no-NB', {
         day: '2-digit',
         month: '2-digit',
         year: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
-    }).format(timestamp)
+    })
+
+    const dayThen = new Date(timestamp).toDateString()
+    const dayNow = new Date().toDateString()
+    const dayYesterday = new Date(Date.now() - 86_400_000).toDateString()
+
+    if (dayThen === dayNow) return shortFormat.format(timestamp)
+
+    if (dayThen === dayYesterday)
+        return 'i går, ' + shortFormat.format(timestamp)
+
+    return fullFormat.format(timestamp)
 }


### PR DESCRIPTION
### Description

Earlier, when displaying a timestamp that occured yesterday but still less than 24 hours ago, the timestamp would be displayed in the `HH:MM` format, which in some cases could be confusing.

This PR will instead display the time difference in seconds/minutes/hours/..., or a timestamp if specified.

![bilde](https://github.com/entur/tavla/assets/61384979/965e4e3b-0bd4-4005-a7ff-ed75338f9512)