### PR TITLE
feat(banner): show banner and remove option to create new boards in old 'entur tavla'

### DIFF
--- a/tavla/src/components/MigrationBanner.tsx
+++ b/tavla/src/components/MigrationBanner.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { BannerAlertBox } from '@entur/alert'
+import { Link } from '@entur/typography'
+
+function MigrationBanner() {
+    return (
+        <BannerAlertBox
+            title="2. april blir denne versjonen av tavla erstattet med en ny og bedre løsning!"
+            closable={false}
+            variant="warning"
+        >
+            Dette betyr at dine eksisterende tavler snart forsvinner, og at du
+            må opprette tavlene dine på nytt i den nye løsningen. Frem til 2.
+            april finner du den nye tavla på{' '}
+            <Link href="https://tavla.beta.entur.no">tavla.beta.entur.no</Link>
+        </BannerAlertBox>
+    )
+}
+
+export { MigrationBanner }

--- a/tavla/src/routes/Admin/index.tsx
+++ b/tavla/src/routes/Admin/index.tsx
@@ -10,6 +10,7 @@ import { Footer } from 'components/Footer'
 import { LockedTavle } from 'scenarios/ErrorPages/LockedTavle'
 import { Navbar } from 'scenarios/Navbar'
 import { ThemeContrastWrapper } from 'components/ThemeContrastWrapper'
+import { MigrationBanner } from 'components/MigrationBanner'
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@entur/tab'
 import { ClosedLockIcon } from '@entur/icons'
 import { Contrast } from '@entur/layout'
@@ -68,75 +69,78 @@ function AdminPage() {
     }
 
     return (
-        <ThemeContrastWrapper
-            useContrast={isDarkOrDefaultTheme(settings.theme)}
-        >
-            <Helmet>
-                <title>Adminside - Tavla - Entur</title>
-            </Helmet>
-            <Navbar theme={settings.theme} />
-            <div className={classes.Admin}>
-                <h1 aria-label="Rediger tavle"></h1>
-                <Tabs index={currentIndex} onChange={switchTab}>
-                    <TabList className={classes.TabList}>
-                        <Tab className={classes.Tab}>Rediger innhold</Tab>
-                        <Tab className={classes.Tab}>Velg visning</Tab>
-                        <Tab className={classes.Tab}>Tilpass utseende</Tab>
-                        <Tab className={classes.Tab}>
-                            Last opp logo {lockIcon}
-                        </Tab>
-                        <Tab className={classes.Tab}>
-                            Endre lenke {lockIcon}
-                        </Tab>
-                        <Tab className={classes.Tab}>
-                            Deling {lockIconShareTab}
-                        </Tab>
-                        {settings.liteAccess && (
-                            <Tab className={classes.Tab}>Lite</Tab>
-                        )}
-                    </TabList>
-                    <TabPanels>
-                        <TabPanel>
-                            <EditTab />
-                        </TabPanel>
-                        <TabPanel>
-                            <DashboardPickerTab />
-                        </TabPanel>
-                        <TabPanel>
-                            <ThemeTab />
-                        </TabPanel>
-                        <TabPanel>
-                            <LogoTab
-                                tabIndex={currentIndex}
-                                setTabIndex={switchTab}
-                            />
-                        </TabPanel>
-                        <TabPanel>
-                            <NameTab
-                                tabIndex={currentIndex}
-                                setTabIndex={switchTab}
-                            />
-                        </TabPanel>
-                        <TabPanel>
-                            <ShareTab
-                                tabIndex={currentIndex}
-                                setTabIndex={switchTab}
-                                locked={lockShareTab}
-                            />
-                        </TabPanel>
-                        {settings.liteAccess && (
+        <>
+            <MigrationBanner />
+            <ThemeContrastWrapper
+                useContrast={isDarkOrDefaultTheme(settings.theme)}
+            >
+                <Helmet>
+                    <title>Adminside - Tavla - Entur</title>
+                </Helmet>
+                <Navbar theme={settings.theme} />
+                <div className={classes.Admin}>
+                    <h1 aria-label="Rediger tavle"></h1>
+                    <Tabs index={currentIndex} onChange={switchTab}>
+                        <TabList className={classes.TabList}>
+                            <Tab className={classes.Tab}>Rediger innhold</Tab>
+                            <Tab className={classes.Tab}>Velg visning</Tab>
+                            <Tab className={classes.Tab}>Tilpass utseende</Tab>
+                            <Tab className={classes.Tab}>
+                                Last opp logo {lockIcon}
+                            </Tab>
+                            <Tab className={classes.Tab}>
+                                Endre lenke {lockIcon}
+                            </Tab>
+                            <Tab className={classes.Tab}>
+                                Deling {lockIconShareTab}
+                            </Tab>
+                            {settings.liteAccess && (
+                                <Tab className={classes.Tab}>Lite</Tab>
+                            )}
+                        </TabList>
+                        <TabPanels>
                             <TabPanel>
-                                <LiteSettings />
+                                <EditTab />
                             </TabPanel>
-                        )}
-                    </TabPanels>
-                </Tabs>
-                <LockAndViewButtons />
-            </div>
-            <Contrast>
-                <Footer />
-            </Contrast>
-        </ThemeContrastWrapper>
+                            <TabPanel>
+                                <DashboardPickerTab />
+                            </TabPanel>
+                            <TabPanel>
+                                <ThemeTab />
+                            </TabPanel>
+                            <TabPanel>
+                                <LogoTab
+                                    tabIndex={currentIndex}
+                                    setTabIndex={switchTab}
+                                />
+                            </TabPanel>
+                            <TabPanel>
+                                <NameTab
+                                    tabIndex={currentIndex}
+                                    setTabIndex={switchTab}
+                                />
+                            </TabPanel>
+                            <TabPanel>
+                                <ShareTab
+                                    tabIndex={currentIndex}
+                                    setTabIndex={switchTab}
+                                    locked={lockShareTab}
+                                />
+                            </TabPanel>
+                            {settings.liteAccess && (
+                                <TabPanel>
+                                    <LiteSettings />
+                                </TabPanel>
+                            )}
+                        </TabPanels>
+                    </Tabs>
+                    <LockAndViewButtons />
+                </div>
+                <Contrast>
+                    <Footer />
+                </Contrast>
+            </ThemeContrastWrapper>
+        </>
     )
 }
 

