### PR TITLE
feat(edit): board actions in edit page

### DIFF
--- a/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
@@ -1,13 +1,16 @@
 import { IconButton } from '@entur/button'
-import { CopyIcon, EditIcon, ExternalIcon } from '@entur/icons'
+import { EditIcon } from '@entur/icons'
 import { Tooltip } from '@entur/tooltip'
 import Link from 'next/link'
 import { TBoard } from 'types/settings'
 import { useLink } from '../../../../../src/Shared/hooks/useLink'
-import { useToast } from '@entur/alert'
 import classes from './styles.module.css'
 import { Column } from './Column'
 import { Delete } from './Delete'
+import {
+    CopyButton,
+    OpenButton,
+} from 'app/(admin)/edit/[id]/components/Buttons'
 
 function Actions({ board }: { board: TBoard }) {
     const link = useLink(board.id)
@@ -37,37 +40,20 @@ function Edit({ bid }: { bid?: string }) {
     )
 }
 
-function Copy({ link }: { link?: string }) {
-    const { addToast } = useToast()
-
+function Copy({ link, type }: { link?: string; type?: 'button' | 'icon' }) {
     return (
         <Tooltip content="Kopier lenke" placement="bottom">
-            <IconButton
-                aria-label="Kopier lenke"
-                onClick={() => {
-                    navigator.clipboard.writeText(link ?? '')
-                    addToast('Lenke til Tavla kopiert')
-                }}
-            >
-                <CopyIcon />
-            </IconButton>
+            <CopyButton link={link} type={type} />
         </Tooltip>
     )
 }
 
-function Open({ link }: { link?: string }) {
+function Open({ link, type }: { link?: string; type?: 'button' | 'icon' }) {
     return (
         <Tooltip content="Åpne tavle" placement="bottom">
-            <IconButton
-                as={Link}
-                aria-label="Åpne tavle"
-                href={link ?? '/'}
-                target="_blank"
-            >
-                <ExternalIcon />
-            </IconButton>
+            <OpenButton link={link} type={type} />
         </Tooltip>
     )
 }
 
-export { Actions }
+export { Actions, Open, Copy }

--- a/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
@@ -6,18 +6,15 @@ import { TBoard } from 'types/settings'
 import classes from './styles.module.css'
 import { Column } from './Column'
 import { Delete } from './Delete'
-import {
-    CopyButton,
-    OpenButton,
-} from 'app/(admin)/edit/[id]/components/Buttons'
+import { Copy, Open } from 'app/(admin)/edit/[id]/components/Buttons'
 
 function Actions({ board }: { board: TBoard }) {
     return (
         <Column column="actions">
             <div className={classes.actions}>
                 <Edit bid={board.id} />
-                <CopyButton bid={board.id} />
-                <OpenButton bid={board.id} />
+                <Copy bid={board.id} />
+                <Open bid={board.id} />
                 <Delete board={board} />
             </div>
         </Column>

--- a/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
@@ -6,7 +6,8 @@ import { TBoard } from 'types/settings'
 import classes from './styles.module.css'
 import { Column } from './Column'
 import { Delete } from './Delete'
-import { Copy, Open } from 'app/(admin)/edit/[id]/components/Buttons'
+import { Open } from 'app/(admin)/edit/[id]/components/Buttons/Open'
+import { Copy } from 'app/(admin)/edit/[id]/components/Buttons/Copy'
 
 function Actions({ board }: { board: TBoard }) {
     return (

--- a/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Actions.tsx
@@ -3,7 +3,6 @@ import { EditIcon } from '@entur/icons'
 import { Tooltip } from '@entur/tooltip'
 import Link from 'next/link'
 import { TBoard } from 'types/settings'
-import { useLink } from '../../../../../src/Shared/hooks/useLink'
 import classes from './styles.module.css'
 import { Column } from './Column'
 import { Delete } from './Delete'
@@ -13,13 +12,12 @@ import {
 } from 'app/(admin)/edit/[id]/components/Buttons'
 
 function Actions({ board }: { board: TBoard }) {
-    const link = useLink(board.id)
     return (
         <Column column="actions">
             <div className={classes.actions}>
                 <Edit bid={board.id} />
-                <Copy link={link} />
-                <Open link={link} />
+                <CopyButton bid={board.id} />
+                <OpenButton bid={board.id} />
                 <Delete board={board} />
             </div>
         </Column>
@@ -40,20 +38,4 @@ function Edit({ bid }: { bid?: string }) {
     )
 }
 
-function Copy({ link, type }: { link?: string; type?: 'button' | 'icon' }) {
-    return (
-        <Tooltip content="Kopier lenke" placement="bottom">
-            <CopyButton link={link} type={type} />
-        </Tooltip>
-    )
-}
-
-function Open({ link, type }: { link?: string; type?: 'button' | 'icon' }) {
-    return (
-        <Tooltip content="Åpne tavle" placement="bottom">
-            <OpenButton link={link} type={type} />
-        </Tooltip>
-    )
-}
-
-export { Actions, Open, Copy }
+export { Actions }

--- a/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -1,4 +1,9 @@
-import { IconButton, PrimaryButton, SecondarySquareButton } from '@entur/button'
+import {
+    Button,
+    IconButton,
+    PrimaryButton,
+    SecondarySquareButton,
+} from '@entur/button'
 import { CloseIcon, DeleteIcon } from '@entur/icons'
 import { TBoard } from 'types/settings'
 import { Tooltip } from '@entur/tooltip'
@@ -12,16 +17,15 @@ import { deleteBoardAction } from '../../utils/formActions'
 import { getFormFeedbackForField } from 'app/(admin)/utils'
 import sheep from 'assets/illustrations/Sheep.png'
 import Image from 'next/image'
-function Delete({ board }: { board: TBoard }) {
+
+function Delete({ board, type }: { board: TBoard; type?: 'icon' | 'button' }) {
     const [state, action] = useFormState(deleteBoardAction, undefined)
     const { isOpen, open, close } = useModalWithValue('delete', board.id ?? '')
 
     return (
         <>
             <Tooltip content="Slett tavle" placement="bottom">
-                <IconButton aria-label="Slett tavle" onClick={open}>
-                    <DeleteIcon />
-                </IconButton>
+                <DeleteButton type={type} open={open} />
             </Tooltip>
             <Modal
                 open={isOpen}
@@ -63,4 +67,22 @@ function Delete({ board }: { board: TBoard }) {
     )
 }
 
-export { Delete }
+function DeleteButton({
+    type,
+    open,
+}: {
+    type?: 'button' | 'icon'
+    open: () => void
+}) {
+    return type === 'button' ? (
+        <Button variant="secondary" aria-label="Slett tavle" onClick={open}>
+            Slett Tavle
+        </Button>
+    ) : (
+        <IconButton aria-label="Slett tavle" onClick={open}>
+            <DeleteIcon />
+        </IconButton>
+    )
+}
+
+export { Delete, DeleteButton }

--- a/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -75,11 +75,14 @@ function DeleteButton({
     type?: 'button' | 'icon'
     open: () => void
 }) {
-    return type === 'button' ? (
-        <Button variant="secondary" aria-label="Slett tavle" onClick={open}>
-            Slett Tavle
-        </Button>
-    ) : (
+    if (type === 'button') {
+        return (
+            <Button variant="secondary" aria-label="Slett tavle" onClick={open}>
+                Slett Tavle
+            </Button>
+        )
+    }
+    return (
         <IconButton aria-label="Slett tavle" onClick={open}>
             <DeleteIcon />
         </IconButton>

--- a/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -26,7 +26,7 @@ function Delete({ board, type }: { board: TBoard; type?: 'icon' | 'button' }) {
     return (
         <>
             <Tooltip content="Slett tavle" placement="bottom">
-                <DeleteButton type={type} open={open} />
+                <DeleteButton type={type} onClick={open} />
             </Tooltip>
             <Modal
                 open={isOpen}
@@ -70,20 +70,24 @@ function Delete({ board, type }: { board: TBoard; type?: 'icon' | 'button' }) {
 
 function DeleteButton({
     type,
-    open,
+    onClick,
 }: {
     type?: 'button' | 'icon'
-    open: () => void
+    onClick: () => void
 }) {
     if (type === 'button') {
         return (
-            <Button variant="secondary" aria-label="Slett tavle" onClick={open}>
+            <Button
+                variant="secondary"
+                aria-label="Slett tavle"
+                onClick={onClick}
+            >
                 Slett Tavle
             </Button>
         )
     }
     return (
-        <IconButton aria-label="Slett tavle" onClick={open}>
+        <IconButton aria-label="Slett tavle" onClick={onClick}>
             <DeleteIcon />
         </IconButton>
     )

--- a/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -1,3 +1,4 @@
+'use client'
 import {
     Button,
     IconButton,

--- a/next-tavla/app/(admin)/boards/utils/formActions.ts
+++ b/next-tavla/app/(admin)/boards/utils/formActions.ts
@@ -5,6 +5,7 @@ import { isString } from 'lodash'
 import { revalidatePath } from 'next/cache'
 import { addTag, removeTag } from './updateTags'
 import { deleteBoard } from 'app/(admin)/utils/firebase'
+import { redirect } from 'next/navigation'
 
 export async function deleteBoardAction(
     prevState: TFormFeedback | undefined,
@@ -20,6 +21,7 @@ export async function deleteBoardAction(
             return getFormFeedbackForError(e)
         return getFormFeedbackForError('general')
     }
+    redirect('/boards')
 }
 
 export async function addTagAction(

--- a/next-tavla/app/(admin)/edit/[id]/components/Buttons/Copy.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/Buttons/Copy.tsx
@@ -1,11 +1,9 @@
 'use client'
 import { useToast } from '@entur/alert'
 import { Button, IconButton } from '@entur/button'
-import { CopyIcon, ExternalIcon } from '@entur/icons'
+import { CopyIcon } from '@entur/icons'
 import { Tooltip } from '@entur/tooltip'
 import { useLink } from 'hooks/useLink'
-import Link from 'next/link'
-import React from 'react'
 
 function Copy({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
     const { addToast } = useToast()
@@ -35,36 +33,4 @@ function Copy({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
         </Tooltip>
     )
 }
-
-function Open({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
-    const link = useLink(bid)
-    if (type === 'button') {
-        return (
-            <Button
-                variant="primary"
-                as={Link}
-                aria-label="Åpne tavle"
-                href={link ?? '/'}
-                target="_blank"
-            >
-                Åpne Tavle
-                <ExternalIcon />
-            </Button>
-        )
-    }
-
-    return (
-        <Tooltip content="Åpne tavle" placement="bottom">
-            <IconButton
-                as={Link}
-                aria-label="Åpne tavle"
-                href={link ?? '/'}
-                target="_blank"
-            >
-                <ExternalIcon />
-            </IconButton>
-        </Tooltip>
-    )
-}
-
-export { Open, Copy }
+export { Copy }

--- a/next-tavla/app/(admin)/edit/[id]/components/Buttons/Open.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/Buttons/Open.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { Button, IconButton } from '@entur/button'
+import { ExternalIcon } from '@entur/icons'
+import { Tooltip } from '@entur/tooltip'
+import { useLink } from 'hooks/useLink'
+import Link from 'next/link'
+import React from 'react'
+
+function Open({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
+    const link = useLink(bid)
+    if (type === 'button') {
+        return (
+            <Button
+                variant="primary"
+                as={Link}
+                aria-label="Åpne tavle"
+                href={link ?? '/'}
+                target="_blank"
+            >
+                Åpne Tavle
+                <ExternalIcon />
+            </Button>
+        )
+    }
+
+    return (
+        <Tooltip content="Åpne tavle" placement="bottom">
+            <IconButton
+                as={Link}
+                aria-label="Åpne tavle"
+                href={link ?? '/'}
+                target="_blank"
+            >
+                <ExternalIcon />
+            </IconButton>
+        </Tooltip>
+    )
+}
+
+export { Open }

--- a/next-tavla/app/(admin)/edit/[id]/components/Buttons/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/Buttons/index.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useToast } from '@entur/alert'
+import { Button, IconButton } from '@entur/button'
+import { CopyIcon, ExternalIcon } from '@entur/icons'
+import { Delete } from 'app/(admin)/boards/components/Column/Delete'
+import { useLink } from 'hooks/useLink'
+import Link from 'next/link'
+import React from 'react'
+import { TBoard } from 'types/settings'
+
+function Buttons({ board }: { board: TBoard }) {
+    const link = useLink(board.id)
+    return (
+        <div className="flexRow g-2 w-100 alignCenter">
+            <OpenButton link={link} type="button" />
+
+            <CopyButton link={link} type="button" />
+
+            <Delete board={board} type="button" />
+        </div>
+    )
+}
+
+function CopyButton({
+    type,
+    link,
+}: {
+    type?: 'button' | 'icon'
+    link?: string
+}) {
+    const { addToast } = useToast()
+
+    const copy = () => {
+        navigator.clipboard.writeText(link ?? '')
+        addToast('Lenke til Tavla kopiert')
+    }
+    return type === 'button' ? (
+        <Button variant="secondary" aria-label="Kopier tavle" onClick={copy}>
+            Kopier Tavle
+            <CopyIcon />
+        </Button>
+    ) : (
+        <IconButton aria-label="Kopier tavle" onClick={copy}>
+            <CopyIcon />
+        </IconButton>
+    )
+}
+
+function OpenButton({
+    type,
+    link,
+}: {
+    type?: 'button' | 'icon'
+    link?: string
+}) {
+    return type === 'button' ? (
+        <Button
+            variant="primary"
+            as={Link}
+            aria-label="Åpne tavle"
+            href={link ?? '/'}
+            target="_blank"
+        >
+            Åpne Tavle
+            <ExternalIcon />
+        </Button>
+    ) : (
+        <IconButton
+            as={Link}
+            aria-label="Åpne tavle"
+            href={link ?? '/'}
+            target="_blank"
+        >
+            <ExternalIcon />
+        </IconButton>
+    )
+}
+
+export { Buttons, OpenButton, CopyButton }

--- a/next-tavla/app/(admin)/edit/[id]/components/Buttons/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/Buttons/index.tsx
@@ -7,7 +7,7 @@ import { useLink } from 'hooks/useLink'
 import Link from 'next/link'
 import React from 'react'
 
-function CopyButton({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
+function Copy({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
     const { addToast } = useToast()
     const link = useLink(bid)
     const copy = () => {
@@ -36,7 +36,7 @@ function CopyButton({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
     )
 }
 
-function OpenButton({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
+function Open({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
     const link = useLink(bid)
     if (type === 'button') {
         return (
@@ -67,4 +67,4 @@ function OpenButton({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
     )
 }
 
-export { OpenButton, CopyButton }
+export { Open, Copy }

--- a/next-tavla/app/(admin)/edit/[id]/components/Buttons/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/Buttons/index.tsx
@@ -2,78 +2,69 @@
 import { useToast } from '@entur/alert'
 import { Button, IconButton } from '@entur/button'
 import { CopyIcon, ExternalIcon } from '@entur/icons'
-import { Delete } from 'app/(admin)/boards/components/Column/Delete'
+import { Tooltip } from '@entur/tooltip'
 import { useLink } from 'hooks/useLink'
 import Link from 'next/link'
 import React from 'react'
-import { TBoard } from 'types/settings'
 
-function Buttons({ board }: { board: TBoard }) {
-    const link = useLink(board.id)
-    return (
-        <div className="flexRow g-2 w-100 alignCenter">
-            <OpenButton link={link} type="button" />
-
-            <CopyButton link={link} type="button" />
-
-            <Delete board={board} type="button" />
-        </div>
-    )
-}
-
-function CopyButton({
-    type,
-    link,
-}: {
-    type?: 'button' | 'icon'
-    link?: string
-}) {
+function CopyButton({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
     const { addToast } = useToast()
-
+    const link = useLink(bid)
     const copy = () => {
         navigator.clipboard.writeText(link ?? '')
         addToast('Lenke til Tavla kopiert')
     }
-    return type === 'button' ? (
-        <Button variant="secondary" aria-label="Kopier tavle" onClick={copy}>
-            Kopier Tavle
-            <CopyIcon />
-        </Button>
-    ) : (
-        <IconButton aria-label="Kopier tavle" onClick={copy}>
-            <CopyIcon />
-        </IconButton>
+
+    if (type === 'button') {
+        return (
+            <Button
+                variant="secondary"
+                aria-label="Kopier tavle"
+                onClick={copy}
+            >
+                Kopier Tavle
+                <CopyIcon />
+            </Button>
+        )
+    }
+    return (
+        <Tooltip content="Kopier lenke" placement="bottom">
+            <IconButton aria-label="Kopier tavle" onClick={copy}>
+                <CopyIcon />
+            </IconButton>
+        </Tooltip>
     )
 }
 
-function OpenButton({
-    type,
-    link,
-}: {
-    type?: 'button' | 'icon'
-    link?: string
-}) {
-    return type === 'button' ? (
-        <Button
-            variant="primary"
-            as={Link}
-            aria-label="Åpne tavle"
-            href={link ?? '/'}
-            target="_blank"
-        >
-            Åpne Tavle
-            <ExternalIcon />
-        </Button>
-    ) : (
-        <IconButton
-            as={Link}
-            aria-label="Åpne tavle"
-            href={link ?? '/'}
-            target="_blank"
-        >
-            <ExternalIcon />
-        </IconButton>
+function OpenButton({ type, bid }: { type?: 'button' | 'icon'; bid?: string }) {
+    const link = useLink(bid)
+    if (type === 'button') {
+        return (
+            <Button
+                variant="primary"
+                as={Link}
+                aria-label="Åpne tavle"
+                href={link ?? '/'}
+                target="_blank"
+            >
+                Åpne Tavle
+                <ExternalIcon />
+            </Button>
+        )
+    }
+
+    return (
+        <Tooltip content="Åpne tavle" placement="bottom">
+            <IconButton
+                as={Link}
+                aria-label="Åpne tavle"
+                href={link ?? '/'}
+                target="_blank"
+            >
+                <ExternalIcon />
+            </IconButton>
+        </Tooltip>
     )
 }
 
-export { Buttons, OpenButton, CopyButton }
+export { OpenButton, CopyButton }

--- a/next-tavla/app/(admin)/edit/[id]/page.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/page.tsx
@@ -4,13 +4,10 @@ import { addTile, getBoard } from './actions'
 import { Heading1, Heading2 } from '@entur/typography'
 import classes from './styles.module.css'
 import { TileCard } from './components/TileCard'
-import { Button } from '@entur/button'
-import Link from 'next/link'
 import { MetaSettings } from './components/MetaSettings'
 import { TileSelector } from 'app/(admin)/components/TileSelector'
 import { formDataToTile } from 'app/(admin)/components/TileSelector/utils'
 import { revalidatePath } from 'next/cache'
-import { ExternalIcon } from '@entur/icons'
 import { Metadata } from 'next'
 import { getOrganizationForBoard } from './components/TileCard/actions'
 import { ClientBoard } from './components/ClientBoard'
@@ -45,16 +42,9 @@ export default async function EditPage({ params }: TProps) {
                 <Heading1 className="m-0">
                     Rediger tavle {board.meta?.title}
                 </Heading1>
-                <Button
-                    as={Link}
-                    aria-label="Åpne tavle"
-                    href={`/${params.id}`}
-                    target="_blank"
-                    variant="secondary"
-                >
-                    Åpne tavle
-                    <ExternalIcon />
-                </Button>
+                <div className="flexRow g-2">
+                    <Buttons board={board} />
+                </div>
             </div>
             <MetaSettings bid={params.id} meta={board.meta} />
             <Heading2 className="mt-3">Stoppesteder i tavla</Heading2>

--- a/next-tavla/app/(admin)/edit/[id]/page.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/page.tsx
@@ -12,6 +12,8 @@ import { Metadata } from 'next'
 import { getOrganizationForBoard } from './components/TileCard/actions'
 import { ClientBoard } from './components/ClientBoard'
 import { getUser, hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
+import { CopyButton, OpenButton } from './components/Buttons'
+import { Delete } from 'app/(admin)/boards/components/Column/Delete'
 
 type TProps = {
     params: { id: TBoardID }
@@ -30,7 +32,6 @@ export default async function EditPage({ params }: TProps) {
     if (!user || !user.uid) return redirect('/')
 
     const board = await getBoard(params.id)
-
     const organization = await getOrganizationForBoard(params.id)
 
     const access = await hasBoardEditorAccess(params.id)
@@ -43,7 +44,9 @@ export default async function EditPage({ params }: TProps) {
                     Rediger tavle {board.meta?.title}
                 </Heading1>
                 <div className="flexRow g-2">
-                    <Buttons board={board} />
+                    <OpenButton bid={board.id} type="button" />
+                    <CopyButton bid={board.id} type="button" />
+                    <Delete board={board} type="button" />
                 </div>
             </div>
             <MetaSettings bid={params.id} meta={board.meta} />

--- a/next-tavla/app/(admin)/edit/[id]/page.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/page.tsx
@@ -12,8 +12,9 @@ import { Metadata } from 'next'
 import { getOrganizationForBoard } from './components/TileCard/actions'
 import { ClientBoard } from './components/ClientBoard'
 import { getUser, hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
-import { Copy, Open } from './components/Buttons'
 import { Delete } from 'app/(admin)/boards/components/Column/Delete'
+import { Open } from './components/Buttons/Open'
+import { Copy } from './components/Buttons/Copy'
 
 type TProps = {
     params: { id: TBoardID }

--- a/next-tavla/app/(admin)/edit/[id]/page.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/page.tsx
@@ -12,7 +12,7 @@ import { Metadata } from 'next'
 import { getOrganizationForBoard } from './components/TileCard/actions'
 import { ClientBoard } from './components/ClientBoard'
 import { getUser, hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
-import { CopyButton, OpenButton } from './components/Buttons'
+import { Copy, Open } from './components/Buttons'
 import { Delete } from 'app/(admin)/boards/components/Column/Delete'
 
 type TProps = {
@@ -44,8 +44,8 @@ export default async function EditPage({ params }: TProps) {
                     Rediger tavle {board.meta?.title}
                 </Heading1>
                 <div className="flexRow g-2">
-                    <OpenButton bid={board.id} type="button" />
-                    <CopyButton bid={board.id} type="button" />
+                    <Open bid={board.id} type="button" />
+                    <Copy bid={board.id} type="button" />
                     <Delete board={board} type="button" />
                 </div>
             </div>


### PR DESCRIPTION
I tried to 'reuse' the buttons from `Actions.tsx`, and changes were made since they were iconbuttons and not normal buttons. They are still unchanged in the boards overview page, see picture below.

- <img width="1612" alt="image" src="https://github.com/entur/tavla/assets/74315929/1d33375c-3705-4b52-a645-1cdfb5505027">

- ![image](https://github.com/entur/tavla/assets/74315929/2b41dab1-83d2-4a90-b9ea-883376d5b148)
