### PR TITLE
fix(organizations): delete-toast does not appear until org is deleted

### DIFF
--- a/tavla/app/(admin)/components/Delete/actions.ts
+++ b/tavla/app/(admin)/components/Delete/actions.ts
@@ -11,11 +11,19 @@ import { logout } from '../Login/actions'
 
 export async function deleteOrganization(
     prevState: TFormFeedback | undefined,
-    oid: TOrganizationID,
+    data: FormData,
 ) {
     const user = await getUserFromSessionCookie()
 
     if (!user) logout()
+
+    const oid = data.get('oid') as TOrganizationID
+    if (!oid) return getFormFeedbackForError('general')
+
+    const organizationName = data.get('oname') as string
+    const name = data.get('name') as string
+    if (name !== organizationName)
+        return getFormFeedbackForError('organization/name-mismatch')
 
     try {
         await deleteOrg(oid)

--- a/tavla/app/(admin)/components/Delete/actions.ts
+++ b/tavla/app/(admin)/components/Delete/actions.ts
@@ -10,10 +10,9 @@ import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 
 export async function deleteOrganization(
     prevState: TFormFeedback | undefined,
-    data: FormData,
+    oid: TOrganizationID,
 ) {
     const user = await getUserFromSessionCookie()
-    const oid = data.get('oid') as TOrganizationID
 
     if (!oid || !user) return getFormFeedbackForError('general')
 

--- a/tavla/app/(admin)/components/Delete/actions.ts
+++ b/tavla/app/(admin)/components/Delete/actions.ts
@@ -17,11 +17,6 @@ export async function deleteOrganization(
 
     if (!oid || !user) return getFormFeedbackForError('general')
 
-    const organizationName = data.get('oname') as string
-    const name = data.get('name') as string
-    if (name !== organizationName)
-        return getFormFeedbackForError('organization/name-mismatch')
-
     try {
         await deleteOrg(oid)
         revalidatePath('/')

--- a/tavla/app/(admin)/components/Delete/actions.ts
+++ b/tavla/app/(admin)/components/Delete/actions.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from 'next/cache'
 import { TFormFeedback, getFormFeedbackForError } from 'app/(admin)/utils'
 import { FirebaseError } from 'firebase/app'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
+import { logout } from '../Login/actions'
 
 export async function deleteOrganization(
     prevState: TFormFeedback | undefined,
@@ -14,7 +15,7 @@ export async function deleteOrganization(
 ) {
     const user = await getUserFromSessionCookie()
 
-    if (!oid || !user) return getFormFeedbackForError('general')
+    if (!user) logout()
 
     try {
         await deleteOrg(oid)

--- a/tavla/app/(admin)/components/Delete/index.tsx
+++ b/tavla/app/(admin)/components/Delete/index.tsx
@@ -47,8 +47,10 @@ function Delete({
                 getFormFeedbackForError('organization/name-mismatch'),
             )
 
-        organization.id && deleteOrgAction(organization.id)
-        addToast('Organisasjon slettet!')
+        if (organization.id) {
+            deleteOrgAction(organization.id)
+            addToast('Organisasjon slettet!')
+        }
     }
 
     return (

--- a/tavla/app/(admin)/components/Delete/index.tsx
+++ b/tavla/app/(admin)/components/Delete/index.tsx
@@ -2,9 +2,8 @@
 import { Button, IconButton, SecondarySquareButton } from '@entur/button'
 import { CloseIcon, DeleteIcon } from '@entur/icons'
 import { Modal } from '@entur/modal'
-import { Heading2, Label, Paragraph } from '@entur/typography'
+import { Heading2, Paragraph, SubParagraph } from '@entur/typography'
 import { TOrganization } from 'types/settings'
-import { HiddenInput } from 'components/Form/HiddenInput'
 import { TextField } from '@entur/form'
 import { SubmitButton } from 'components/Form/SubmitButton'
 import { useFormState } from 'react-dom'
@@ -42,14 +41,13 @@ function Delete({
     const DeleteButton = type === 'icon' ? IconButton : Button
 
     const submit = async (data: FormData) => {
-        const organizationName = data.get('oname') as string
         const name = data.get('name') as string
-        if (name !== organizationName)
+        if (name !== organization.name)
             return setNameError(
                 getFormFeedbackForError('organization/name-mismatch'),
             )
 
-        deleteOrgAction(data)
+        organization.id && deleteOrgAction(organization.id)
         addToast('Organisasjon slettet!')
     }
 
@@ -76,7 +74,7 @@ function Delete({
                     setNameError(undefined)
                 }}
                 closeLabel="Avbryt sletting"
-                className="flex flex-col justify-start items-center text-center"
+                className="flex flex-col text-center"
             >
                 <SecondarySquareButton
                     aria-label="Avbryt sletting"
@@ -88,37 +86,34 @@ function Delete({
                 >
                     <CloseIcon />
                 </SecondarySquareButton>
-                <Image src={ducks} alt="" className="h-1/2 w-1/2" />
+                <Image src={ducks} alt="" className="h-1/2 w-1/2 mx-auto" />
                 <Heading2>Slett organisasjon</Heading2>
-                <Paragraph className="mt-8">
+                <Paragraph>
                     {`Er du sikker på at du vil slette organisasjonen 
                     "${organization.name}"? Alle tavlene i organisasjonen vil også bli slettet.`}
                 </Paragraph>
-                <form
-                    action={submit}
-                    className="flex flex-col w-full gap-4"
-                    aria-live="polite"
-                    aria-relevant="all"
-                >
-                    <HiddenInput id="oname" value={organization.name} />
-                    <HiddenInput id="oid" value={organization.id} />
-                    <Label className="font-medium text-left">
-                        Bekreft ved å skrive inn navnet på organisasjonen
-                    </Label>
-                    <TextField
-                        name="name"
-                        label="Organisasjonsnavn"
-                        type="text"
-                        required
-                        aria-required
-                        className="w-full"
-                        {...getFormFeedbackForField('name', nameError)}
-                    />
-                    <FormError {...getFormFeedbackForField('general', state)} />
+                <SubParagraph className="font-medium text-left">
+                    Bekreft ved å skrive inn navnet på organisasjonen
+                </SubParagraph>
+                <form action={submit} aria-live="polite" aria-relevant="all">
+                    <div>
+                        <TextField
+                            name="name"
+                            label="Organisasjonsnavn"
+                            type="text"
+                            required
+                            aria-required
+                            {...getFormFeedbackForField('name', nameError)}
+                        />
+                        <FormError
+                            {...getFormFeedbackForField('general', state)}
+                        />
+                    </div>
                     <SubmitButton
                         variant="primary"
                         width="fluid"
                         aria-label="Slett organisasjon"
+                        className="mt-8"
                     >
                         Ja, slett organisasjon
                     </SubmitButton>

--- a/tavla/app/(admin)/components/Delete/index.tsx
+++ b/tavla/app/(admin)/components/Delete/index.tsx
@@ -22,6 +22,7 @@ import { Tooltip } from '@entur/tooltip'
 import Link from 'next/link'
 import { useToast } from '@entur/alert'
 import { useState } from 'react'
+import { HiddenInput } from 'components/Form/HiddenInput'
 
 function Delete({
     organization,
@@ -47,10 +48,8 @@ function Delete({
                 getFormFeedbackForError('organization/name-mismatch'),
             )
 
-        if (organization.id) {
-            deleteOrgAction(organization.id)
-            addToast('Organisasjon slettet!')
-        }
+        deleteOrgAction(data)
+        addToast('Organisasjon slettet!')
     }
 
     return (
@@ -98,6 +97,8 @@ function Delete({
                     Bekreft ved å skrive inn navnet på organisasjonen
                 </SubParagraph>
                 <form action={submit} aria-live="polite" aria-relevant="all">
+                    <HiddenInput id="oname" value={organization.name} />
+                    <HiddenInput id="oid" value={organization.id} />
                     <div>
                         <TextField
                             name="name"


### PR DESCRIPTION
problemet er at toasten må legges til kun dersom sletting av org går gjennom, og jeg har ikke fått til å sjekke det på en ordentlig måte. har derfor flyttet halve error-håndteringen ut av slette-funksjonen. 

dette funker som en quick-fix, men jeg antar det ikke er sånn her vi egt har lyst til å gjøre det. plis hjelp

![Screenshot 2024-09-16 at 11 43 43](https://github.com/user-attachments/assets/e7247aaf-1c05-49dd-a82d-14208e5adc76)
(kommer ikke opp toast i denne situasjonen)