### PR TITLE
chore(board): spacing between tilecard name and action buttons

### DIFF
--- a/next-tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -114,9 +114,9 @@ function TileCard({
                     isOpen ? 'rounded-t' : 'rounded'
                 }`}
             >
-                <div className="flex flex-row gap-4 items-center">
+                <div className="flex flex-row gap-4 items-center mr-2">
                     <Heading3 margin="none">{tile.name}</Heading3>
-                    <div className="flex flex-row gap-4 h-8">
+                    <div className="hidden sm:flex flex-row gap-4 h-8">
                         {transportModes.map((tm) => (
                             <TransportIcon transportMode={tm} key={tm} />
                         ))}


### PR DESCRIPTION
The change applies to mobile view
before:
- ![image](https://github.com/user-attachments/assets/a95e0e6a-20f3-4d0a-b749-793cc4b5d9cd)

After:
- ![image](https://github.com/user-attachments/assets/f1683db8-061f-42aa-ad4a-5ef19ef85c5a)

