### PR TITLE
fix(edit): switch toogling and automatic off-state on walking distance

### DIFF
--- a/next-tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -181,7 +181,7 @@ function TileCard({ bid, tile }: { bid: TBoardID; tile: TTile }) {
                                         tile.walkingDistance?.visible ?? false
                                     }
                                     disabled={
-                                        tile.walkingDistance?.visible ?? false
+                                        tile.walkingDistance ? false : true
                                     }
                                 >
                                     Vis gåavstand


### PR DESCRIPTION
There were two problems: 
- It was not possible to turn on/off the switch if it was just enabled and saved
- The switch were automatically off if other stuffed were changed and saved (even if it should have been on)

