### PR TITLE
feat(landing): carousel of preview boards

### DIFF
--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -20,7 +20,7 @@ const CarouselIndicators = ({
                 <button
                     key={index}
                     className={`w-5 h-5 rounded-full -translate-x-1/2 bottom-5 mt-[3vh] left-1/2 border border-gray-700 ${
-                        index === activeIndex ? 'bg-blue' : 'bg-grey'
+                        index === activeIndex ? 'bg-blue' : 'bg-secondary'
                     }`}
                     onClick={() => onClick(index)}
                 />
@@ -65,7 +65,12 @@ function Preview({ boards }: { boards: TBoard[] }) {
                 >
                     left
                 </LeftArrowIcon>
-                <div className="md:w-full w-2/3 mx-auto">
+                <div
+                    className="md:w-full w-2/3 mx-auto"
+                    data-theme={
+                        currentBoard.theme === 'light' ? 'light' : 'dark'
+                    }
+                >
                     <Board board={currentBoard} style={{ display: 'flex' }} />
                 </div>
                 <RightArrowIcon

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -19,8 +19,8 @@ const CarouselIndicators = ({
             {boards.map((_, index) => (
                 <button
                     key={index}
-                    className={`w-5 h-5 rounded-full -translate-x-1/2 bottom-5 mt-[3vh] left-1/2 border border-gray-700 ${
-                        index === activeIndex ? 'bg-blue' : 'bg-secondary'
+                    className={`w-5 h-5 rounded-full  bottom-5 mt-[2vh] left-1/2 ${
+                        index === activeIndex ? 'bg-blue' : 'bg-tertiary'
                     }`}
                     onClick={() => onClick(index)}
                 />
@@ -31,11 +31,16 @@ const CarouselIndicators = ({
 
 function Preview({ boards }: { boards: TBoard[] }) {
     const [boardIndex, setBoardIndex] = useState(0)
+    const [fade, setFade] = useState(true)
 
     useEffect(() => {
         const interval = setInterval(() => {
-            setBoardIndex((boardIndex + 1) % boards.length)
-        }, 5000)
+            setFade(false)
+            setTimeout(() => {
+                setBoardIndex((boardIndex + 1) % boards.length)
+                setFade(true)
+            }, 500)
+        }, 4000)
         return () => clearInterval(interval)
     }, [boardIndex, boards])
 
@@ -61,21 +66,32 @@ function Preview({ boards }: { boards: TBoard[] }) {
             <div className="flex flex-row h-[40vh]">
                 <LeftArrowIcon
                     onClick={prevSlide}
-                    className="w-10 h-10 my-auto mr-5"
+                    className="w-10 h-10 my-auto md:mr-5 mr-2"
                 >
                     left
                 </LeftArrowIcon>
                 <div
-                    className="md:w-full w-2/3 mx-auto"
+                    className="md:w-full w-3/4 mx-auto"
                     data-theme={
                         currentBoard.theme === 'light' ? 'light' : 'dark'
                     }
+                    id="default-carousel"
+                    data-carousel="slide"
                 >
-                    <Board board={currentBoard} style={{ display: 'flex' }} />
+                    <div
+                        className={`w-full h-full transform transition-all duration-500 ease-in-out p-4 ${
+                            fade ? 'opacity-100' : 'opacity-0'
+                        }`}
+                    >
+                        <Board
+                            board={currentBoard}
+                            style={{ display: 'flex' }}
+                        />
+                    </div>
                 </div>
                 <RightArrowIcon
                     onClick={nextSlide}
-                    className="w-10 h-10 my-auto ml-5"
+                    className="w-10 h-10 my-auto md:ml-5 ml-2"
                 />
             </div>
             <div className="h-[10vh] mx-10">

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -15,11 +15,11 @@ const CarouselIndicators = ({
     onClick: (index: number) => void
 }) => {
     return (
-        <div className="flex flex-row space-x-3 justify-center h-[10vh]">
+        <div className="flex flex-row md:space-x-3 space-x-5 justify-center h-[10vh]">
             {boards.map((_, index) => (
                 <button
                     key={index}
-                    className={`w-5 h-5 rounded-full  bottom-5 mt-[2vh] left-1/2 ${
+                    className={`md:w-5 md:h-5 w-6 h-6 rounded-full  bottom-5 mt-[2vh] left-1/2 ${
                         index === activeIndex ? 'bg-blue' : 'bg-tertiary'
                     }`}
                     onClick={() => onClick(index)}
@@ -40,7 +40,7 @@ function Preview({ boards }: { boards: TBoard[] }) {
                 setBoardIndex((boardIndex + 1) % boards.length)
                 setFade(true)
             }, 500)
-        }, 4000)
+        }, 4500)
         return () => clearInterval(interval)
     }, [boardIndex, boards])
 
@@ -66,12 +66,12 @@ function Preview({ boards }: { boards: TBoard[] }) {
             <div className="flex flex-row h-[40vh]">
                 <LeftArrowIcon
                     onClick={prevSlide}
-                    className="w-10 h-10 my-auto md:mr-5 mr-2"
+                    className="w-10 h-10 my-auto mr-5 hidden md:block"
                 >
                     left
                 </LeftArrowIcon>
                 <div
-                    className="md:w-full w-3/4 mx-auto"
+                    className="w-full mx-auto"
                     data-theme={
                         currentBoard.theme === 'light' ? 'light' : 'dark'
                     }
@@ -91,7 +91,7 @@ function Preview({ boards }: { boards: TBoard[] }) {
                 </div>
                 <RightArrowIcon
                     onClick={nextSlide}
-                    className="w-10 h-10 my-auto md:ml-5 ml-2"
+                    className="w-10 h-10 my-auto ml-5 hidden md:block"
                 />
             </div>
             <div className="h-[10vh] mx-10">

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -2,6 +2,7 @@
 
 import { LeftArrowIcon, RightArrowIcon } from '@entur/icons'
 import { Board } from 'Board/scenarios/Board'
+import { usePostHog } from 'posthog-js/react'
 import { SetStateAction, useEffect, useState } from 'react'
 import { TBoard } from 'types/settings'
 
@@ -32,6 +33,7 @@ const CarouselIndicators = ({
 function Preview({ boards }: { boards: TBoard[] }) {
     const [boardIndex, setBoardIndex] = useState(0)
     const [fade, setFade] = useState(true)
+    const posthog = usePostHog()
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -45,17 +47,20 @@ function Preview({ boards }: { boards: TBoard[] }) {
     }, [boardIndex, boards])
 
     const nextSlide = () => {
+        posthog.capture('CAROUSEL_ARROW_BTN')
         setBoardIndex((prevIndex) =>
             prevIndex === boards.length - 1 ? 0 : prevIndex + 1,
         )
     }
     const prevSlide = () => {
+        posthog.capture('CAROUSEL_ARROW_BTN')
         setBoardIndex((prevIndex) =>
             prevIndex === 0 ? boards.length - 1 : prevIndex - 1,
         )
     }
 
     const goToSlide = (index: SetStateAction<number>) => {
+        posthog.capture('CAROUSEL_INDICATOR_BTNS')
         setBoardIndex(index)
     }
 

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import { IconButton } from '@entur/button'
 import { LeftArrowIcon, RightArrowIcon } from '@entur/icons'
 import { Board } from 'Board/scenarios/Board'
 import { usePostHog } from 'posthog-js/react'
-import { SetStateAction, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { TBoard } from 'types/settings'
 
 const CarouselIndicators = ({
@@ -16,11 +17,11 @@ const CarouselIndicators = ({
     onClick: (index: number) => void
 }) => {
     return (
-        <div className="flex flex-row md:space-x-3 space-x-5 justify-center h-[10vh]">
+        <div className="flex flex-row md:space-x-3 space-x-5 justify-center mt-4">
             {boards.map((_, index) => (
                 <button
                     key={index}
-                    className={`md:w-5 md:h-5 w-6 h-6 rounded-full  bottom-5 mt-[2vh] left-1/2 ${
+                    className={`md:w-5 md:h-5 w-6 h-6 rounded-full  bottom-5 ${
                         index === activeIndex ? 'bg-blue' : 'bg-tertiary'
                     }`}
                     onClick={() => onClick(index)}
@@ -59,7 +60,7 @@ function Preview({ boards }: { boards: TBoard[] }) {
         )
     }
 
-    const goToSlide = (index: SetStateAction<number>) => {
+    const goToSlide = (index: number) => {
         posthog.capture('CAROUSEL_INDICATOR_BTNS')
         setBoardIndex(index)
     }
@@ -67,24 +68,22 @@ function Preview({ boards }: { boards: TBoard[] }) {
     const currentBoard = boards[boardIndex] ?? undefined
     if (!currentBoard) return null
     return (
-        <div>
+        <div className="xl:w-1/2 h-[50vh] overflow-hidden rounded-2xl py-10 w-full">
             <div className="flex flex-row h-[40vh]">
-                <LeftArrowIcon
-                    onClick={prevSlide}
-                    className="w-10 h-10 my-auto mr-5 hidden md:block"
-                >
-                    left
-                </LeftArrowIcon>
+                <div className="my-auto hidden md:block ml-2">
+                    <IconButton
+                        onClick={prevSlide}
+                        aria-label="Vis forrige tavle"
+                    >
+                        <LeftArrowIcon />
+                    </IconButton>
+                </div>
                 <div
                     className="w-full mx-auto"
-                    data-theme={
-                        currentBoard.theme === 'light' ? 'light' : 'dark'
-                    }
-                    id="default-carousel"
-                    data-carousel="slide"
+                    data-theme={currentBoard.theme ?? 'dark'}
                 >
                     <div
-                        className={`w-full h-full transform transition-all duration-500 ease-in-out p-4 ${
+                        className={`w-full h-full transform transition-all duration-500 ease-in-out p-2 ${
                             fade ? 'opacity-100' : 'opacity-0'
                         }`}
                     >
@@ -94,18 +93,21 @@ function Preview({ boards }: { boards: TBoard[] }) {
                         />
                     </div>
                 </div>
-                <RightArrowIcon
-                    onClick={nextSlide}
-                    className="w-10 h-10 my-auto ml-5 hidden md:block"
-                />
+                <div className="my-auto hidden md:block mr-2">
+                    <IconButton
+                        onClick={nextSlide}
+                        aria-label="Vis neste tavle"
+                    >
+                        <RightArrowIcon />
+                    </IconButton>
+                </div>
             </div>
-            <div className="h-[10vh] mx-10">
-                <CarouselIndicators
-                    boards={boards}
-                    activeIndex={boardIndex}
-                    onClick={goToSlide}
-                />
-            </div>
+
+            <CarouselIndicators
+                boards={boards}
+                activeIndex={boardIndex}
+                onClick={goToSlide}
+            />
         </div>
     )
 }

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -17,7 +17,10 @@ const CarouselIndicators = ({
     onClick: (index: number) => void
 }) => {
     return (
-        <div className="flex flex-row md:space-x-3 space-x-5 justify-center mt-4">
+        <div
+            className="flex flex-row md:space-x-3 space-x-5 justify-center mt-4"
+            aria-label="Knapper for å bytte mellom avgangstavler"
+        >
             {boards.map((_, index) => (
                 <button
                     key={index}

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -1,8 +1,33 @@
 'use client'
 
+import { LeftArrowIcon, RightArrowIcon } from '@entur/icons'
 import { Board } from 'Board/scenarios/Board'
-import { useEffect, useState } from 'react'
+import { SetStateAction, useEffect, useState } from 'react'
 import { TBoard } from 'types/settings'
+
+const CarouselIndicators = ({
+    boards,
+    activeIndex,
+    onClick,
+}: {
+    boards: TBoard[]
+    activeIndex: number
+    onClick: (index: number) => void
+}) => {
+    return (
+        <div className="flex flex-row space-x-3 justify-center h-[10vh]">
+            {boards.map((_, index) => (
+                <button
+                    key={index}
+                    className={`w-5 h-5 rounded-full -translate-x-1/2 bottom-5 mt-[3vh] left-1/2 border border-gray-700 ${
+                        index === activeIndex ? 'bg-blue' : 'bg-grey'
+                    }`}
+                    onClick={() => onClick(index)}
+                />
+            ))}
+        </div>
+    )
+}
 
 function Preview({ boards }: { boards: TBoard[] }) {
     const [boardIndex, setBoardIndex] = useState(0)
@@ -10,12 +35,52 @@ function Preview({ boards }: { boards: TBoard[] }) {
     useEffect(() => {
         const interval = setInterval(() => {
             setBoardIndex((boardIndex + 1) % boards.length)
-        }, 10000)
+        }, 5000)
         return () => clearInterval(interval)
     }, [boardIndex, boards])
 
+    const nextSlide = () => {
+        setBoardIndex((prevIndex) =>
+            prevIndex === boards.length - 1 ? 0 : prevIndex + 1,
+        )
+    }
+    const prevSlide = () => {
+        setBoardIndex((prevIndex) =>
+            prevIndex === 0 ? boards.length - 1 : prevIndex - 1,
+        )
+    }
+
+    const goToSlide = (index: SetStateAction<number>) => {
+        setBoardIndex(index)
+    }
+
     const currentBoard = boards[boardIndex] ?? undefined
     if (!currentBoard) return null
-    return <Board board={currentBoard} style={{ display: 'flex' }} />
+    return (
+        <div>
+            <div className="flex flex-row h-[40vh]">
+                <LeftArrowIcon
+                    onClick={prevSlide}
+                    className="w-10 h-10 my-auto mr-5"
+                >
+                    left
+                </LeftArrowIcon>
+                <div className="md:w-full w-2/3 mx-auto">
+                    <Board board={currentBoard} style={{ display: 'flex' }} />
+                </div>
+                <RightArrowIcon
+                    onClick={nextSlide}
+                    className="w-10 h-10 my-auto ml-5"
+                />
+            </div>
+            <div className="h-[10vh] mx-10">
+                <CarouselIndicators
+                    boards={boards}
+                    activeIndex={boardIndex}
+                    onClick={goToSlide}
+                />
+            </div>
+        </div>
+    )
 }
 export { Preview }

--- a/tavla/app/(admin)/components/Preview/index.tsx
+++ b/tavla/app/(admin)/components/Preview/index.tsx
@@ -83,11 +83,13 @@ function Preview({ boards }: { boards: TBoard[] }) {
                     data-theme={currentBoard.theme ?? 'dark'}
                 >
                     <div
+                        aria-label="Eksempel på avgangstavler"
                         className={`w-full h-full transform transition-all duration-500 ease-in-out p-2 ${
                             fade ? 'opacity-100' : 'opacity-0'
                         }`}
                     >
                         <Board
+                            aria-hidden
                             board={currentBoard}
                             style={{ display: 'flex' }}
                         />

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -54,10 +54,7 @@ async function Landing() {
             <div className="flex flex-col justify-center pb-10">
                 <div className="flex flex-col mx-auto items-center justify-start py-4 container overflow-hidden">
                     <div className="flex flex-col items-center justify-start gap-4 py-4 w-full">
-                        <div
-                            className="xl:w-1/2 h-[50vh] overflow-hidden rounded-2xl py-10 w-full"
-                            data-theme="dark"
-                        >
+                        <div className="xl:w-1/2 h-[50vh] overflow-hidden rounded-2xl py-10 w-full">
                             <Preview boards={previewBoards} />
                         </div>
 

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -51,87 +51,80 @@ async function Landing() {
                     </div>
                 </div>
             </div>
-            <div className="flex flex-col justify-center pb-10">
-                <div className="flex flex-col mx-auto items-center justify-start py-4 container overflow-hidden">
-                    <div className="flex flex-col items-center justify-start gap-4 py-4 w-full">
-                        <div className="xl:w-1/2 h-[50vh] overflow-hidden rounded-2xl py-10 w-full">
-                            <Preview boards={previewBoards} />
-                        </div>
 
-                        <div className="xl:w-1/2">
-                            <Heading2>Kort om Tavla</Heading2>
-                            <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
-                                <ListItem>
-                                    Du kan lage avgangstavler fra alle
-                                    stoppesteder, holdeplasser, knutepunkter,
-                                    fergekaier mm. i hele Norge. Dette gjelder
-                                    for alle typer offentlig transport,
-                                    inkludert ferger, hurtigbåter og fly.
-                                </ListItem>
-                                <ListItem>
-                                    Det er helt gratis å implementere og bruke
-                                    Tavla.
-                                </ListItem>
-                                <ListItem>
-                                    Tavla kan vises på ulike typer skjermer og
-                                    er tilpasset flere operativsystem og
-                                    oppløsninger.
-                                </ListItem>
-                            </UnorderedList>
-                            <Paragraph className="pt-50 italic">
-                                Tavla sin kildekode er tilgjengelig for alle på{' '}
-                                <EnturLink href="https://github.com/entur/tavla">
-                                    GitHub
-                                </EnturLink>
-                                . Dette gjør at du kan følge utviklingen av
-                                produktet direkte og foreslå forbedringer selv.
-                            </Paragraph>
+            <div className="flex flex-col mx-auto items-center justify-start py-4 container overflow-hidden pb-10">
+                <div className="flex flex-col items-center justify-start gap-4 py-4 w-full">
+                    <Preview boards={previewBoards} />
 
-                            <Heading3>Enkelt å tilpasse og samarbeide</Heading3>
+                    <div className="xl:w-1/2">
+                        <Heading2>Kort om Tavla</Heading2>
+                        <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
+                            <ListItem>
+                                Du kan lage avgangstavler fra alle stoppesteder,
+                                holdeplasser, knutepunkter, fergekaier mm. i
+                                hele Norge. Dette gjelder for alle typer
+                                offentlig transport, inkludert ferger,
+                                hurtigbåter og fly.
+                            </ListItem>
+                            <ListItem>
+                                Det er helt gratis å implementere og bruke
+                                Tavla.
+                            </ListItem>
+                            <ListItem>
+                                Tavla kan vises på ulike typer skjermer og er
+                                tilpasset flere operativsystem og oppløsninger.
+                            </ListItem>
+                        </UnorderedList>
+                        <Paragraph className="pt-50 italic">
+                            Tavla sin kildekode er tilgjengelig for alle på{' '}
+                            <EnturLink href="https://github.com/entur/tavla">
+                                GitHub
+                            </EnturLink>
+                            . Dette gjør at du kan følge utviklingen av
+                            produktet direkte og foreslå forbedringer selv.
+                        </Paragraph>
 
-                            <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
-                                <ListItem>
-                                    Tilpass tekststørrelse, fargetema, logo og
-                                    hvilken informasjon som skal vises, slik at
-                                    tavlen(e) passer til dine omgivelser og dine
-                                    besøkende sine behov.
-                                </ListItem>
-                                <ListItem>
-                                    Velg om du vil vise hele kollektivtilbudet
-                                    fra et stoppested, eller kun vise spesifikke
-                                    linjer, stoppesteder eller fremkomstmidler.
-                                </ListItem>
-                                <ListItem>
-                                    Opprett organisasjoner (mapper) for å samle
-                                    tavler og gi andre tilgang til å
-                                    administrere dem. Her kan du også velge
-                                    standardinnstillinger som vil gjelde alle
-                                    tavler i organisasjonen.
-                                </ListItem>
-                            </UnorderedList>
+                        <Heading3>Enkelt å tilpasse og samarbeide</Heading3>
 
-                            <Heading2 className="pt-8">
-                                Eksempler på bruk
-                            </Heading2>
-                            <Heading3>Hoteller</Heading3>
-                            <Paragraph>
-                                Plasser Tavla i resepsjonsområdet slik at
-                                gjester kan se sanntidsinformasjon om avganger
-                                fra stoppesteder i nærheten.
-                            </Paragraph>
-                            <Heading3>Arbeidsplasser</Heading3>
-                            <Paragraph>
-                                Vis Tavla på informasjonspunkter eller skjermer
-                                ved inngangen slik at besøkende enkelt kan
-                                planlegge hjemreisen.
-                            </Paragraph>
-                            <Heading3>Kjøpesentre</Heading3>
-                            <Paragraph>
-                                Sett opp Tavla på sentrale steder slik at kunder
-                                alltid har oppdatert informasjon om offentlig
-                                transport.
-                            </Paragraph>
-                        </div>
+                        <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
+                            <ListItem>
+                                Tilpass tekststørrelse, fargetema, logo og
+                                hvilken informasjon som skal vises, slik at
+                                tavlen(e) passer til dine omgivelser og dine
+                                besøkende sine behov.
+                            </ListItem>
+                            <ListItem>
+                                Velg om du vil vise hele kollektivtilbudet fra
+                                et stoppested, eller kun vise spesifikke linjer,
+                                stoppesteder eller fremkomstmidler.
+                            </ListItem>
+                            <ListItem>
+                                Opprett organisasjoner (mapper) for å samle
+                                tavler og gi andre tilgang til å administrere
+                                dem. Her kan du også velge standardinnstillinger
+                                som vil gjelde alle tavler i organisasjonen.
+                            </ListItem>
+                        </UnorderedList>
+
+                        <Heading2 className="pt-8">Eksempler på bruk</Heading2>
+                        <Heading3>Hoteller</Heading3>
+                        <Paragraph>
+                            Plasser Tavla i resepsjonsområdet slik at gjester
+                            kan se sanntidsinformasjon om avganger fra
+                            stoppesteder i nærheten.
+                        </Paragraph>
+                        <Heading3>Arbeidsplasser</Heading3>
+                        <Paragraph>
+                            Vis Tavla på informasjonspunkter eller skjermer ved
+                            inngangen slik at besøkende enkelt kan planlegge
+                            hjemreisen.
+                        </Paragraph>
+                        <Heading3>Kjøpesentre</Heading3>
+                        <Paragraph>
+                            Sett opp Tavla på sentrale steder slik at kunder
+                            alltid har oppdatert informasjon om offentlig
+                            transport.
+                        </Paragraph>
                     </div>
                 </div>
             </div>

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -55,7 +55,7 @@ async function Landing() {
                 <div className="flex flex-col mx-auto items-center justify-start py-4 container overflow-hidden">
                     <div className="flex flex-col items-center justify-start gap-4 py-4 w-full">
                         <div
-                            className="xl:w-1/2 h-[40vh] overflow-hidden rounded-2xl py-10 w-full"
+                            className="xl:w-1/2 h-[50vh] overflow-hidden rounded-2xl py-10 w-full"
                             data-theme="dark"
                         >
                             <Preview boards={previewBoards} />

--- a/tavla/src/Shared/utils/previewBoards.ts
+++ b/tavla/src/Shared/utils/previewBoards.ts
@@ -6,6 +6,7 @@ export const previewBoards: TBoard[] = [
         meta: {
             fontSize: 'medium',
         },
+        theme: 'dark',
         tiles: [
             {
                 columns: [
@@ -50,6 +51,7 @@ export const previewBoards: TBoard[] = [
         meta: {
             fontSize: 'medium',
         },
+        theme: 'light',
         tiles: [
             {
                 columns: ['line', 'destination', 'time', 'realtime'],
@@ -69,6 +71,7 @@ export const previewBoards: TBoard[] = [
         meta: {
             fontSize: 'medium',
         },
+        theme: 'light',
         tiles: [
             {
                 columns: ['line', 'destination', 'time', 'realtime'],

--- a/tavla/src/Shared/utils/previewBoards.ts
+++ b/tavla/src/Shared/utils/previewBoards.ts
@@ -8,11 +8,17 @@ export const previewBoards: TBoard[] = [
         },
         tiles: [
             {
-                columns: ['line', 'destination', 'time', 'realtime'],
-                placeId: 'NSR:StopPlace:58260',
-                name: 'Dalsbergstien',
+                columns: [
+                    'line',
+                    'destination',
+                    'time',
+                    'realtime',
+                    'platform',
+                ],
+                placeId: 'NSR:StopPlace:61291',
+                name: 'Stavanger stasjon, Stavanger',
                 type: 'stop_place',
-                uuid: 'uoO6yA-S0ztol4auy_QSv',
+                uuid: '1s9E_8qW_e2-cWii94rl4',
             },
         ],
     },
@@ -25,10 +31,17 @@ export const previewBoards: TBoard[] = [
         tiles: [
             {
                 columns: ['line', 'destination', 'time', 'realtime'],
-                placeId: 'NSR:StopPlace:58366',
-                name: 'Jernbanetorget',
+                placeId: 'NSR:StopPlace:58382',
+                name: 'Aker brygge, Oslo',
                 type: 'stop_place',
-                uuid: 'uoO6yA-S0ztol4auy_QSv',
+                uuid: 'lqfe6yE6hStaM8yWbfmb2',
+                whitelistedLines: [
+                    'RUT:Line:3701',
+                    'RUT:Line:3702',
+                    'RUT:Line:3810',
+                    'RUT:Line:3820',
+                    'RUT:Line:3821',
+                ],
             },
         ],
     },
@@ -39,18 +52,30 @@ export const previewBoards: TBoard[] = [
         },
         tiles: [
             {
-                columns: [
-                    'line',
-                    'destination',
-                    'time',
-                    'realtime',
-                    'arrivalTime',
-                ],
-                placeId: 'NSR:StopPlace:58767',
-                name: 'Festøya ferjekai, Ørsta',
+                columns: ['line', 'destination', 'time', 'realtime'],
+                placeId: 'NSR:StopPlace:58856',
+                name: 'Lysaker stasjon, Bærum',
                 type: 'stop_place',
-                uuid: 'syD_TXEoo5x3R8ar2gB_V',
-                whitelistedLines: ['MOR:Line:1049', 'MOR:Line:1069'],
+                uuid: 'WPLoeygP7d173RifiQDvd',
+                walkingDistance: {
+                    distance: 868,
+                    visible: true,
+                },
+            },
+        ],
+    },
+    {
+        id: 'aLr7VN03RDThtjYYfd9v',
+        meta: {
+            fontSize: 'medium',
+        },
+        tiles: [
+            {
+                columns: ['line', 'destination', 'time', 'realtime'],
+                placeId: 'NSR:StopPlace:59261',
+                name: 'Trondheim lufthavn, Stjørdal',
+                type: 'stop_place',
+                uuid: 'iELiaTnG7uxRM6aN2Ba9A',
             },
         ],
     },


### PR DESCRIPTION
Added auto-rolling carousel of previewboards to landing page:

![Screenshot 2024-09-09 at 15 29 40](https://github.com/user-attachments/assets/7dc4005e-bb7d-4818-9466-98092ef40158)

On mobile:

![Screenshot 2024-09-09 at 15 30 17](https://github.com/user-attachments/assets/8e5f40fa-20b6-4ed9-b43c-eb32a7ff70b1)
