### PR TITLE
fix(create):empty org dropdown on personal board choice

### DIFF
--- a/next-tavla/app/(admin)/components/CreateBoard/index.tsx
+++ b/next-tavla/app/(admin)/components/CreateBoard/index.tsx
@@ -154,7 +154,7 @@ function NameAndOrganizationSelector({
             <Dropdown
                 items={organizations}
                 label="Dine organisasjoner"
-                selectedItem={selectedOrganization}
+                selectedItem={personal ? null : selectedOrganization}
                 onChange={setSelectedOrganization}
                 clearable
                 className="mb-4"


### PR DESCRIPTION
fix this:
- <img width="764" alt="image" src="https://github.com/entur/tavla/assets/74315929/c6c39b39-cfec-4965-8934-af5cca4fbd0a">

Now, the dropdown is empty when disabled