### PR TITLE
style(landing): compact view

### DIFF
--- a/next-tavla/app/page.tsx
+++ b/next-tavla/app/page.tsx
@@ -40,7 +40,7 @@ async function Landing() {
                             for reisende
                         </Heading1>
                     </div>
-                    <div className="flex flex-row justify-center overflow-hidden py-2">
+                    <div className="flex flex-row justify-center overflow-hidden pt-2 pb-4">
                         <Image
                             src={landingImage}
                             alt=""

--- a/next-tavla/app/page.tsx
+++ b/next-tavla/app/page.tsx
@@ -28,18 +28,23 @@ async function Landing() {
             <TopNavigation loggedIn={loggedIn} />
             <main>
                 <Welcome />
-                <div className="flex flex-col justify-center pb-10 pt-6 lg:pt-16">
+                <div className="flex flex-col justify-center pb-10 pt-6">
                     <div className="flex flex-col py-4 container mx-auto">
-                        <Heading1>Lag din egen avgangstavle</Heading1>
-                        <Heading1 className="italic text-highlight font-normal">
+                        <Heading1 margin="none">
+                            Lag din egen avgangstavle
+                        </Heading1>
+                        <Heading1
+                            className="italic !text-highlight !font-normal"
+                            margin="bottom"
+                        >
                             for reisende
                         </Heading1>
                     </div>
-                    <div className="flex flex-row justify-center overflow-hidden py-16 md:py-32">
+                    <div className="flex flex-row justify-center overflow-hidden py-2">
                         <Image
                             src={landingImage}
                             alt=""
-                            className="scale-150"
+                            className="scale-125"
                         />
                     </div>
 

--- a/next-tavla/app/privacy/components/ExpandableInfo.tsx
+++ b/next-tavla/app/privacy/components/ExpandableInfo.tsx
@@ -71,17 +71,19 @@ function ExpandableInfo() {
                         <EnturLink
                             as={Link}
                             href="https://firebase.google.com/docs/auth"
+                            className="items-center inline-flex flex-row gap-1"
                         >
                             Firebase Auth
-                            <ExternalIcon className="ml-8" />
+                            <ExternalIcon />
                         </EnturLink>{' '}
                         og{' '}
                         <EnturLink
                             as={Link}
                             href="https://firebase.google.com/support/privacy"
+                            className="items-center inline-flex flex-row gap-1"
                         >
                             Firebase Privacy Policy
-                            <ExternalIcon className="ml-8" />
+                            <ExternalIcon />
                         </EnturLink>
                         .
                     </ListItem>

--- a/next-tavla/app/privacy/page.tsx
+++ b/next-tavla/app/privacy/page.tsx
@@ -4,7 +4,6 @@ import doves from 'assets/illustrations/Doves.png'
 import hedgehog from 'assets/illustrations/Hedgehog.png'
 import squirrel from 'assets/illustrations/Squirrel.png'
 import Image from 'next/image'
-import { Footer } from 'app/(admin)/components/Footer'
 import { TopNavigation } from 'app/(admin)/components/TopNavigation'
 import { cookies } from 'next/headers'
 import { ExpandableInfo } from './components/ExpandableInfo'
@@ -62,7 +61,6 @@ async function Privacy() {
                 </div>
                 <ExpandableInfo />
             </main>
-            <Footer />
         </>
     )
 }


### PR DESCRIPTION
Also removed double footer in /privacy page, and fix aligning of icons in links in /privacy.

**Before:** 
![image](https://github.com/entur/tavla/assets/43408175/7c371fe4-c30c-43f2-83d1-745ca7ea9f6c)


**After:** 
![image](https://github.com/entur/tavla/assets/43408175/21731d16-fd2c-4b05-8d60-7244786a8a32)
