### PR TITLE
style(demo): move information to an expandable panel 

### DIFF
--- a/tavla/app/demo/components/DemoBoard.tsx
+++ b/tavla/app/demo/components/DemoBoard.tsx
@@ -22,7 +22,7 @@ function DemoBoard() {
     return (
         <>
             <div className="flex flex-col gap-4">
-                <Heading3 margin="none">
+                <Heading3 as="h2" margin="none">
                     Hvilke stoppesteder vil du vise i tavlen?
                 </Heading3>
                 <TileSelector

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { BaseExpand } from '@entur/expand'
+import { DownArrowIcon, UpArrowIcon } from '@entur/icons'
+import { Heading5, ListItem, UnorderedList } from '@entur/typography'
+import { useState } from 'react'
+
+function ExpandableInformation() {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+        <div>
+            <div className="flex flex-row">
+                <div
+                    className={`flex justify-between items-center px-6  py-4 bg-blue80 w-full ${
+                        isOpen ? 'rounded-t' : 'rounded'
+                    }`}
+                    onClick={() => setIsOpen(!isOpen)}
+                    style={{ cursor: 'pointer' }}
+                >
+                    <Heading5 margin="none">
+                        Hva du kan gjøre med Tavla om du logger inn
+                    </Heading5>
+                    {isOpen ? <UpArrowIcon /> : <DownArrowIcon />}
+                </div>
+            </div>
+            <BaseExpand open={isOpen}>
+                <div className="bg-blue90 px-6  py-4 rounded-b">
+                    <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
+                        <ListItem>Endre tekststørrelse</ListItem>
+                        <ListItem>
+                            Legge til en info-melding nederst i tavlen
+                        </ListItem>
+                        <ListItem>
+                            Endre fargetema (lys eller mørk modus)
+                        </ListItem>
+                        <ListItem>
+                            Legge inn adressen som tavlen står på og vise
+                            gåavstand fra tavlen til stoppested(ene)
+                        </ListItem>
+                        <ListItem>
+                            Opprette så mange tavler du vil og samle disse i
+                            ulike organisasjoner (mapper)
+                        </ListItem>
+                        <ListItem>
+                            Gi andre tilgang til å administrere tavlen
+                        </ListItem>
+                    </UnorderedList>
+                </div>
+            </BaseExpand>
+        </div>
+    )
+}
+
+export { ExpandableInformation }

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { BaseExpand } from '@entur/expand'
 import { DownArrowIcon, UpArrowIcon } from '@entur/icons'
-import { Heading5, ListItem, UnorderedList } from '@entur/typography'
+import { Heading5, ListItem, Paragraph, UnorderedList } from '@entur/typography'
 import { useState } from 'react'
 
 function ExpandableInformation() {
@@ -17,9 +17,9 @@ function ExpandableInformation() {
                     onClick={() => setIsOpen(!isOpen)}
                     style={{ cursor: 'pointer' }}
                 >
-                    <Heading5 margin="none">
+                    <Paragraph className="font-bold" margin="none">
                         Hva du kan gjøre med Tavla om du logger inn
-                    </Heading5>
+                    </Paragraph>
                     {isOpen ? <UpArrowIcon /> : <DownArrowIcon />}
                 </div>
             </div>

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { BaseExpand } from '@entur/expand'
 import { DownArrowIcon, UpArrowIcon } from '@entur/icons'
-import { Heading5, ListItem, Paragraph, UnorderedList } from '@entur/typography'
+import { ListItem, Paragraph, UnorderedList } from '@entur/typography'
 import { useState } from 'react'
 
 function ExpandableInformation() {

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -9,43 +9,39 @@ function ExpandableInformation() {
 
     return (
         <div>
-            <div className="flex flex-row">
-                <div
-                    className={`flex justify-between items-center px-6  py-4 bg-blue80 w-full ${
-                        isOpen ? 'rounded-t' : 'rounded'
-                    }`}
-                    onClick={() => setIsOpen(!isOpen)}
-                    style={{ cursor: 'pointer' }}
-                >
-                    <Paragraph className="font-bold" margin="none">
-                        Hva du kan gjøre med Tavla om du logger inn
-                    </Paragraph>
-                    {isOpen ? <UpArrowIcon /> : <DownArrowIcon />}
-                </div>
+            <div
+                className={`flex flex-row justify-between items-center px-6  py-4 bg-blue80 w-full cursor-pointer ${
+                    isOpen ? 'rounded-t' : 'rounded'
+                }`}
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                <Paragraph className="font-bold" margin="none">
+                    Hva kan du gjøre med Tavla om du logger inn?
+                </Paragraph>
+                {isOpen ? <UpArrowIcon /> : <DownArrowIcon />}
             </div>
-            <BaseExpand open={isOpen}>
-                <div className="bg-blue90 px-6  py-4 rounded-b">
-                    <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
-                        <ListItem>Endre tekststørrelse</ListItem>
-                        <ListItem>
-                            Legge til en info-melding nederst i tavlen
-                        </ListItem>
-                        <ListItem>
-                            Endre fargetema (lys eller mørk modus)
-                        </ListItem>
-                        <ListItem>
-                            Legge inn adressen som tavlen står på og vise
-                            gåavstand fra tavlen til stoppested(ene)
-                        </ListItem>
-                        <ListItem>
-                            Opprette så mange tavler du vil og samle disse i
-                            ulike organisasjoner (mapper)
-                        </ListItem>
-                        <ListItem>
-                            Gi andre tilgang til å administrere tavlen
-                        </ListItem>
-                    </UnorderedList>
-                </div>
+            <BaseExpand
+                open={isOpen}
+                className="bg-blue90 px-6  py-4 rounded-b"
+            >
+                <UnorderedList className="space-y-3 gap-1 pl-6">
+                    <ListItem>Endre tekststørrelse</ListItem>
+                    <ListItem>
+                        Legge til en infomelding nederst i tavlen
+                    </ListItem>
+                    <ListItem>Endre fargetema (lys eller mørk modus)</ListItem>
+                    <ListItem>
+                        Legge inn adressen som tavlen står på og vise gåavstand
+                        fra tavlen til stoppested(ene)
+                    </ListItem>
+                    <ListItem>
+                        Opprette så mange tavler du vil og samle disse i ulike
+                        organisasjoner (mapper)
+                    </ListItem>
+                    <ListItem>
+                        Gi andre tilgang til å administrere tavlen
+                    </ListItem>
+                </UnorderedList>
             </BaseExpand>
         </div>
     )

--- a/tavla/app/demo/page.tsx
+++ b/tavla/app/demo/page.tsx
@@ -52,7 +52,6 @@ async function Demo() {
                     </ListItem>
                 </UnorderedList>
             </div>
-            {!loggedIn && <CreateUserButton />}
         </main>
     )
 }

--- a/tavla/app/demo/page.tsx
+++ b/tavla/app/demo/page.tsx
@@ -1,15 +1,9 @@
-import {
-    Heading1,
-    Heading2,
-    LeadParagraph,
-    ListItem,
-    Paragraph,
-    UnorderedList,
-} from '@entur/typography'
+import { Heading1, LeadParagraph } from '@entur/typography'
 import { verifySession } from 'app/(admin)/utils/firebase'
 import { cookies } from 'next/headers'
 import { DemoBoard } from './components/DemoBoard'
 import CreateUserButton from './components/CreateUserButton'
+import { ExpandableInformation } from './components/ExpandableInformation'
 
 async function Demo() {
     const session = cookies().get('session')?.value
@@ -26,31 +20,11 @@ async function Demo() {
                     lagret.
                 </LeadParagraph>
             </div>
+            <ExpandableInformation />
             {!loggedIn && <CreateUserButton />}
 
             <div className="flex flex-col gap-10">
                 <DemoBoard />
-            </div>
-            <div>
-                <Heading2>Innstillinger som krever innlogging</Heading2>
-                <Paragraph margin="none">Hvis du logger inn, kan du:</Paragraph>
-                <UnorderedList className="flex flex-col gap-1 pl-6">
-                    <ListItem>Endre tekststørrelse</ListItem>
-                    <ListItem>Endre fargetema (lys eller mørk modus)</ListItem>
-                    <ListItem>
-                        Legge til en info-melding nederst i tavlen
-                    </ListItem>
-                    <ListItem>
-                        Vis gåavstanden fra tavlens adresse til stoppested(ene)
-                    </ListItem>
-                    <ListItem>
-                        Opprette så mange tavler du vil, og samle disse i ulike
-                        organisasjoner (mapper)
-                    </ListItem>
-                    <ListItem>
-                        Gi andre tilgang til å administrere tavlen
-                    </ListItem>
-                </UnorderedList>
             </div>
         </main>
     )


### PR DESCRIPTION
The "Hva du kan gjøre med Tavla om du logger inn" is changed to an expandable panel. 
One of two "Opprett bruker" is removed. 
![Screenshot 2024-09-04 at 12 48 57](https://github.com/user-attachments/assets/638bf27a-da3d-4316-bb70-0aebd235c45f)
