### PR TITLE
feat(scripts): added script for running emulators without devserver

### DIFF
--- a/next-tavla/package.json
+++ b/next-tavla/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "dev": "next dev & firebase emulators:start --project=ent-tavla-dev",
         "dev:persist": "next dev & firebase emulators:start --project=ent-tavla-dev --import=./.db --export-on-exit",
+        "emulators": "firebase emulators:start --project=ent-tavla-dev --import=./.db --export-on-exit",
         "build": "next build",
         "build:prod": "NEXT_PUBLIC_ENV=prod next build",
         "typecheck": "tsc --noEmit --incremental false",


### PR DESCRIPTION
#### Description

Adds a script for running the emulators without the development servers. Useful for keeping the emulators alive while building and running the production server for Chromium 56 development.