--- a/tavla/src/routes/LandingPage/index.tsx
+++ b/tavla/src/routes/LandingPage/index.tsx
@@ -1,19 +1,15 @@
-import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React from 'react'
 import { Helmet } from 'react-helmet'
-import { Coordinates } from 'src/types'
-import { DEFAULT_SETTINGS } from 'settings/settings'
-import { createSettings } from 'settings/firebase'
 import { Footer } from 'components/Footer'
 import previewVideo from 'assets/videos/tavler.webm'
 import { Navbar } from 'scenarios/Navbar'
+import { MigrationBanner } from 'components/MigrationBanner'
 import { Tooltip } from '@entur/tooltip'
 import { Heading1, Heading2, Paragraph, Link } from '@entur/typography'
 import { Contrast } from '@entur/layout'
 import { ForwardIcon } from '@entur/icons'
 import { GridContainer, GridItem } from '@entur/grid'
 import { TypographyCarousel } from './TypographyCarousel/TypographyCarousel'
-import { SearchPanel } from './SearchPanel/SearchPanel'
 import classes from './LandingPage.module.scss'
 
 function EnturLink(): JSX.Element {
@@ -33,24 +29,25 @@ function toggleVideo(video: HTMLVideoElement) {
 }
 
 function LandingPage(): JSX.Element {
-    const navigate = useNavigate()
-    const addLocation = useCallback(
-        (position: Coordinates, locationName: string): void => {
-            const initialSettings = {
-                ...DEFAULT_SETTINGS,
-                coordinates: position,
-                boardName: locationName,
-                created: new Date(),
-            }
-            createSettings(initialSettings).then((docRef) => {
-                navigate(`/t/${docRef.id}`)
-            })
-        },
-        [navigate],
-    )
+    // const navigate = useNavigate()
+    // const addLocation = useCallback(
+    //     (position: Coordinates, locationName: string): void => {
+    //         const initialSettings = {
+    //             ...DEFAULT_SETTINGS,
+    //             coordinates: position,
+    //             boardName: locationName,
+    //             created: new Date(),
+    //         }
+    //         createSettings(initialSettings).then((docRef) => {
+    //             navigate(`/t/${docRef.id}`)
+    //         })
+    //     },
+    //     [navigate],
+    // )
 
     return (
         <>
+            <MigrationBanner />
             <a
                 id="skip-nav"
                 className={classes.ScreenreaderText}
@@ -82,9 +79,6 @@ function LandingPage(): JSX.Element {
                                     </div>
                                 </Tooltip>
                             </header>
-                            <SearchPanel
-                                handleCoordinatesSelected={addLocation}
-                            />
                         </GridItem>
                     </GridContainer>
                 </Contrast>

--- a/tavla/src/routes/MyBoards/OwnedBoards/GridView/GridView.tsx
+++ b/tavla/src/routes/MyBoards/OwnedBoards/GridView/GridView.tsx
@@ -1,11 +1,8 @@
-import { Link } from 'react-router-dom'
 import React from 'react'
 import type { DocumentData } from 'firebase/firestore'
 import type { User } from 'firebase/auth'
 import { Board } from 'src/types'
-import { AddBoardIcon } from 'assets/icons/AddBoardIcon'
 import { Contrast } from '@entur/layout'
-import { Heading3 } from '@entur/typography'
 import { BoardCard } from '../BoardCard/BoardCard'
 import classes from './GridView.module.scss'
 
@@ -22,14 +19,6 @@ function GridView({ boards, user }: { boards: DocumentData; user: User }) {
                     settings={board.data}
                 />
             ))}
-            <div>
-                <Link to="/">
-                    <div className={classes.AddBoard}>
-                        <AddBoardIcon className={classes.AddIcon} />
-                    </div>
-                </Link>
-                <Heading3>Lag ny tavle</Heading3>
-            </div>
         </Contrast>
     )
 }

