### PR TITLE
fix(edit): edit board page when meta field missing

### DIFF
--- a/next-tavla/app/(admin)/edit/[id]/components/MetaSettings/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/MetaSettings/index.tsx
@@ -11,7 +11,7 @@ import { DEFAULT_BOARD_NAME } from 'app/(admin)/utils/constants'
 import { useToast } from '@entur/alert'
 import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
 
-function MetaSettings({ bid, meta }: { bid: TBoardID; meta: TMeta }) {
+function MetaSettings({ bid, meta }: { bid: TBoardID; meta?: TMeta }) {
     const { addToast } = useToast()
     return (
         <>
@@ -34,7 +34,7 @@ function MetaSettings({ bid, meta }: { bid: TBoardID; meta: TMeta }) {
                     <TextField
                         name="name"
                         className="w-full"
-                        defaultValue={meta.title ?? DEFAULT_BOARD_NAME}
+                        defaultValue={meta?.title ?? DEFAULT_BOARD_NAME}
                         label="Navn på tavlen"
                         maxLength={30}
                     />
@@ -46,7 +46,7 @@ function MetaSettings({ bid, meta }: { bid: TBoardID; meta: TMeta }) {
                     </SubmitButton>
                 </div>
             </form>
-            <Address bid={bid} location={meta.location} />
+            <Address bid={bid} location={meta?.location} />
             <form
                 action={async (data: FormData) => {
                     const font = data.get('font') as TFontSize
@@ -56,7 +56,7 @@ function MetaSettings({ bid, meta }: { bid: TBoardID; meta: TMeta }) {
                 className="box flex flex-col justify-between"
             >
                 <Heading3 margin="bottom">Tekststørrelse </Heading3>
-                <FontChoiceChip font={meta.fontSize ?? 'medium'} />
+                <FontChoiceChip font={meta?.fontSize ?? 'medium'} />
                 <div className="flex flex-row mt-8 justify-end">
                     <SubmitButton variant="secondary" className="max-sm:w-full">
                         Lagre tekststørrelse

--- a/next-tavla/app/(admin)/edit/[id]/page.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/page.tsx
@@ -16,6 +16,7 @@ import { Open } from './components/Buttons/Open'
 import { Copy } from './components/Buttons/Copy'
 import { Footer } from './components/Footer'
 import { RefreshButton } from './components/RefreshButton'
+import { DEFAULT_BOARD_NAME } from 'app/(admin)/utils/constants'
 
 type TProps = {
     params: { id: TBoardID }
@@ -25,7 +26,7 @@ export async function generateMetadata({ params }: TProps): Promise<Metadata> {
     const { id } = params
     const board = await getBoard(id)
     return {
-        title: `${board.meta?.title} | Entur Tavla`,
+        title: `${board.meta?.title ?? DEFAULT_BOARD_NAME} | Entur Tavla`,
     }
 }
 
@@ -69,7 +70,7 @@ export default async function EditPage({ params }: TProps) {
 
                         const tile = await getWalkingDistanceTile(
                             formDataToTile(data, organization),
-                            board.meta.location,
+                            board.meta?.location,
                         )
                         if (!tile.placeId) return
                         await addTile(params.id, tile)


### PR DESCRIPTION
Cause: If meta-settings are not present, location is undefined. This causes the server to throw an error in edit board page. 

Before: Throws error in production
- ![image](https://github.com/entur/tavla/assets/74315929/b85eea77-82e2-488c-8eec-4891a19fb7a3)


After
- <img width="1499" alt="image" src="https://github.com/entur/tavla/assets/74315929/b5c6838d-2ab2-4066-8795-7f923d5c7a90">
