### PR TITLE
fix(create): create board with no default org settings

### DIFF
--- a/next-tavla/app/(admin)/components/CreateBoard/index.tsx
+++ b/next-tavla/app/(admin)/components/CreateBoard/index.tsx
@@ -96,7 +96,7 @@ function CreateBoard() {
                                 ...board,
                                 meta: { ...board?.meta, title: name },
                             } as TBoard)
-                            setOrganization(organization)
+                            setOrganization(personal ? undefined : organization)
                             setFormError(undefined)
 
                             router.push(getPathWithParams('stops'))


### PR DESCRIPTION
SetOrganization to undefined if user has ticked checkbox. No default counties will show on next page

![image](https://github.com/entur/tavla/assets/74315929/6281c580-df5b-4266-891d-b32f96ef1d6d)
 