### PR TITLE
style(organization): less spacing between heading and leadparagraph

### DIFF
--- a/next-tavla/app/(admin)/organizations/[id]/page.tsx
+++ b/next-tavla/app/(admin)/organizations/[id]/page.tsx
@@ -50,14 +50,16 @@ async function EditOrganizationPage({ params }: TProps) {
 
     return (
         <main className={classes.root}>
-            <Heading1 margin="top">{organization.name}</Heading1>
-            <LeadParagraph margin="none" className="mb-4">
-                Valgene som tas blir satt som standard når det opprettes en
-                tavle i organisasjonen &quot;{organization.name}&quot;. Valgene
-                kan fortsatt justeres i hver enkelt tavle (med unntak av logo).
-                Innstillingene vil ikke påvirke tavler som allerede har blitt
-                opprettet.
-            </LeadParagraph>
+            <div>
+                <Heading1 margin="top">{organization.name}</Heading1>
+                <LeadParagraph margin="none" className="mb-2">
+                    Valgene som tas blir satt som standard når det opprettes en
+                    tavle i organisasjonen &quot;{organization.name}&quot;.
+                    Valgene kan fortsatt justeres i hver enkelt tavle (med
+                    unntak av logo). Innstillingene vil ikke påvirke tavler som
+                    allerede har blitt opprettet.
+                </LeadParagraph>
+            </div>
             <div className={classes.organization}>
                 <MemberAdministration
                     members={usersReq.users}


### PR DESCRIPTION
In edit organization, based on design sketches. Designer approves the visual changes

Before:
- ![image](https://github.com/entur/tavla/assets/74315929/64631f13-38e0-4b0f-a5e8-eea4b70b5bfc)

After:
- ![image](https://github.com/entur/tavla/assets/74315929/62c0d6ad-f913-4fc8-808f-9d09dd69779f)