--- a/tavla/src/routes/MyBoards/OwnedBoards/OwnedBoards.tsx
+++ b/tavla/src/routes/MyBoards/OwnedBoards/OwnedBoards.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, useState } from 'react'
-import { Link } from 'react-router-dom'
 import type { User } from 'firebase/auth'
 import type { DocumentData } from 'firebase/firestore'
 import { SegmentedChoice, SegmentedControl } from '@entur/form'
 import { Contrast } from '@entur/layout'
-import { AddIcon } from '@entur/icons'
 import { GridView } from './GridView/GridView'
 import { ListView } from './ListView/ListView'
 import classes from './OwnedBoards.module.scss'
@@ -29,15 +27,15 @@ function OwnedBoards({ boards, user }: { boards: DocumentData; user: User }) {
     return (
         <div>
             <Contrast className={classes.Header}>
-                <div>
-                    {chosenBoardView == 'list' && (
+                <div className={classes.NewBoardWrapper}>
+                    {/* {chosenBoardView == 'list' && (
                         <Link to="/">
                             <div className={classes.NewBoardWrapper}>
                                 <AddIcon />
                                 Lag ny tavle
                             </div>
                         </Link>
-                    )}
+                    )} */}
                 </div>
 
                 <div className={classes.Wrapper}>

--- a/tavla/src/routes/MyBoards/index.tsx
+++ b/tavla/src/routes/MyBoards/index.tsx
@@ -12,6 +12,7 @@ import { Board, SharedBoard } from 'src/types'
 import { Navbar } from 'scenarios/Navbar'
 import { NoAccessToTavler } from 'scenarios/ErrorPages/NoAccessToTavler'
 import { NoTavlerAvailable } from 'scenarios/ErrorPages/NoTavlerAvailable'
+import { MigrationBanner } from 'components/MigrationBanner'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@entur/tab'
 import { Contrast, NotificationBadge } from '@entur/layout'
 import { SharedBoards } from './SharedBoards/SharedBoards'
@@ -167,42 +168,45 @@ function MyBoards() {
     }
 
     return (
-        <Contrast>
-            <Helmet>
-                <title>Mine tavler - Tavla - Entur</title>
-            </Helmet>
-            <Navbar />
-            <div className={classes.MyBoards}>
-                <Tabs index={currentIndex} onChange={switchTab}>
-                    <TabList>
-                        <Tab>Tavler</Tab>
-                        <Tab>
-                            Invitasjoner
-                            {sharedBoards.length > 0 ? (
-                                <>
-                                    {' '}
-                                    <NotificationBadge
-                                        variant="info"
-                                        // Uses inline style as classnames are not applied correctly
-                                        style={{ display: 'inline-block' }}
-                                    >
-                                        {sharedBoards.length}
-                                    </NotificationBadge>
-                                </>
-                            ) : null}
-                        </Tab>
-                    </TabList>
-                    <TabPanels>
-                        <TabPanel>
-                            <OwnedBoards boards={boards} user={user} />
-                        </TabPanel>
-                        <TabPanel>
-                            <SharedBoards sharedBoards={sharedBoards} />
-                        </TabPanel>
-                    </TabPanels>
-                </Tabs>
-            </div>
-        </Contrast>
+        <>
+            <MigrationBanner />
+            <Contrast>
+                <Helmet>
+                    <title>Mine tavler - Tavla - Entur</title>
+                </Helmet>
+                <Navbar />
+                <div className={classes.MyBoards}>
+                    <Tabs index={currentIndex} onChange={switchTab}>
+                        <TabList>
+                            <Tab>Tavler</Tab>
+                            <Tab>
+                                Invitasjoner
+                                {sharedBoards.length > 0 ? (
+                                    <>
+                                        {' '}
+                                        <NotificationBadge
+                                            variant="info"
+                                            // Uses inline style as classnames are not applied correctly
+                                            style={{ display: 'inline-block' }}
+                                        >
+                                            {sharedBoards.length}
+                                        </NotificationBadge>
+                                    </>
+                                ) : null}
+                            </Tab>
+                        </TabList>
+                        <TabPanels>
+                            <TabPanel>
+                                <OwnedBoards boards={boards} user={user} />
+                            </TabPanel>
+                            <TabPanel>
+                                <SharedBoards sharedBoards={sharedBoards} />
+                            </TabPanel>
+                        </TabPanels>
+                    </Tabs>
+                </div>
+            </Contrast>
+        </>
     )
 }
 

--- a/tavla/src/scenarios/ErrorPages/NoTavlerAvailable.tsx
+++ b/tavla/src/scenarios/ErrorPages/NoTavlerAvailable.tsx
@@ -1,25 +1,18 @@
-import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React from 'react'
 import duerLight from 'assets/images/duer@2x.png'
+import { MigrationBanner } from 'components/MigrationBanner'
 import { ErrorWrapper } from './components/ErrorWrapper'
 
 function NoTavlerAvailable(): JSX.Element {
-    const navigate = useNavigate()
-    const callback = useCallback(
-        (event: React.SyntheticEvent<HTMLButtonElement>): void => {
-            event.preventDefault()
-            navigate(`/`)
-        },
-        [navigate],
-    )
     return (
         <div>
+            <MigrationBanner />
             <ErrorWrapper
                 title="Her var det tomt!"
-                message="Du har ingen tavler som er lagret på denne kontoen. Trykk på knappen nedenfor for å lage en avgangstavle."
+                message="Du har ingen tavler som er lagret på denne kontoen."
                 image={duerLight}
-                callbackMessage="Lag en ny tavle"
-                callback={callback}
+                // callbackMessage="Lag en ny tavle nå"
+                // callback={callback}
                 altText=""
             />
         </div>


### PR DESCRIPTION

The banner will be shown in:
- landing-page
- edit boards-page 
- my boards-page

![image](https://github.com/entur/tavla/assets/74315929/09013071-406d-41f0-8fac-91693edd606f)

![image](https://github.com/entur/tavla/assets/74315929/6e314600-40cb-4a3d-9a12-f9c84ecf109e)

<img width="1628" alt="image" src="https://github.com/entur/tavla/assets/74315929/49186c42-8bc5-4eb7-9c0f-a869d33f4b04">
