### PR TITLE
fix(board): set board update on renewed focus of tab

### DIFF
--- a/tavla/src/Shared/hooks/useQuery.ts
+++ b/tavla/src/Shared/hooks/useQuery.ts
@@ -23,7 +23,7 @@ export function useQuery<Data, Variables>(
         [query, variables, mergedOptions.endpoint],
         fetcher,
         {
-            revalidateOnFocus: false,
+            revalidateOnFocus: true,
             revalidateOnReconnect: true,
             refreshInterval: mergedOptions.poll ? 30000 : undefined,
             keepPreviousData: true,


### PR DESCRIPTION
Meldt inn som issue på github: Tavla på mobil blir utdatert når man bytter til en annen tab eller går ut av nettleser. Setter nå at ny fetch av data skjer hver gang man går inn på tavla-taben på nytt.


Obs: la leve i dev litt så vi catcher bugs