### PR TITLE
fix(boards):Text color preview

### DIFF
--- a/next-tavla/app/page.tsx
+++ b/next-tavla/app/page.tsx
@@ -52,7 +52,7 @@ function Landing() {
                         <div className="flex flex-col xl:flex-row gap-4">
                             <div
                                 className="xl:w-1/2 h-[60vh] overflow-y-hidden rounded-2xl"
-                                data-theme="entur"
+                                data-theme="dark"
                             >
                                 <Preview boards={previewBoards} />
                             </div>

--- a/next-tavla/src/Board/scenarios/Table/index.tsx
+++ b/next-tavla/src/Board/scenarios/Table/index.tsx
@@ -33,7 +33,9 @@ function Table({
             </div>
         )
 
-    const theme = document.querySelector('.root')?.getAttribute('data-theme')
+    const theme = document
+        .querySelector('[data-theme]')
+        ?.getAttribute('data-theme')
 
     if (departures.length === 0)
         return (
@@ -43,7 +45,7 @@ function Table({
                     alt=""
                     className="h-[6em] w-[6em] lg:h-[15em] lg:w-[15em] sm:max-h-[10em] sm:max-w-[10em]"
                 />
-                <Paragraph className="text-primary sm:pb-8 ">
+                <Paragraph className="!text-primary sm:pb-8 ">
                     Ingen avganger de neste 24 timene.
                 </Paragraph>
             </div>


### PR DESCRIPTION
Before (in dark mode):
- ![image](https://github.com/user-attachments/assets/b278f04e-b4fc-4a20-b864-7079f707a0b8)
After:
- ![image](https://github.com/user-attachments/assets/98101e61-d184-45c1-943b-c915cce32079)

Also changed preview board on homepage to be darkmode:
- ![image](https://github.com/user-attachments/assets/5d2234a4-10dc-4dea-9323-aac2bd4a1676)
