### PR TITLE
fix(accessibility): tags, filter and choose columns

### DIFF
--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/Tags.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/Tags.tsx
@@ -7,7 +7,6 @@ import { TTag } from 'types/meta'
 import { ReactNode } from 'react'
 import { DraggableColumn } from './DraggableColumn'
 import { colorsFromHash, sortArrayByOverlap } from '../../utils'
-import { VisuallyHidden } from '@entur/a11y'
 
 function TagList({ tags, children }: { tags: TTag[]; children?: ReactNode }) {
     return (
@@ -22,7 +21,7 @@ function TagList({ tags, children }: { tags: TTag[]; children?: ReactNode }) {
                         backgroundColor: colorsFromHash(tag),
                     }}
                 >
-                    <VisuallyHidden>Merkelapp: </VisuallyHidden>
+                    <span className="visuallyHidden">Merkelapp:</span>
                     {tag}
                 </Badge>
             ))}

--- a/next-tavla/src/Admin/scenarios/Boards/components/Column/Tags.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Column/Tags.tsx
@@ -7,20 +7,22 @@ import { TTag } from 'types/meta'
 import { ReactNode } from 'react'
 import { DraggableColumn } from './DraggableColumn'
 import { colorsFromHash, sortArrayByOverlap } from '../../utils'
+import { VisuallyHidden } from '@entur/a11y'
 
 function TagList({ tags, children }: { tags: TTag[]; children?: ReactNode }) {
     return (
-        <div className="flexRow flexWrap g-1 alignCenter">
+        <div className="flexRow flexWrap g-1 alignCenter" role="list">
             {tags.map((tag) => (
                 <Badge
+                    role="listitem"
                     key={tag}
-                    aria-label={tag}
                     variant="primary"
                     style={{
                         color: 'white',
                         backgroundColor: colorsFromHash(tag),
                     }}
                 >
+                    <VisuallyHidden>Merkelapp: </VisuallyHidden>
                     {tag}
                 </Badge>
             ))}

--- a/next-tavla/src/Admin/scenarios/Boards/components/FilterButton/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/FilterButton/index.tsx
@@ -16,6 +16,7 @@ import { FilterChip } from '@entur/chip'
 import { uniq } from 'lodash'
 import classes from './styles.module.css'
 import { NotificationBadge } from '@entur/layout'
+import { VisuallyHidden } from '@entur/a11y'
 
 function FilterButton() {
     const { filterTags, boards } = useBoardsSettings()
@@ -33,10 +34,11 @@ function FilterButton() {
                 <div className={classes.buttonWrapper}>
                     <SecondaryButton aria-label="Filtrer tavler på merkelapper">
                         Filter
-                        <FilterIcon />
+                        <FilterIcon aria-hidden="true" />
                     </SecondaryButton>
                     <NotificationBadge variant="primary" max={10}>
                         {filterTags.length}
+                        <VisuallyHidden>merkelapper valgt</VisuallyHidden>
                     </NotificationBadge>
                 </div>
             </PopoverTrigger>

--- a/next-tavla/src/Admin/scenarios/Boards/components/FilterButton/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/FilterButton/index.tsx
@@ -38,8 +38,8 @@ function FilterButton() {
                     </SecondaryButton>
                     <NotificationBadge variant="primary" max={10}>
                         {filterTags.length}
-                        <VisuallyHidden>merkelapper valgt</VisuallyHidden>
                     </NotificationBadge>
+                    <VisuallyHidden>merkelapper valgt</VisuallyHidden>
                 </div>
             </PopoverTrigger>
             <PopoverContent>

--- a/next-tavla/src/Admin/scenarios/Boards/components/FilterButton/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/FilterButton/index.tsx
@@ -16,7 +16,6 @@ import { FilterChip } from '@entur/chip'
 import { uniq } from 'lodash'
 import classes from './styles.module.css'
 import { NotificationBadge } from '@entur/layout'
-import { VisuallyHidden } from '@entur/a11y'
 
 function FilterButton() {
     const { filterTags, boards } = useBoardsSettings()
@@ -39,7 +38,7 @@ function FilterButton() {
                     <NotificationBadge variant="primary" max={10}>
                         {filterTags.length}
                     </NotificationBadge>
-                    <VisuallyHidden>merkelapper valgt</VisuallyHidden>
+                    <span className="visuallyHidden">merkelapper valgt</span>
                 </div>
             </PopoverTrigger>
             <PopoverContent>

--- a/next-tavla/src/Admin/scenarios/Boards/components/Search/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/Search/index.tsx
@@ -17,6 +17,7 @@ function Search() {
 
     return (
         <TextField
+            className="w-50"
             label="Søk på navn på tavle"
             prepend={<SearchIcon inline aria-hidden="true" />}
             value={settings.search}

--- a/next-tavla/src/Admin/scenarios/Boards/components/ToggleBoardsColumns/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/components/ToggleBoardsColumns/index.tsx
@@ -1,4 +1,4 @@
-import { IconButton, SecondarySquareButton } from '@entur/button'
+import { IconButton, SecondaryButton } from '@entur/button'
 import { AdjustmentsIcon, CloseIcon } from '@entur/icons'
 import classes from './styles.module.css'
 import {
@@ -22,9 +22,10 @@ function ToggleBoardsColumns() {
     return (
         <Popover>
             <PopoverTrigger>
-                <SecondarySquareButton className="flexColumn">
-                    <AdjustmentsIcon />
-                </SecondarySquareButton>
+                <SecondaryButton>
+                    Velg kolonner
+                    <AdjustmentsIcon aria-hidden="true" />
+                </SecondaryButton>
             </PopoverTrigger>
             <PopoverContent>
                 <div className="p-1">

--- a/next-tavla/src/Admin/scenarios/Boards/index.tsx
+++ b/next-tavla/src/Admin/scenarios/Boards/index.tsx
@@ -50,9 +50,9 @@ function Boards({ boards }: { boards: TBoard[] }) {
         <SettingsContext.Provider value={settings}>
             <SettingsDispatchContext.Provider value={dispatch}>
                 <div className={classes.boards}>
-                    <div className="flexRow justifyBetween ">
-                        <div className={classes.actionRow}>
-                            <Search />
+                    <div className="flexRow alignCenter g-1">
+                        <Search />
+                        <div className="flexRow g-1">
                             <FilterButton />
                             <ToggleBoardsColumns />
                         </div>

--- a/next-tavla/src/Shared/styles/global.css
+++ b/next-tavla/src/Shared/styles/global.css
@@ -54,3 +54,13 @@ a {
 .secondaryButton:hover {
     background-color: var(--tertiary-background-color);
 }
+
+.visuallyHidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}

--- a/next-tavla/tsconfig.json
+++ b/next-tavla/tsconfig.json
@@ -35,5 +35,5 @@
         }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", ".next/*"]
 }


### PR DESCRIPTION
### Description:
- tags inside boards table will now be read like this: "list with 2 elements". "merkelapp: oslo sentrum, item 1 of 2",....
- notification badge in filter button: says how many tags are selected for filter
- choose columns: changed to contain text