### PR TITLE
fix(footer): switch text and logo based on theme

### DIFF
--- a/next-tavla/pages/[id].tsx
+++ b/next-tavla/pages/[id].tsx
@@ -48,7 +48,7 @@ function BoardPage({
                     organizationLogo={organizationLogo}
                 />
                 <Board board={board} />
-                {organizationLogo && <Footer />}
+                {organizationLogo && <Footer theme={board.theme ?? 'dark'} />}
             </div>
         </div>
     )

--- a/next-tavla/src/Shared/components/Footer/index.tsx
+++ b/next-tavla/src/Shared/components/Footer/index.tsx
@@ -1,13 +1,25 @@
 import Image from 'next/image'
-import EnturLogo from 'assets/logos/entur/Enturlogo_White.svg'
+import EnturLogoWhite from 'assets/logos/entur/Enturlogo_White.svg'
+import EnturLogoBlue from 'assets/logos/entur/Enturlogo_Blue.svg'
+import { TTheme } from 'types/settings'
 
-function Footer() {
+function Footer({ theme }: { theme: TTheme }) {
     return (
-        <footer className="flex flex-row justify-start items-center text-2xl">
+        <footer className="flex flex-row justify-start items-center text-2xl text-primary">
             <span>Tjenesten leveres av</span>
-            <Image src={EnturLogo} alt="Entur logo" height={70} />
+            <Image src={getLogo(theme)} alt="Entur logo" height={70} />
         </footer>
     )
 }
 
 export { Footer }
+
+export function getLogo(theme: TTheme) {
+    switch (theme) {
+        case 'light':
+            return EnturLogoBlue
+        case 'dark':
+        case 'entur':
+            return EnturLogoWhite
+    }
+}

--- a/next-tavla/src/Shared/components/Footer/index.tsx
+++ b/next-tavla/src/Shared/components/Footer/index.tsx
@@ -15,11 +15,6 @@ function Footer({ theme }: { theme: TTheme }) {
 export { Footer }
 
 export function getLogo(theme: TTheme) {
-    switch (theme) {
-        case 'light':
-            return EnturLogoBlue
-        case 'dark':
-        case 'entur':
-            return EnturLogoWhite
-    }
+    if (theme === 'light') return EnturLogoBlue
+    return EnturLogoWhite
 }


### PR DESCRIPTION


DARK
![image](https://github.com/entur/tavla/assets/43408175/727135cd-ec33-4aa1-985e-75799d0a0314)

LIGHT
![image](https://github.com/entur/tavla/assets/43408175/72449009-9108-427f-8837-f305cdd6da63)

ENTUR
![image](https://github.com/entur/tavla/assets/43408175/076cc952-4fab-46cd-80e4-024890433ddc)
