### PR TITLE
feat(login): reset password link confirmation

### DIFF
--- a/next-tavla/app/(admin)/components/Login/Reset.tsx
+++ b/next-tavla/app/(admin)/components/Login/Reset.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { sendPasswordResetEmail } from 'firebase/auth'
 import musk from 'assets/illustrations/Musk.png'
 import { Heading3, Paragraph } from '@entur/typography'
-import { TextField } from '@entur/form'
+import { TextField, VariantType } from '@entur/form'
 import { PrimaryButton } from '@entur/button'
 import {
     TFormFeedback,
@@ -14,6 +14,8 @@ import { auth } from 'utils/firebase'
 import { useFormState } from 'react-dom'
 import { FirebaseError } from 'firebase/app'
 import { FormError } from '../FormError'
+import { useState } from 'react'
+import { useToast } from '@entur/alert'
 
 function Reset() {
     const submit = async (
@@ -23,6 +25,8 @@ function Reset() {
         const email = data.get('email') as string
         try {
             await sendPasswordResetEmail(auth, email)
+            setTextVariant('success')
+            addToast('E-post sendt!')
         } catch (e: unknown) {
             if (e instanceof FirebaseError) {
                 return getFormFeedbackForError(e)
@@ -30,7 +34,8 @@ function Reset() {
         }
     }
     const [state, action] = useFormState(submit, undefined)
-
+    const [textVariant, setTextVariant] = useState<VariantType>('info')
+    const { addToast } = useToast()
     return (
         <div className="textCenter">
             <Image src={musk} aria-hidden="true" alt="" className="h-50 w-50" />
@@ -43,12 +48,14 @@ function Reset() {
                 <TextField
                     name="email"
                     label="E-post"
+                    aria-label="E-post"
                     type="email"
+                    variant={textVariant}
                     {...getFormFeedbackForField('email', state)}
                 />
                 <FormError {...getFormFeedbackForField('user', state)} />
                 <FormError {...getFormFeedbackForField('general', state)} />
-                <PrimaryButton type="submit">
+                <PrimaryButton type="submit" aria-label="Tilbakestill passord">
                     Tilbakestill passord
                 </PrimaryButton>
             </form>

--- a/next-tavla/app/(admin)/components/Login/Reset.tsx
+++ b/next-tavla/app/(admin)/components/Login/Reset.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { sendPasswordResetEmail } from 'firebase/auth'
 import musk from 'assets/illustrations/Musk.png'
 import { Heading3, Paragraph } from '@entur/typography'
-import { TextField, VariantType } from '@entur/form'
+import { TextField } from '@entur/form'
 import { PrimaryButton } from '@entur/button'
 import {
     TFormFeedback,
@@ -14,8 +14,6 @@ import { auth } from 'utils/firebase'
 import { useFormState } from 'react-dom'
 import { FirebaseError } from 'firebase/app'
 import { FormError } from '../FormError'
-import { useState } from 'react'
-import { useToast } from '@entur/alert'
 
 function Reset() {
     const submit = async (
@@ -25,8 +23,7 @@ function Reset() {
         const email = data.get('email') as string
         try {
             await sendPasswordResetEmail(auth, email)
-            setTextVariant('success')
-            addToast('E-post sendt!')
+            return getFormFeedbackForError('reset/email-sent')
         } catch (e: unknown) {
             if (e instanceof FirebaseError) {
                 return getFormFeedbackForError(e)
@@ -34,8 +31,6 @@ function Reset() {
         }
     }
     const [state, action] = useFormState(submit, undefined)
-    const [textVariant, setTextVariant] = useState<VariantType>('info')
-    const { addToast } = useToast()
     return (
         <div className="textCenter">
             <Image src={musk} aria-hidden="true" alt="" className="h-50 w-50" />
@@ -50,7 +45,6 @@ function Reset() {
                     label="E-post"
                     aria-label="E-post"
                     type="email"
-                    variant={textVariant}
                     {...getFormFeedbackForField('email', state)}
                 />
                 <FormError {...getFormFeedbackForField('user', state)} />

--- a/next-tavla/app/(admin)/utils.ts
+++ b/next-tavla/app/(admin)/utils.ts
@@ -183,6 +183,14 @@ export function getFormFeedbackForError(e?: TError): TFormFeedback {
                 variant: 'error',
             }
         }
+        case 'reset/email-sent': {
+            return {
+                form_type: 'email',
+                feedback:
+                    'Vi har sendt deg en lenke for å nullstille passordet.',
+                variant: 'success',
+            }
+        }
     }
 
     return {


### PR DESCRIPTION
When clicking on reset password, the textfield turns green and a success-toast appears

Results:
![image](https://github.com/entur/tavla/assets/74315929/f849c887-aa49-4dc7-ae6c-e1a211fdd41f)
