### PR TITLE
fix(edit): display name error handling

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
@@ -24,7 +24,7 @@ export async function saveTitle(bid: TBoardID, name: string) {
         .collection('boards')
         .doc(bid)
         .update({
-            'meta.title': name.substring(0, 30),
+            'meta.title': name.substring(0, 50),
             'meta.dateModified': Date.now(),
         })
     revalidatePath(`/edit/${bid}`)

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/actions.ts
@@ -39,7 +39,16 @@ export async function saveTile(bid: TBoardID, tile: TTile) {
             'meta.dateModified': Date.now(),
         })
     const index = doc.tiles.indexOf(oldTile)
-    doc.tiles[index] = tile
+
+    if (tile.displayName !== undefined) {
+        doc.tiles[index] = {
+            ...tile,
+            displayName: tile.displayName?.substring(0, 50),
+        }
+    } else {
+        doc.tiles[index] = tile
+    }
+
     docRef.update({ tiles: doc.tiles, 'meta.dateModified': Date.now() })
 
     revalidatePath(`/edit/${bid}`)

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -121,10 +121,11 @@ function TileCard({
                 distance: tile.walkingDistance?.distance,
             },
             offset: Number(offset) || undefined,
-            displayName: displayName || undefined,
+            displayName: displayName.substring(0, 50) || undefined,
         } as TTile
-        reset()
+
         bid === 'demo' ? saveTileToDemoBoard(newTile) : saveTile(bid, newTile)
