### PR TITLE
fix(verify): manual check if email is verified

### DIFF
--- a/next-tavla/app/(admin)/components/Login/Email.tsx
+++ b/next-tavla/app/(admin)/components/Login/Email.tsx
@@ -45,7 +45,7 @@ function Email() {
             const uid = await credential.user.getIdToken()
             const error = await login(uid)
             if (error && auth.currentUser) {
-                sendEmailVerification(auth.currentUser)
+                await sendEmailVerification(auth.currentUser)
                 return getFormFeedbackForError(error)
             }
         } catch (e: unknown) {


### PR DESCRIPTION
Tried to follow this turtorial: https://firebase.google.com/docs/reference/rest/auth#section-confirm-email-verification

When doing this curl command (with the right api-key and oob code):
```
curl 'https://identitytoolkit.googleapis.com/v1/accounts:update?key=[API_KEY]' \
-H 'Content-Type: application/json' --data-binary '{"oobCode":"[VERIFICATION_CODE]"}'
```
This is the output:
![image](https://github.com/entur/tavla/assets/43408175/312c60a8-1bd3-40bd-849d-559f69601d24)

By using the oobCode one can find the field to check if the email is verified even thought the message we are displaying to the user says otherwise. 

It is hard to check this using the emulator, so it need to be checked in the dev-env. 

If the `applyActionCode` funtion is failing (as it does if one presses the link from the outlook-email), it goes to the `catch`-block trying to manually check if the email is verified. 