### PR TITLE
feat(organizations): set feedback if organization name is empty 

### DIFF
--- a/next-tavla/src/Admin/scenarios/Organizations/components/CreateOrganization/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Organizations/components/CreateOrganization/index.tsx
@@ -1,6 +1,6 @@
 import { useToast } from '@entur/alert'
 import { PrimaryButton } from '@entur/button'
-import { TextField } from '@entur/form'
+import { TextField, VariantType } from '@entur/form'
 import { AddIcon } from '@entur/icons'
 import { Modal } from '@entur/modal'
 import { Paragraph } from '@entur/typography'
@@ -14,7 +14,18 @@ function CreateOrganization() {
     const [organizationName, setOrganizationName] = useState('')
     const router = useRouter()
     const { addToast } = useToast()
+    const [textfieldProps, setTextFieldProps] = useState<{
+        variant?: VariantType | undefined
+        feedback?: string
+    }>({})
     const saveOrganization = async () => {
+        if (!organizationName || organizationName.length < 1) {
+            setTextFieldProps({
+                variant: 'error',
+                feedback: 'Du må sette et navn på organisasjonen',
+            })
+            return
+        }
         const req = await createOrganizationRequest(organizationName)
         if (req.status !== 200)
             return addToast({
@@ -50,6 +61,8 @@ function CreateOrganization() {
                     size="medium"
                     label="Navn på din organisasjon"
                     className="w-50"
+                    variant={textfieldProps.variant}
+                    feedback={textfieldProps.feedback}
                 />
                 <PrimaryButton className="mt-2" onClick={saveOrganization}>
                     Opprett


### PR DESCRIPTION
### Description:
Set feeback to textfield if organization name is empty when creating a new organization
### Image:
<img width="716" alt="image" src="https://github.com/entur/tavla/assets/64562118/40ce750d-7779-4a35-a561-ecf7bbf94c2e">
