### PR TITLE
feat(create): add organization to create board modal 

### DIFF
--- a/tavla/app/(admin)/components/CreateBoard/index.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/index.tsx
@@ -1,10 +1,10 @@
 'use client'
 import { AddIcon } from '@entur/icons'
 import { Modal } from '@entur/modal'
-import { Heading3, Label } from '@entur/typography'
+import { Heading3, Label, Paragraph } from '@entur/typography'
 import { useState } from 'react'
-import { TBoard } from 'types/settings'
-import { TextField } from '@entur/form'
+import { TBoard, TOrganizationID } from 'types/settings'
+import { Checkbox, TextField } from '@entur/form'
 import {
     TFormFeedback,
     getFormFeedbackForError,
@@ -13,11 +13,25 @@ import {
 import { SubmitButton } from 'components/Form/SubmitButton'
 import { create } from './actions'
 import { useSearchParamsModal } from 'app/(admin)/hooks/useSearchParamsModal'
+import { Dropdown } from '@entur/dropdown'
+import { HiddenInput } from 'components/Form/HiddenInput'
+import { useOrganizations } from 'app/(admin)/hooks/useOrganizations'
 
 function CreateBoard() {
     const [open, close] = useSearchParamsModal('board')
 
     const [state, setFormError] = useState<TFormFeedback | undefined>()
+
+    const { organizations, selectedOrganization, setSelectedOrganization } =
+        useOrganizations()
+
+    const [personal, setPersonal] = useState<boolean>(false)
+
+    const reset = () => {
+        setPersonal(false)
+        setSelectedOrganization(null)
+        setFormError(undefined)
+    }
 
     return (
         <>
@@ -26,7 +40,7 @@ function CreateBoard() {
                 size="medium"
                 className="flex flex-col items-center"
                 onDismiss={() => {
-                    setFormError(undefined)
+                    reset()
                     close()
                 }}
                 closeLabel="Avbryt opprettelse av tavle"
@@ -39,26 +53,80 @@ function CreateBoard() {
                                 getFormFeedbackForError('board/name-missing'),
                             )
                         }
-                        await create({
+
+                        const organization = data.get(
+                            'organization',
+                        ) as TOrganizationID
+                        const personal = data.get('personal')
+                        if (!organization && !personal) {
+                            return setFormError(
+                                getFormFeedbackForError(
+                                    'create/organization-missing',
+                                ),
+                            )
+                        }
+
+                        const board = {
                             tiles: [],
                             meta: {
-                                title: name.substring(0, 30),
+                                title: name.substring(0, 50),
                             },
-                        } as TBoard)
+                        } as TBoard
+
+                        await create(board, organization)
+
+                        reset()
                     }}
                     className="w-full md:w-3/4"
                 >
-                    <Heading3>Hva skal tavlen hete?</Heading3>
+                    <Heading3>Velg navn og organisasjon for tavlen</Heading3>
+                    <Paragraph className="!mb-4">
+                        Gi tavlen et navn og legg den til i en organisasjon.
+                        Velger du en organisasjon vil alle i organisasjonen ha
+                        tilgang til tavlen.
+                    </Paragraph>
                     <Label>Gi tavlen et navn</Label>
                     <TextField
                         size="medium"
                         label="Navn"
                         id="name"
                         name="name"
-                        maxLength={30}
+                        maxLength={50}
                         required
                         {...getFormFeedbackForField('name', state)}
                     />
+
+                    <div className="mt-4">
+                        <Label>Legg til i en organisasjon</Label>
+                        <Dropdown
+                            items={organizations}
+                            label="Dine organisasjoner"
+                            selectedItem={
+                                personal ? null : selectedOrganization
+                            }
+                            onChange={setSelectedOrganization}
+                            clearable
+                            aria-required="true"
+                            className="mb-4"
+                            disabled={personal}
+                            {...getFormFeedbackForField('organization', state)}
+                        />
+                        <Checkbox
+                            checked={personal}
+                            onChange={() => {
+                                setPersonal(!personal)
+                                setFormError(undefined)
+                            }}
+                            name="personal"
+                        >
+                            Privat tavle
+                        </Checkbox>
+                        <HiddenInput
+                            id="organization"
+                            value={selectedOrganization?.value.id}
+                        />
+                    </div>
+
                     <div className="flex flex-row mt-8 justify-end">
                         <SubmitButton
                             variant="primary"

--- a/tavla/app/(admin)/components/CreateBoard/index.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/index.tsx
@@ -2,7 +2,7 @@
 import { AddIcon } from '@entur/icons'
 import { Modal } from '@entur/modal'
 import { Heading3, Label, Paragraph } from '@entur/typography'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { TBoard, TOrganizationID } from 'types/settings'
 import { Checkbox, TextField } from '@entur/form'
 import {
@@ -22,8 +22,12 @@ function CreateBoard() {
 
     const [state, setFormError] = useState<TFormFeedback | undefined>()
 
-    const { organizations, selectedOrganization, setSelectedOrganization } =
-        useOrganizations()
+    const {
+        organizations,
+        selectedOrganization,
+        setSelectedOrganization,
+        fetchOrganizations,
+    } = useOrganizations()
 
     const [personal, setPersonal] = useState<boolean>(false)
 
@@ -32,6 +36,10 @@ function CreateBoard() {
         setSelectedOrganization(null)
         setFormError(undefined)
     }
+
+    useEffect(() => {
+        if (open) fetchOrganizations()
+    }, [open, fetchOrganizations])
 
     return (
         <>

--- a/tavla/app/(admin)/components/CreateBoard/index.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/index.tsx
@@ -108,11 +108,11 @@ function CreateBoard() {
                             clearable
                             aria-required="true"
                             className="mb-4"
-                            disabled={personal}
+                            disabled={personal || organizations().length == 0}
                             {...getFormFeedbackForField('organization', state)}
                         />
                         <Checkbox
-                            checked={personal}
+                            checked={personal || organizations().length == 0}
                             onChange={() => {
                                 setPersonal(!personal)
                                 setFormError(undefined)

--- a/tavla/app/(admin)/hooks/useOrganizations.ts
+++ b/tavla/app/(admin)/hooks/useOrganizations.ts
@@ -13,23 +13,31 @@ function useOrganizations(organization?: TOrganization) {
             organization ? organizationToDropdownItem(organization) : null,
         )
 
-    useEffect(() => {
-        getOrganizationsForUser().then((res) => {
-            setOrganizationList(
-                res?.map((o) => ({
-                    value: o ?? undefined,
-                    label: o.name ?? '',
-                })),
-            )
-        })
+    const fetchOrganizations = useCallback(async () => {
+        const res = await getOrganizationsForUser()
+        setOrganizationList(
+            res?.map((o) => ({
+                value: o ?? undefined,
+                label: o.name ?? '',
+            })),
+        )
     }, [])
+
+    useEffect(() => {
+        fetchOrganizations()
+    }, [fetchOrganizations])
 
     const organizations = useCallback(
         () => organizationList,
         [organizationList],
     )
 
-    return { organizations, selectedOrganization, setSelectedOrganization }
+    return {
+        organizations,
+        selectedOrganization,
+        setSelectedOrganization,
+        fetchOrganizations,
+    }
 }
 
 export { useOrganizations }


### PR DESCRIPTION
Lagt tilbake at man kan legge til organisasjon når man oppretter tavle. 

Jeg har egentlig gjort det slik som denne PRen hvor man tidligere fjernet det: https://github.com/entur/tavla/pull/1580/files

I den gamle koden, så ble organisasjonslisten i opprett-modal automatisk oppdatert når man laget en ny/slettet en organisasjon. Det funket ikke nå, så jeg måtte legge til en `fetchOrganizations()` for å få hentet ut den nyeste dataen. Har noen noe andre forslag til hvordan det kan gjøres? Skjønner ikke helt at det funket før, men ikke nå ⛪ 

![image](https://github.com/user-attachments/assets/ccc52c00-7179-4304-a742-3b64910b61ec)

Også lagt til at om man ikke har en org, er så den disablet og privat tavle er alltid huket av: 

![image](https://github.com/user-attachments/assets/5faab99a-3efc-4142-bbcc-54137949d3a1)
