### PR TITLE
feat(tileselector): add correct icons to stopplace-selector dropdown

### DIFF
--- a/tavla/app/(admin)/edit/utils.ts
+++ b/tavla/app/(admin)/edit/utils.ts
@@ -1,6 +1,6 @@
 import { NormalizedDropdownItemType } from '@entur/dropdown'
 import { HomeIcon, MapPinIcon } from '@entur/icons'
-import { getTransportIcon } from 'components/TransportIcon'
+import { SmallTravelTag } from 'components/TravelTag'
 import { uniq } from 'lodash'
 import { TTransportMode } from 'types/graphql-schema'
 import { TLocation } from 'types/meta'
@@ -93,13 +93,21 @@ export function getVenueIcon(category: TCategory) {
     }
 }
 
+const travelTags = (category: TCategory[]) => {
+    return uniq(category.map((mode) => categoryToTransportmode(mode))).map(
+        (tm) => () => {
+            return SmallTravelTag({
+                transportMode: tm,
+            })
+        },
+    )
+}
+
 export function getIcons(layer?: string, category?: TCategory[]) {
     if (!layer || !category) return
     if (layer !== 'venue')
         return uniq(uniq(category).map((mode) => getVenueIcon(mode)))
-    return uniq(category).map((mode) =>
-        getTransportIcon(categoryToTransportmode(mode)),
-    )
+    return travelTags(category)
 }
 
 export function isEmptyOrSpaces(str?: string) {

--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -55,7 +55,7 @@ function SmallTravelTag({
     publicCode?: string | null
     icons?: boolean
 }) {
-    if (!transportMode || (!publicCode && transportMode !== 'air')) return null
+    if (!transportMode) return null
     return (
         <div
             aria-label={`${transportModeNames[transportMode]} - linje ${publicCode}`}
@@ -67,12 +67,12 @@ function SmallTravelTag({
             {icons && (
                 <TransportIcon
                     className={`block h-6 fill-background ${
-                        transportMode === 'air' ? 'w-4' : 'w-6'
+                        publicCode ? 'w-6' : 'w-4'
                     }`}
                     transportMode={transportMode}
                 />
             )}
-            {transportMode !== 'air' && (
+            {publicCode && (
                 <div className="text-[0.65rem] w-full flex justify-center align-center">
                     {publicCode}
                 </div>

--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -1,5 +1,6 @@
 import { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
 import { TransportIcon } from 'components/TransportIcon'
+import { isOnlyWhiteSpace } from 'app/(admin)/edit/utils'
 
 const transportModeNames: Record<TTransportMode, string> = {
     air: 'Fly',
@@ -67,12 +68,14 @@ function SmallTravelTag({
             {icons && (
                 <TransportIcon
                     className={`block h-6 fill-background ${
-                        publicCode ? 'w-6' : 'w-4'
+                        publicCode && !isOnlyWhiteSpace(publicCode)
+                            ? 'w-6'
+                            : 'w-4'
                     }`}
                     transportMode={transportMode}
                 />
             )}
-            {publicCode && (
+            {publicCode && !isOnlyWhiteSpace(publicCode) && (
                 <div className="text-[0.65rem] w-full flex justify-center align-center">
                     {publicCode}
                 </div>


### PR DESCRIPTION
Bytter fra de svarte transportmiddel-ikonene til samme som vi har på retning-dropdown, dvs hvitt ikon inni boks med farge.

Før:
<img width="453" alt="Screenshot 2024-09-13 at 08 41 29" src="https://github.com/user-attachments/assets/5e0faa2e-2b80-4f5b-89a5-953e77519119">

Etter:
<img width="512" alt="Screenshot 2024-09-13 at 08 41 52" src="https://github.com/user-attachments/assets/2156afbb-296c-4221-a5ac-bd13003fa2ec">
