### PR TITLE
style(organizations): add illustration to empty org page

### DIFF
--- a/tavla/app/(admin)/organizations/components/Organizations.tsx
+++ b/tavla/app/(admin)/organizations/components/Organizations.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image'
 import { Link, Paragraph } from '@entur/typography'
 import NextLink from 'next/link'
 import { Actions } from './Actions'
+import { IllustratedInfo } from 'app/(admin)/components/IllustratedInfo'
+import { isEmpty } from 'lodash'
 
 function Organizations({
     userId,
@@ -12,6 +14,13 @@ function Organizations({
     userId: string
     organizations: TOrganization[]
 }) {
+    if (isEmpty(organizations))
+        return (
+            <IllustratedInfo
+                title="Her var det tomt"
+                description="Du er ikke en del av noen organisasjoner ennå"
+            />
+        )
     return (
         <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
             {organizations.map((organization) => (


### PR DESCRIPTION
Illustrasjon lagt til, vi tar en runde senere på at opprett org knappen kanskje kan flyttes (Hannah ser på det først)

![Screenshot 2024-09-12 at 08 04 07](https://github.com/user-attachments/assets/edb6d2f6-e415-4a70-abac-003ac3bd5f4b)
