### PR TITLE
chore(organization): not allow org name to contain only whitespaces

### DIFF
--- a/next-tavla/src/Admin/utils/formActions.ts
+++ b/next-tavla/src/Admin/utils/formActions.ts
@@ -75,9 +75,7 @@ export async function createOrganizationAction(
     try {
         const name = data.get('name')?.toString() ?? ''
 
-        if (!name) return getFormFeedbackForError('organization/name-missing')
-
-        if (/^\s*$/.test(name))
+        if (!name || /^\s*$/.test(name))
             return getFormFeedbackForError('organization/name-missing')
 
         const user = await getUserFromSessionCookie()

--- a/next-tavla/src/Admin/utils/formActions.ts
+++ b/next-tavla/src/Admin/utils/formActions.ts
@@ -77,6 +77,9 @@ export async function createOrganizationAction(
 
         if (!name) return getFormFeedbackForError('organization/name-missing')
 
+        if (/^\s*$/.test(name))
+            return getFormFeedbackForError('organization/name-missing')
+
         const user = await getUserFromSessionCookie()
 
         if (!user) return getFormFeedbackForError('auth/operation-not-allowed')


### PR DESCRIPTION
If organization name consists of only whitespaces, the organization will not be created