### PR TITLE
feat(boards): add button to empty board page

### DIFF
--- a/tavla/app/(admin)/boards/components/BoardTable/index.tsx
+++ b/tavla/app/(admin)/boards/components/BoardTable/index.tsx
@@ -19,12 +19,11 @@ function BoardTable({
             <IllustratedInfo
                 title="Her var det tomt"
                 description="Du har ikke laget noen tavler ennå"
-                CreateButton={() => (
-                    <PrimaryButton as={Link} href="?board">
-                        Opprett tavle <AddIcon /> <CreateBoard />
-                    </PrimaryButton>
-                )}
-            />
+            >
+                <PrimaryButton as={Link} href="?board">
+                    Opprett tavle <AddIcon /> <CreateBoard />
+                </PrimaryButton>
+            </IllustratedInfo>
         )
 
     return (

--- a/tavla/app/(admin)/boards/components/BoardTable/index.tsx
+++ b/tavla/app/(admin)/boards/components/BoardTable/index.tsx
@@ -15,6 +15,7 @@ function BoardTable({
             <IllustratedInfo
                 title="Her var det tomt"
                 description="Du har ikke laget noen tavler ennå"
+                hasCreateButton={true}
             />
         )
 

--- a/tavla/app/(admin)/boards/components/BoardTable/index.tsx
+++ b/tavla/app/(admin)/boards/components/BoardTable/index.tsx
@@ -4,6 +4,10 @@ import { TableRows } from 'app/(admin)/boards/components/TableRows'
 import { TBoardWithOrganizaion } from 'types/settings'
 import { isEmpty } from 'lodash'
 import { IllustratedInfo } from 'app/(admin)/components/IllustratedInfo'
+import { PrimaryButton } from '@entur/button'
+import Link from 'next/link'
+import { AddIcon } from '@entur/icons'
+import { CreateBoard } from 'app/(admin)/components/CreateBoard'
 
 function BoardTable({
     boardsWithOrg,
@@ -15,7 +19,11 @@ function BoardTable({
             <IllustratedInfo
                 title="Her var det tomt"
                 description="Du har ikke laget noen tavler ennå"
-                hasCreateButton={true}
+                CreateButton={() => (
+                    <PrimaryButton as={Link} href="?board">
+                        Opprett tavle <AddIcon /> <CreateBoard />
+                    </PrimaryButton>
+                )}
             />
         )
 

--- a/tavla/app/(admin)/components/IllustratedInfo/index.tsx
+++ b/tavla/app/(admin)/components/IllustratedInfo/index.tsx
@@ -5,18 +5,18 @@ import { Heading2, LeadParagraph } from '@entur/typography'
 function IllustratedInfo({
     title,
     description,
-    CreateButton,
+    children,
 }: {
     title: string
     description: string
-    CreateButton?: () => JSX.Element
+    children: React.ReactNode
 }) {
     return (
         <div className="flex flex-col items-center bg-secondary rounded pb-16">
             <Image src={animals} aria-hidden="true" alt="" />
             <Heading2 className="my-4">{title}</Heading2>
             <LeadParagraph margin="bottom">{description}</LeadParagraph>
-            {CreateButton && <CreateButton />}
+            {children}
         </div>
     )
 }

--- a/tavla/app/(admin)/components/IllustratedInfo/index.tsx
+++ b/tavla/app/(admin)/components/IllustratedInfo/index.tsx
@@ -1,30 +1,22 @@
 import Image from 'next/image'
 import animals from 'assets/illustrations/Animals.png'
 import { Heading2, LeadParagraph } from '@entur/typography'
-import { PrimaryButton } from '@entur/button'
-import Link from 'next/link'
-import { CreateBoard } from '../CreateBoard'
-import { AddIcon } from '@entur/icons'
 
 function IllustratedInfo({
     title,
     description,
-    hasCreateButton = false,
+    CreateButton,
 }: {
     title: string
     description: string
-    hasCreateButton?: boolean
+    CreateButton?: () => JSX.Element
 }) {
     return (
         <div className="flex flex-col items-center bg-secondary rounded pb-16">
             <Image src={animals} aria-hidden="true" alt="" />
             <Heading2 className="my-4">{title}</Heading2>
             <LeadParagraph margin="bottom">{description}</LeadParagraph>
-            {hasCreateButton && (
-                <PrimaryButton as={Link} href="?board">
-                    Opprett tavle <AddIcon /> <CreateBoard />
-                </PrimaryButton>
-            )}
+            {CreateButton && <CreateButton />}
         </div>
     )
 }

--- a/tavla/app/(admin)/components/IllustratedInfo/index.tsx
+++ b/tavla/app/(admin)/components/IllustratedInfo/index.tsx
@@ -9,7 +9,7 @@ function IllustratedInfo({
 }: {
     title: string
     description: string
-    children: React.ReactNode
+    children?: React.ReactNode
 }) {
     return (
         <div className="flex flex-col items-center bg-secondary rounded pb-16">

--- a/tavla/app/(admin)/components/IllustratedInfo/index.tsx
+++ b/tavla/app/(admin)/components/IllustratedInfo/index.tsx
@@ -1,19 +1,30 @@
 import Image from 'next/image'
 import animals from 'assets/illustrations/Animals.png'
 import { Heading2, LeadParagraph } from '@entur/typography'
+import { PrimaryButton } from '@entur/button'
+import Link from 'next/link'
+import { CreateBoard } from '../CreateBoard'
+import { AddIcon } from '@entur/icons'
 
 function IllustratedInfo({
     title,
     description,
+    hasCreateButton = false,
 }: {
     title: string
     description: string
+    hasCreateButton?: boolean
 }) {
     return (
         <div className="flex flex-col items-center bg-secondary rounded pb-16">
             <Image src={animals} aria-hidden="true" alt="" />
             <Heading2 className="my-4">{title}</Heading2>
             <LeadParagraph margin="bottom">{description}</LeadParagraph>
+            {hasCreateButton && (
+                <PrimaryButton as={Link} href="?board">
+                    Opprett tavle <AddIcon /> <CreateBoard />
+                </PrimaryButton>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
Lagt til opprett tavle-knapp:
![Screenshot 2024-09-12 at 08 46 23](https://github.com/user-attachments/assets/e227ba71-087a-453f-a937-c8d08e9ed218)