+        reset()
     }
     const [state, action] = useFormState(submit, undefined)
     useEffect(() => {

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -43,6 +43,12 @@ import { TransportModeAndLines } from './TransportModeAndLines'
 import { deleteTile, getOrganizationForBoard, saveTile } from './actions'
 import { useLines } from './useLines'
 import { sortLineByPublicCode } from './utils'
+import { isOnlyWhiteSpace } from 'app/(admin)/edit/utils'
+import {
+    TFormFeedback,
+    getFormFeedbackForError,
+    getFormFeedbackForField,
+} from 'app/(admin)/utils'
 
 function TileCard({
     bid,
@@ -77,6 +83,9 @@ function TileCard({
         useState(walkingDistanceInMinutes === tile.offset)
 
     const [offset, setOffset] = useState(tile.offset ?? '')
+    const [formError, setFormError] = useState<TFormFeedback | undefined>(
+        undefined,
+    )
 
     useEffect(() => {
         if (!address) {
@@ -86,8 +95,9 @@ function TileCard({
 
     const reset = () => {
         setConfirmOpen(false)
-        setIsOpen(false)
+        setFormError(undefined)
         setChanged(false)
+        setIsOpen(false)
     }
 
     const lines = useLines(tile)
@@ -226,7 +236,13 @@ function TileCard({
                                 'displayName',
                             ) as string
                             data.delete('displayName')
-
+                            if (isOnlyWhiteSpace(displayName)) {
+                                return setFormError(
+                                    getFormFeedbackForError(
+                                        'board/tiles-name-missing',
+                                    ),
+                                )
+                            }
                             let lines: string[] = []
                             for (const line of data.values()) {
                                 lines.push(line as string)
@@ -248,12 +264,11 @@ function TileCard({
                                 offset: Number(offset) || undefined,
                                 displayName: displayName || undefined,
                             } as TTile
-
+                            reset()
                             bid === 'demo'
                                 ? saveTileToDemoBoard(newTile)
                                 : saveTile(bid, newTile)
                         }}
-                        onSubmit={reset}
                         onInput={() => setChanged(true)}
                     >
                         <div className="flex flex-col gap-2">
@@ -268,6 +283,8 @@ function TileCard({
                                 className="!w-2/5"
                                 name="displayName"
                                 defaultValue={tile.displayName}
+                                maxLength={50}
+                                {...getFormFeedbackForField('name', formError)}
                             />
                         </div>
                         <Heading4>Gåavstand</Heading4>

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -49,6 +49,7 @@ import {
     getFormFeedbackForError,
     getFormFeedbackForField,
 } from 'app/(admin)/utils'
+import { useFormState } from 'react-dom'
 
 function TileCard({
     bid,
@@ -83,10 +84,49 @@ function TileCard({
         useState(walkingDistanceInMinutes === tile.offset)
 
     const [offset, setOffset] = useState(tile.offset ?? '')
-    const [formError, setFormError] = useState<TFormFeedback | undefined>(
-        undefined,
-    )
 
+    const submit = async (
+        prevState: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
+        const columns = data.getAll('columns') as TColumn[]
+        data.delete('columns')
+        const count = data.get('count') as number | null
+        data.delete('count')
+        const distance = data.get('showDistance') as string
+        data.delete('showDistance')
+        const offset = data.get('offset') as number | null
+        data.delete('offset')
+        const displayName = data.get('displayName') as string
+        data.delete('displayName')
+        if (isOnlyWhiteSpace(displayName)) {
+            return getFormFeedbackForError('board/tiles-name-missing')
+        }
+
+        let lines: string[] = []
+        for (const line of data.values()) {
+            lines.push(line as string)
+        }
+        // If the length of lines equals all the lines, we don't want to include any
+        lines = lines.length == count ? [] : lines
+
+        if (columns !== tile.columns) await captureColumnChangeEvent()
+
+        const newTile = {
+            ...tile,
+            columns: columns,
+            whitelistedLines: lines,
+            walkingDistance: {
+                visible: distance === 'on',
+                distance: tile.walkingDistance?.distance,
+            },
+            offset: Number(offset) || undefined,
+            displayName: displayName || undefined,
+        } as TTile
+        reset()
+        bid === 'demo' ? saveTileToDemoBoard(newTile) : saveTile(bid, newTile)
+    }
+    const [state, action] = useFormState(submit, undefined)
     useEffect(() => {
         if (!address) {
             setOffsetBasedOnWalkingDistance(false)
@@ -95,7 +135,6 @@ function TileCard({
 
     const reset = () => {
         setConfirmOpen(false)
-        setFormError(undefined)
         setChanged(false)
         setIsOpen(false)
     }
@@ -223,52 +262,7 @@ function TileCard({
                 >
                     <form
                         id={tile.uuid}
-                        action={async (data: FormData) => {
-                            const columns = data.getAll('columns') as TColumn[]
-                            data.delete('columns')
-                            const count = data.get('count') as number | null
-                            data.delete('count')
-                            const distance = data.get('showDistance') as string
-                            data.delete('showDistance')
-                            const offset = data.get('offset') as number | null
-                            data.delete('offset')
-                            const displayName = data.get(
-                                'displayName',
-                            ) as string
-                            data.delete('displayName')
-                            if (isOnlyWhiteSpace(displayName)) {
-                                return setFormError(
-                                    getFormFeedbackForError(
-                                        'board/tiles-name-missing',
-                                    ),
-                                )
-                            }
-                            let lines: string[] = []
-                            for (const line of data.values()) {
-                                lines.push(line as string)
-                            }
-                            // If the length of lines equals all the lines, we don't want to include any
-                            lines = lines.length == count ? [] : lines
-
-                            if (columns !== tile.columns)
-                                captureColumnChangeEvent()
-
-                            const newTile = {
-                                ...tile,
-                                columns: columns,
-                                whitelistedLines: lines,
-                                walkingDistance: {
-                                    visible: distance === 'on',
-                                    distance: tile.walkingDistance?.distance,
-                                },
-                                offset: Number(offset) || undefined,
-                                displayName: displayName || undefined,
-                            } as TTile
-                            reset()
-                            bid === 'demo'
-                                ? saveTileToDemoBoard(newTile)
-                                : saveTile(bid, newTile)
-                        }}
+                        action={action}
                         onInput={() => setChanged(true)}
                     >
                         <div className="flex flex-col gap-2">
@@ -284,7 +278,7 @@ function TileCard({
                                 name="displayName"
                                 defaultValue={tile.displayName}
                                 maxLength={50}
-                                {...getFormFeedbackForField('name', formError)}
+                                {...getFormFeedbackForField('name', state)}
                             />
                         </div>
                         <Heading4>Gåavstand</Heading4>

--- a/tavla/app/(admin)/edit/utils.ts
+++ b/tavla/app/(admin)/edit/utils.ts
@@ -106,7 +106,7 @@ export function isEmptyOrSpaces(str?: string) {
     return str === undefined || str.match(/^ *$/) !== null
 }
 export function isOnlyWhiteSpace(str: string) {
-    if (typeof str === 'undefined' || str === '') {
+    if (str === undefined || str === '') {
         return false
     }
 

--- a/tavla/app/(admin)/edit/utils.ts
+++ b/tavla/app/(admin)/edit/utils.ts
@@ -106,9 +106,7 @@ export function isEmptyOrSpaces(str?: string) {
     return str === undefined || str.match(/^ *$/) !== null
 }
 export function isOnlyWhiteSpace(str: string) {
-    if (str === undefined || str === '') {
-        return false
-    }
+    if (str === undefined || str === '') return false
 
     return str.trim() === ''
 }

--- a/tavla/app/(admin)/edit/utils.ts
+++ b/tavla/app/(admin)/edit/utils.ts
@@ -105,3 +105,10 @@ export function getIcons(layer?: string, category?: TCategory[]) {
 export function isEmptyOrSpaces(str?: string) {
     return str === undefined || str.match(/^ *$/) !== null
 }
+export function isOnlyWhiteSpace(str: string) {
+    if (typeof str === 'undefined' || str === '') {
+        return false
+    }
+
+    return str.trim() === ''
+}

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -22,6 +22,12 @@ export type TFormFeedback = {
 }
 
 export type TError = FirebaseError | string
+export function getFormFeedbackForField(
+    form_type: InputType,
+    feedback?: TFormFeedback,
+) {
+    if (form_type === feedback?.form_type) return feedback
+}
 
 export function getFormFeedbackForError(
     e?: TError,
@@ -228,13 +234,6 @@ export function getFormFeedbackForError(
         feedback: 'En feil har oppstått.',
         variant: 'error',
     }
-}
-
-export function getFormFeedbackForField(
-    form_type: InputType,
-    feedback?: TFormFeedback,
-) {
-    if (form_type === feedback?.form_type) return feedback
 }
 
 export function userInOrganization(


### PR DESCRIPTION
stops action after clicking on save tile if displayname is only whitespace. Returns formerror instead
After:
- ![image](https://github.com/user-attachments/assets/6cb6d113-ddc1-4ac6-bad1-a01152ef9464)
