### PR TITLE
feat(boards): add org to search

### DIFF
--- a/next-tavla/app/(admin)/boards/components/Column/Name.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Name.tsx
@@ -3,17 +3,18 @@ import { Column } from './Column'
 import { TBoard } from 'types/settings'
 import Link from 'next/link'
 
-function Name({ board }: { board?: TBoard }) {
-    if (!board) return <Column column="name">{DEFAULT_BOARD_NAME}</Column>
+function Name({ board }: { board: TBoard }) {
     return (
         <Column column="name">
             <Link
                 href={`/edit/${board.id}`}
                 className="hidden sm:block hover:underline"
             >
-                {board.meta.title}
+                {board.meta.title ?? DEFAULT_BOARD_NAME}
             </Link>
-            <p className="block sm:hidden">{board.meta.title}</p>
+            <p className="block sm:hidden">
+                {board.meta.title ?? DEFAULT_BOARD_NAME}
+            </p>
         </Column>
     )
 }

--- a/next-tavla/app/(admin)/boards/components/Column/Organization.tsx
+++ b/next-tavla/app/(admin)/boards/components/Column/Organization.tsx
@@ -1,9 +1,13 @@
 import Link from 'next/link'
 import { Column } from './Column'
 import { TOrganization } from 'types/settings'
+import { DEFAULT_ORGANIZATION_NAME } from 'app/(admin)/utils/constants'
 
 function Organization({ organization }: { organization?: TOrganization }) {
-    if (!organization) return <Column column="organization">Privat</Column>
+    if (!organization)
+        return (
+            <Column column="organization">{DEFAULT_ORGANIZATION_NAME}</Column>
+        )
 
     return (
         <Column column="organization">

--- a/next-tavla/app/(admin)/boards/components/Search/index.tsx
+++ b/next-tavla/app/(admin)/boards/components/Search/index.tsx
@@ -13,7 +13,7 @@ function Search() {
     }, [replace, search])
     return (
         <TextField
-            label="Søk på navn på tavle"
+            label="Søk på navn på tavle eller organisasjon"
             prepend={<SearchIcon inline aria-hidden="true" />}
             value={search}
             onChange={(e) => {

--- a/next-tavla/app/(admin)/boards/components/TableRows/index.tsx
+++ b/next-tavla/app/(admin)/boards/components/TableRows/index.tsx
@@ -5,7 +5,10 @@ import { TBoard, TBoardWithOrganizaion } from 'types/settings'
 import { uniq } from 'lodash'
 import { TTag } from 'types/meta'
 import { useSearchParam } from '../../hooks/useSearchParam'
-import { DEFAULT_BOARD_NAME } from 'app/(admin)/utils/constants'
+import {
+    DEFAULT_BOARD_NAME,
+    DEFAULT_ORGANIZATION_NAME,
+} from 'app/(admin)/utils/constants'
 import { DEFAULT_BOARD_COLUMNS, TBoardsColumn } from 'app/(admin)/utils/types'
 
 function TableRows({
@@ -21,8 +24,12 @@ function TableRows({
         'i',
     )
 
-    const filterByTitle = (board: TBoard) =>
-        searchFilter.test(board?.meta?.title ?? DEFAULT_BOARD_NAME)
+    const filterByTitleAndOrgName = (boardWithOrg: TBoardWithOrganizaion) =>
+        searchFilter.test(
+            `${boardWithOrg.board?.meta?.title ?? DEFAULT_BOARD_NAME} ${
+                boardWithOrg.organization?.name ?? DEFAULT_ORGANIZATION_NAME
+            }`,
+        )
 
     const filterByTags = (board: TBoard) =>
         filter.length === 0 ||
@@ -32,7 +39,7 @@ function TableRows({
         <>
             {boardsWithOrg
                 .filter((boardWithOrg: TBoardWithOrganizaion) =>
-                    filterByTitle(boardWithOrg.board),
+                    filterByTitleAndOrgName(boardWithOrg),
                 )
                 .filter((boardWithOrg: TBoardWithOrganizaion) =>
                     filterByTags(boardWithOrg.board),

--- a/next-tavla/app/(admin)/boards/components/TableRows/index.tsx
+++ b/next-tavla/app/(admin)/boards/components/TableRows/index.tsx
@@ -19,17 +19,23 @@ function TableRows({
     const search = useSearchParam('search') ?? ''
     const filter = useSearchParam('tags')?.split(',') ?? []
     const sortFunction = useSortBoardFunction()
-    const searchFilter = new RegExp(
-        search.replace(/[^a-z/Wæøå0-9- ]+/g, ''),
-        'i',
-    )
+    const searchFilters = search
+        .split(' ')
+        .map((part) => new RegExp(part.replace(/[^a-z/Wæøå0-9- ]+/g, ''), 'i'))
 
     const filterByTitleAndOrgName = (boardWithOrg: TBoardWithOrganizaion) =>
-        searchFilter.test(
-            `${boardWithOrg.board?.meta?.title ?? DEFAULT_BOARD_NAME} ${
-                boardWithOrg.organization?.name ?? DEFAULT_ORGANIZATION_NAME
-            }`,
-        )
+        searchFilters
+            .map(
+                (filter) =>
+                    filter.test(
+                        boardWithOrg?.board.meta.title ?? DEFAULT_BOARD_NAME,
+                    ) ||
+                    filter.test(
+                        boardWithOrg.organization?.name ??
+                            DEFAULT_ORGANIZATION_NAME,
+                    ),
+            )
+            .every((e) => e === true)
 
     const filterByTags = (board: TBoard) =>
         filter.length === 0 ||

--- a/next-tavla/app/(admin)/utils/constants.ts
+++ b/next-tavla/app/(admin)/utils/constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_BOARD_NAME = 'Tavle uten navn'
+export const DEFAULT_ORGANIZATION_NAME = 'Privat'
 
 export const FIREBASE_DEV_CONFIG = {
     apiKey: 'AIzaSyCjyL7k4AehY4M95cxBVaW4LJTy6JNdTjo',


### PR DESCRIPTION
Det er ikke mulig å både søke på tavle navn og organisasjon, kun en av delene.

![image](https://github.com/entur/tavla/assets/43408175/30007169-4cd1-4079-8818-c5f643579e9d)
