### PR TITLE
fix(offset): not show checkbox if distance is NaN

### DIFF
--- a/next-tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/next-tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -288,26 +288,31 @@ function TileCard({
                                 }}
                                 readOnly={offsetBasedOnWalkingDistance}
                             />
-                            {address && (
-                                <Checkbox
-                                    checked={offsetBasedOnWalkingDistance}
-                                    onChange={() => {
-                                        if (!offsetBasedOnWalkingDistance)
-                                            setOffset(walkingDistanceInMinutes)
-                                        else setOffset(tile.offset ?? '')
+                            {address &&
+                                !Number.isNaN(
+                                    tile.walkingDistance?.distance,
+                                ) && (
+                                    <Checkbox
+                                        checked={offsetBasedOnWalkingDistance}
+                                        onChange={() => {
+                                            if (!offsetBasedOnWalkingDistance)
+                                                setOffset(
+                                                    walkingDistanceInMinutes,
+                                                )
+                                            else setOffset(tile.offset ?? '')
 
-                                        setOffsetBasedOnWalkingDistance(
-                                            !offsetBasedOnWalkingDistance,
-                                        )
+                                            setOffsetBasedOnWalkingDistance(
+                                                !offsetBasedOnWalkingDistance,
+                                            )
 
-                                        posthog.capture(
-                                            'OFFSET_BASED_ON_WALKING_DISTANCE_BTN_CLICK',
-                                        )
-                                    }}
-                                >
-                                    Forskyv basert på gåavstand
-                                </Checkbox>
-                            )}
+                                            posthog.capture(
+                                                'OFFSET_BASED_ON_WALKING_DISTANCE_BTN_CLICK',
+                                            )
+                                        }}
+                                    >
+                                        Forskyv basert på gåavstand
+                                    </Checkbox>
+                                )}
                         </div>
 
                         <Heading4>Kolonner</Heading4>


### PR DESCRIPTION
De eneste casene man vil vise checkboken for å forskyve tiden basert på gåavstand er: 
- Når man har adressen og distansen er et nummer
- Når man har adressen og distansen er undefined

Man vil altså ikke vise checkboksen om:
- Man ikke har en adresse
- Distansen er satt til `NaN` (lokasjonen og stoppestedet er for langt unna hverandre). 

Eksempel om et stoppested er i Trondheim og et er i Oslo, og adressen er satt til å være i Oslo: 

![image](https://github.com/user-attachments/assets/cb31e455-e9a7-4f61-b1db-c884c36adc37)
