### PR TITLE
feat(organization): table columns and delete member modal

### DIFF
--- a/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -43,8 +43,8 @@ function Delete({ board }: { board: TBoard }) {
                     {board?.meta?.title
                         ? `Er du sikker på at du vil slette tavlen "${board.meta.title}"? `
                         : 'Er du sikker på at du vil slette denne tavlen? '}
-                    Avgangstavlen vil være borte for godt og ikke mulig å finne
-                    tilbake til.
+                    Tavlen vil være borte for godt og ikke mulig å finne tilbake
+                    til.
                 </Paragraph>
 
                 <form action={action} onSubmit={close} className="w-100">

--- a/next-tavla/app/(admin)/components/Delete/index.tsx
+++ b/next-tavla/app/(admin)/components/Delete/index.tsx
@@ -43,8 +43,8 @@ function Delete({
                     className="g-2"
                     variant="secondary"
                 >
-                    <DeleteIcon />
                     {type === 'secondary' && 'Slett'}
+                    <DeleteIcon />
                 </DeleteButton>
             </Tooltip>
             <Modal

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
@@ -20,7 +20,7 @@ function CountiesSelect({
     return (
         <div>
             <Heading3>Velg fylkene du vil sette opp tavler for</Heading3>
-            <div className={styles.countiesBox}>
+            <div className={styles.box}>
                 <Paragraph>
                     Når du søker etter stoppesteder vil du søke i alle fylker.
                     Her kan du velge hvilke fylker du ønsker å begrense søket

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
@@ -5,7 +5,7 @@ import { TCountyID, TOrganizationID } from 'types/settings'
 import { useCountiesSearch } from 'app/(admin)/hooks/useCountiesSearch'
 import { Checkbox } from '@entur/form'
 import { setCounties } from './actions'
-import styles from './styles.module.css'
+import classes from '../styles.module.css'
 import { Heading3, Paragraph } from '@entur/typography'
 
 function CountiesSelect({
@@ -20,7 +20,7 @@ function CountiesSelect({
     return (
         <div>
             <Heading3>Velg fylkene du vil sette opp tavler for</Heading3>
-            <div className={styles.box}>
+            <div className="box">
                 <Paragraph>
                     Når du søker etter stoppesteder vil du søke i alle fylker.
                     Her kan du velge hvilke fylker du ønsker å begrense søket
@@ -34,7 +34,7 @@ function CountiesSelect({
                         setCounties(oid, counties)
                     }}
                 >
-                    <div className={styles.countiesSelectContainer}>
+                    <div className={classes.countiesSelectContainer}>
                         {counties()
                             .sort(
                                 (

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
@@ -5,7 +5,7 @@ import { TCountyID, TOrganizationID } from 'types/settings'
 import { useCountiesSearch } from 'app/(admin)/hooks/useCountiesSearch'
 import { Checkbox } from '@entur/form'
 import { setCounties } from './actions'
-import classes from '../styles.module.css'
+import classes from './styles.module.css'
 import { Heading3, Paragraph } from '@entur/typography'
 
 function CountiesSelect({

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/index.tsx
@@ -19,7 +19,7 @@ function CountiesSelect({
 
     return (
         <div>
-            <Heading3>Velg fylke/fylker du skal sette opp tavler for</Heading3>
+            <Heading3>Velg fylkene du vil sette opp tavler for</Heading3>
             <div className={styles.countiesBox}>
                 <Paragraph>
                     Når du søker etter stoppesteder vil du søke i alle fylker.

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/styles.module.css
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/styles.module.css
@@ -4,10 +4,3 @@
     grid-auto-flow: column;
     gap: 0 0.5em;
 }
-
-.box {
-    border-radius: 0.5em;
-    margin: 2em 0em;
-    padding: 2em;
-    background: var(--secondary-background-color);
-}

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/styles.module.css
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/styles.module.css
@@ -5,7 +5,7 @@
     gap: 0 0.5em;
 }
 
-.countiesBox {
+.box {
     border-radius: 0.5em;
     margin: 2em 0em;
     padding: 2em;

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/styles.module.css
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/styles.module.css
@@ -7,7 +7,7 @@
 
 .countiesBox {
     border-radius: 0.5em;
-    margin-top: 2em;
+    margin: 2em 0em;
     padding: 2em;
     background: var(--secondary-background-color);
 }

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/InviteUser.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/InviteUser.tsx
@@ -6,9 +6,9 @@ import classes from './styles.module.css'
 import { inviteUserAction } from 'Admin/utils/formActions'
 import { useFormState } from 'react-dom'
 import { HiddenInput } from 'components/Form/HiddenInput'
-import { SubmitButton } from 'components/Form/SubmitButton'
 import { getFormFeedbackForField } from 'app/(admin)/utils'
 import { FormError } from 'app/(admin)/components/FormError'
+import { SecondaryButton } from '@entur/button'
 
 function InviteUser({ oid }: { oid?: TOrganizationID }) {
     const [state, formAction] = useFormState(inviteUserAction, undefined)
@@ -26,14 +26,14 @@ function InviteUser({ oid }: { oid?: TOrganizationID }) {
                         {...getFormFeedbackForField('email', state)}
                     />
                 </div>
-                <SubmitButton
-                    variant="primary"
+                <SecondaryButton
+                    aria-label="Legg til medlem"
                     width="fluid"
                     className={classes.addMemberButton}
                 >
                     Legg til medlem
                     <AddIcon />
-                </SubmitButton>
+                </SecondaryButton>
             </div>
             <FormError {...getFormFeedbackForField('general', state)} />
         </form>

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/InviteUser.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/InviteUser.tsx
@@ -8,7 +8,7 @@ import { useFormState } from 'react-dom'
 import { HiddenInput } from 'components/Form/HiddenInput'
 import { getFormFeedbackForField } from 'app/(admin)/utils'
 import { FormError } from 'app/(admin)/components/FormError'
-import { SecondaryButton } from '@entur/button'
+import { SubmitButton } from 'components/Form/SubmitButton'
 
 function InviteUser({ oid }: { oid?: TOrganizationID }) {
     const [state, formAction] = useFormState(inviteUserAction, undefined)
@@ -26,15 +26,15 @@ function InviteUser({ oid }: { oid?: TOrganizationID }) {
                         {...getFormFeedbackForField('email', state)}
                     />
                 </div>
-                <SecondaryButton
+                <SubmitButton
                     aria-label="Legg til medlem"
-                    type="submit"
+                    variant="secondary"
                     width="fluid"
                     className={classes.addMemberButton}
                 >
                     Legg til medlem
                     <AddIcon />
-                </SecondaryButton>
+                </SubmitButton>
             </div>
             <FormError {...getFormFeedbackForField('general', state)} />
         </form>

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/InviteUser.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/InviteUser.tsx
@@ -28,6 +28,7 @@ function InviteUser({ oid }: { oid?: TOrganizationID }) {
                 </div>
                 <SecondaryButton
                     aria-label="Legg til medlem"
+                    type="submit"
                     width="fluid"
                     className={classes.addMemberButton}
                 >

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
@@ -1,10 +1,6 @@
 import { TOrganizationID, TUser, TUserID } from 'types/settings'
 import classes from './styles.module.css'
 import { RemoveUserButton } from './RemoveUserButton'
-import {
-    MEMBER_TABLE_COLUMNS,
-    MemberTableColumn,
-} from 'Admin/types/organizations'
 
 function MemberList({
     members,
@@ -18,9 +14,8 @@ function MemberList({
     return (
         <div className="flexColumn g-1 mt-3">
             <div className={classes.tableHeader}>
-                {MEMBER_TABLE_COLUMNS.map((column) => (
-                    <div key={column}>{MemberTableColumn[column]}</div>
-                ))}
+                <div>E-post</div>
+                <div>Valg</div>
             </div>
 
             {members.map((member) => (

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
@@ -1,6 +1,10 @@
 import { TOrganizationID, TUser, TUserID } from 'types/settings'
 import classes from './styles.module.css'
 import { RemoveUserButton } from './RemoveUserButton'
+import {
+    MEMBER_TABLE_COLUMNS,
+    MemberTableColumn,
+} from 'Admin/types/organizations'
 
 function MemberList({
     members,
@@ -12,16 +16,27 @@ function MemberList({
     oid?: TOrganizationID
 }) {
     return (
-        <div className="flexColumn g-1">
-            {members.map((member) => (
-                <div className={classes.memberListRow} key={member.uid}>
-                    <div>{member.email}</div>
-                    {member.uid !== currentUserId && (
-                        <RemoveUserButton uid={member.uid} oid={oid} />
-                    )}
-                </div>
-            ))}
-        </div>
+        <table className="flexColumn g-1 mt-3">
+            <thead>
+                <tr className={classes.tableHeader}>
+                    {MEMBER_TABLE_COLUMNS.map((column) => (
+                        <th key={column}>{MemberTableColumn[column]}</th>
+                    ))}
+                </tr>
+            </thead>
+            <tbody>
+                {members.map((member) => (
+                    <tr className={classes.memberListRow} key={member.uid}>
+                        <td>{member.email}</td>
+                        {member.uid !== currentUserId && (
+                            <td>
+                                <RemoveUserButton user={member} oid={oid} />
+                            </td>
+                        )}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     )
 }
 

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
@@ -16,27 +16,22 @@ function MemberList({
     oid?: TOrganizationID
 }) {
     return (
-        <table className="flexColumn g-1 mt-3">
-            <thead>
-                <tr className={classes.tableHeader}>
-                    {MEMBER_TABLE_COLUMNS.map((column) => (
-                        <th key={column}>{MemberTableColumn[column]}</th>
-                    ))}
-                </tr>
-            </thead>
-            <tbody>
-                {members.map((member) => (
-                    <tr className={classes.memberListRow} key={member.uid}>
-                        <td>{member.email}</td>
-                        {member.uid !== currentUserId && (
-                            <td>
-                                <RemoveUserButton user={member} oid={oid} />
-                            </td>
-                        )}
-                    </tr>
+        <div className="flexColumn g-1 mt-3">
+            <div className={classes.tableHeader}>
+                {MEMBER_TABLE_COLUMNS.map((column) => (
+                    <div key={column}>{MemberTableColumn[column]}</div>
                 ))}
-            </tbody>
-        </table>
+            </div>
+
+            {members.map((member) => (
+                <div className={classes.memberListRow} key={member.uid}>
+                    <div>{member.email} </div>
+                    {member.uid !== currentUserId && (
+                        <RemoveUserButton user={member} oid={oid} />
+                    )}
+                </div>
+            ))}
+        </div>
     )
 }
 

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/MemberList.tsx
@@ -20,7 +20,7 @@ function MemberList({
 
             {members.map((member) => (
                 <div className={classes.memberListRow} key={member.uid}>
-                    <div>{member.email} </div>
+                    <div>{member.email}</div>
                     {member.uid !== currentUserId && (
                         <RemoveUserButton user={member} oid={oid} />
                     )}

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/RemoveUserButton.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/RemoveUserButton.tsx
@@ -54,8 +54,8 @@ function RemoveUserButton({
                 <Image src={sheep} alt="" className="h-50 w-50" />
                 <Heading2>Slett medlem</Heading2>
                 <Paragraph className="mt-2">
-                    {`Er du sikker på at du vil slette medlem med e-postadresse 
-            ${user?.email} fra organisasjonen?`}
+                    Er du sikker på at du vil slette medlem med e-postadresse{' '}
+                    {user?.email} fra organisasjonen?
                 </Paragraph>
                 <form
                     action={formAction}

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/RemoveUserButton.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/RemoveUserButton.tsx
@@ -1,33 +1,81 @@
 'use client'
-import { IconButton } from '@entur/button'
-import { DeleteIcon } from '@entur/icons'
+import { IconButton, SecondarySquareButton } from '@entur/button'
+import { CloseIcon, DeleteIcon } from '@entur/icons'
+import { Modal } from '@entur/modal'
+import { Tooltip } from '@entur/tooltip'
+import { Heading2, Paragraph } from '@entur/typography'
 import { removeUserAction } from 'Admin/utils/formActions'
 import { FormError } from 'app/(admin)/components/FormError'
 import { getFormFeedbackForField } from 'app/(admin)/utils'
 import { HiddenInput } from 'components/Form/HiddenInput'
+import { SubmitButton } from 'components/Form/SubmitButton'
 import { useFormState } from 'react-dom'
-import { TOrganizationID, TUserID } from 'types/settings'
-
+import { TOrganizationID, TUser } from 'types/settings'
+import Image from 'next/image'
+import sheep from 'assets/illustrations/Sheep.png'
+import { useModalWithValue } from 'app/(admin)/boards/hooks/useModalWithValue'
 function RemoveUserButton({
-    uid,
+    user,
     oid,
 }: {
-    uid?: TUserID
+    user?: TUser
     oid?: TOrganizationID
 }) {
     const [state, formAction] = useFormState(removeUserAction, undefined)
-
+    const { isOpen, open, close } = useModalWithValue(
+        'deleteUser',
+        user?.uid ?? '',
+    )
     return (
-        <form action={formAction}>
-            <HiddenInput id="uid" value={uid} />
-            <HiddenInput id="oid" value={oid} />
-            <div className="flexRow">
-                <FormError {...getFormFeedbackForField('general', state)} />
-                <IconButton type="submit" aria-label="Fjern bruker">
+        <>
+            <Tooltip content="Slett bruker" placement="bottom">
+                <IconButton
+                    type="submit"
+                    aria-label="Fjern bruker"
+                    onClick={open}
+                >
                     <DeleteIcon />
                 </IconButton>
-            </div>
-        </form>
+            </Tooltip>
+            <Modal
+                open={isOpen}
+                size="small"
+                onDismiss={close}
+                closeLabel="Avbryt sletting"
+                className="flexColumn justifyStart alignCenter textCenter"
+            >
+                <SecondarySquareButton
+                    aria-label="Avbryt sletting"
+                    className="ml-auto"
+                    onClick={close}
+                >
+                    <CloseIcon />
+                </SecondarySquareButton>
+                <Image src={sheep} alt="" className="h-50 w-50" />
+                <Heading2>Slett medlem</Heading2>
+                <Paragraph className="mt-2">
+                    {`Er du sikker på at du vil slette medlem med e-postadresse 
+            ${user?.email} fra organisasjonen?`}
+                </Paragraph>
+                <form
+                    action={formAction}
+                    className="flexColumn w-100 g-2"
+                    aria-live="polite"
+                    aria-relevant="all"
+                >
+                    <HiddenInput id="uid" value={user?.uid} />
+                    <HiddenInput id="oid" value={oid} />
+                    <FormError {...getFormFeedbackForField('general', state)} />
+                    <SubmitButton
+                        variant="primary"
+                        width="fluid"
+                        aria-label="Slett bruker"
+                    >
+                        Ja, slett
+                    </SubmitButton>
+                </form>
+            </Modal>
+        </>
     )
 }
 

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/index.tsx
@@ -3,7 +3,6 @@ import { MemberList } from './MemberList'
 import { TOrganizationID, TUser, TUserID } from 'types/settings'
 import { InviteUser } from './InviteUser'
 import { Contrast } from 'Admin/components/Contrast'
-import styles from './CountiesSelect/styles.module.css'
 function MemberAdministration(props: {
     oid?: TOrganizationID
     uid?: TUserID
@@ -12,7 +11,7 @@ function MemberAdministration(props: {
     return (
         <Contrast className="flexColumn">
             <Heading2>Administrer medlemmer</Heading2>
-            <div className={styles.box}>
+            <div className="box">
                 <Paragraph>
                     Her kan du administrere medlemmer av organisasjonen. Du kan
                     se hvem som er medlem, legge til medlemmer og fjerne

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/index.tsx
@@ -3,23 +3,25 @@ import { MemberList } from './MemberList'
 import { TOrganizationID, TUser, TUserID } from 'types/settings'
 import { InviteUser } from './InviteUser'
 import { Contrast } from 'Admin/components/Contrast'
-
+import styles from './CountiesSelect/styles.module.css'
 function MemberAdministration(props: {
     oid?: TOrganizationID
     uid?: TUserID
     members: TUser[]
 }) {
     return (
-        <Contrast className="flexColumn g-4">
+        <Contrast className="flexColumn">
             <Heading2>Administrer medlemmer</Heading2>
+            <div className={styles.countiesBox}>
+                <Paragraph>
+                    Her kan du administrere medlemmer av organisasjonen. Du kan
+                    se hvem som er medlem, legge til medlemmer og fjerne
+                    medlemmer.
+                </Paragraph>
 
-            <Paragraph>
-                Her kan du administrere medlemmer av organisasjonen. Du kan se
-                hvem som er medlem, legge til medlemmer og fjerne medlemmer.
-            </Paragraph>
-
-            <InviteUser oid={props.oid} />
-            <MemberList {...props} />
+                <InviteUser oid={props.oid} />
+                <MemberList {...props} />
+            </div>
         </Contrast>
     )
 }

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/index.tsx
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/index.tsx
@@ -12,7 +12,7 @@ function MemberAdministration(props: {
     return (
         <Contrast className="flexColumn">
             <Heading2>Administrer medlemmer</Heading2>
-            <div className={styles.countiesBox}>
+            <div className={styles.box}>
                 <Paragraph>
                     Her kan du administrere medlemmer av organisasjonen. Du kan
                     se hvem som er medlem, legge til medlemmer og fjerne

--- a/next-tavla/app/(admin)/organizations/components/MemberAdministration/styles.module.css
+++ b/next-tavla/app/(admin)/organizations/components/MemberAdministration/styles.module.css
@@ -16,3 +16,12 @@
     gap: 0.5em;
     height: 4rem;
 }
+.tableHeader {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    border-bottom: var(--table-header-border-color) solid;
+    font-weight: 500;
+    color: var(--secondary-text-color);
+    padding-bottom: 0.5rem;
+}

--- a/next-tavla/src/Admin/types/organizations.ts
+++ b/next-tavla/src/Admin/types/organizations.ts
@@ -9,3 +9,13 @@ export type TOrganizationsColumn = keyof typeof OrganizationsColumns
 export const ORGANIZATIONS_COLUMNS = Object.keys(
     OrganizationsColumns,
 ) as TOrganizationsColumn[]
+
+export const MemberTableColumn = {
+    email: 'E-post',
+    actions: 'Valg',
+}
+
+export type TMemberTableColumn = keyof typeof MemberTableColumn
+export const MEMBER_TABLE_COLUMNS = Object.keys(
+    MemberTableColumn,
+) as TMemberTableColumn[]

--- a/next-tavla/src/Admin/types/organizations.ts
+++ b/next-tavla/src/Admin/types/organizations.ts
@@ -9,13 +9,3 @@ export type TOrganizationsColumn = keyof typeof OrganizationsColumns
 export const ORGANIZATIONS_COLUMNS = Object.keys(
     OrganizationsColumns,
 ) as TOrganizationsColumn[]
-
-export const MemberTableColumn = {
-    email: 'E-post',
-    actions: 'Valg',
-}
-
-export type TMemberTableColumn = keyof typeof MemberTableColumn
-export const MEMBER_TABLE_COLUMNS = Object.keys(
-    MemberTableColumn,
-) as TMemberTableColumn[]

--- a/next-tavla/src/Shared/styles/global.css
+++ b/next-tavla/src/Shared/styles/global.css
@@ -58,3 +58,9 @@ ul {
     white-space: nowrap;
     width: 1px;
 }
+.box {
+    border-radius: 0.5em;
+    margin: 2em 0em;
+    padding: 2em;
+    background: var(--secondary-background-color);
+}


### PR DESCRIPTION
When editing an organization, the member administration table now has two colum names ("E-post" and "Valg"). It looks like this:
<img width="814" alt="image" src="https://github.com/entur/tavla/assets/74315929/b3e8075d-e2bd-421d-a324-82c3e27ea41f">

When deleting a member, a modal opens up asking for confirmation:
<img width="545" alt="image" src="https://github.com/entur/tavla/assets/74315929/4370f7a3-a71b-49dd-8715-eb50228f0e82">

I tried to change the memberAdministration component to using semantic HTML and corresponding table elements  instead of'`<div>`. I also placed most of the modal-logic inside `RemoveUserButton`. 


