### PR TITLE
feat(landing): show full boards on landing page

### DIFF
--- a/tavla/app/(admin)/components/PreviewCarousel/index.tsx
+++ b/tavla/app/(admin)/components/PreviewCarousel/index.tsx
@@ -71,8 +71,8 @@ function PreviewCarousel({ boards }: { boards: TBoard[] }) {
     const currentBoard = boards[boardIndex] ?? undefined
     if (!currentBoard) return null
     return (
-        <div className="h-[50vh] py-10">
-            <div className="flex flex-row h-[40vh]">
+        <div className="md:h-[50vh]  py-10">
+            <div className="flex flex-row md:h-[40vh]">
                 <div className="my-auto hidden md:block ml-2">
                     <IconButton
                         onClick={prevSlide}

--- a/tavla/app/(admin)/components/PreviewCarousel/index.tsx
+++ b/tavla/app/(admin)/components/PreviewCarousel/index.tsx
@@ -2,7 +2,7 @@
 
 import { IconButton } from '@entur/button'
 import { LeftArrowIcon, RightArrowIcon } from '@entur/icons'
-import { Board } from 'Board/scenarios/Board'
+import { Preview } from 'app/(admin)/edit/[id]/components/Preview'
 import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { TBoard } from 'types/settings'
@@ -34,7 +34,7 @@ const CarouselIndicators = ({
     )
 }
 
-function Preview({ boards }: { boards: TBoard[] }) {
+function PreviewCarousel({ boards }: { boards: TBoard[] }) {
     const [boardIndex, setBoardIndex] = useState(0)
     const [fade, setFade] = useState(true)
     const posthog = usePostHog()
@@ -71,7 +71,7 @@ function Preview({ boards }: { boards: TBoard[] }) {
     const currentBoard = boards[boardIndex] ?? undefined
     if (!currentBoard) return null
     return (
-        <div className="xl:w-1/2 h-[50vh] overflow-hidden rounded-2xl py-10 w-full">
+        <div className="h-[50vh] py-10">
             <div className="flex flex-row h-[40vh]">
                 <div className="my-auto hidden md:block ml-2">
                     <IconButton
@@ -87,15 +87,12 @@ function Preview({ boards }: { boards: TBoard[] }) {
                 >
                     <div
                         aria-label="Eksempel på avgangstavler"
-                        className={`w-full h-full transform transition-all duration-500 ease-in-out p-2 ${
+                        className={`transform transition-all duration-500 ease-in-out ${
                             fade ? 'opacity-100' : 'opacity-0'
                         }`}
+                        style={{ display: 'flex' }}
                     >
-                        <Board
-                            aria-hidden
-                            board={currentBoard}
-                            style={{ display: 'flex' }}
-                        />
+                        <Preview aria-hidden board={currentBoard} landingPage />
                     </div>
                 </div>
                 <div className="my-auto hidden md:block mr-2">
@@ -116,4 +113,4 @@ function Preview({ boards }: { boards: TBoard[] }) {
         </div>
     )
 }
-export { Preview }
+export { PreviewCarousel }

--- a/tavla/app/(admin)/components/PreviewCarousel/index.tsx
+++ b/tavla/app/(admin)/components/PreviewCarousel/index.tsx
@@ -2,7 +2,9 @@
 
 import { IconButton } from '@entur/button'
 import { LeftArrowIcon, RightArrowIcon } from '@entur/icons'
-import { Preview } from 'app/(admin)/edit/[id]/components/Preview'
+import { Board } from 'Board/scenarios/Board'
+import { Footer } from 'components/Footer'
+import { Header } from 'components/Header'
 import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { TBoard } from 'types/settings'
@@ -71,8 +73,8 @@ function PreviewCarousel({ boards }: { boards: TBoard[] }) {
     const currentBoard = boards[boardIndex] ?? undefined
     if (!currentBoard) return null
     return (
-        <div className="md:h-[50vh]  py-10">
-            <div className="flex flex-row md:h-[40vh]">
+        <div className="py-10">
+            <div className="flex flex-row">
                 <div className="my-auto hidden md:block ml-2">
                     <IconButton
                         onClick={prevSlide}
@@ -92,7 +94,16 @@ function PreviewCarousel({ boards }: { boards: TBoard[] }) {
                         }`}
                         style={{ display: 'flex' }}
                     >
-                        <Preview aria-hidden board={currentBoard} landingPage />
+                        <div
+                            className="previewContainer text-xs"
+                            data-theme={currentBoard?.theme ?? 'dark'}
+                        >
+                            <Header theme={currentBoard.theme} />
+                            <div className="md:h-96 h-72">
+                                <Board board={currentBoard} />
+                            </div>
+                            <Footer board={currentBoard} />
+                        </div>
                     </div>
                 </div>
                 <div className="my-auto hidden md:block mr-2">

--- a/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
@@ -8,7 +8,6 @@ import { TBoard, TOrganization } from 'types/settings'
 function Preview({
     board,
     organization,
-    landingPage,
 }: {
     board: TBoard
     organization?: TOrganization
@@ -16,17 +15,11 @@ function Preview({
 }) {
     return (
         <div
-            className={`rounded p-4 bg-primary border border-secondary ${
-                landingPage ? 'text-xs' : 'text-2xl'
-            }`}
+            className="previewContainer text-2xl"
             data-theme={board?.theme ?? 'dark'}
         >
             <Header theme={board.theme} organizationLogo={organization?.logo} />
-            <div
-                className={`${
-                    landingPage ? 'md:h-[32em] h-[22em]' : 'h-[50rem]'
-                }`}
-            >
+            <div className="h-[50rem]">
                 <Board board={board} />
             </div>
             <Footer

--- a/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
@@ -8,17 +8,25 @@ import { TBoard, TOrganization } from 'types/settings'
 function Preview({
     board,
     organization,
+    landingPage,
 }: {
     board: TBoard
     organization?: TOrganization
+    landingPage?: boolean
 }) {
     return (
         <div
-            className="rounded p-4 bg-primary border border-secondary text-2xl"
+            className={`rounded p-4 bg-primary border border-secondary ${
+                landingPage ? 'text-xs' : 'text-2xl'
+            }`}
             data-theme={board?.theme ?? 'dark'}
         >
             <Header theme={board.theme} organizationLogo={organization?.logo} />
-            <div className="h-[50rem]">
+            <div
+                className={`${
+                    landingPage ? 'md:h-[32em] h-[34em]' : 'h-[50rem]'
+                }`}
+            >
                 <Board board={board} />
             </div>
             <Footer

--- a/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
@@ -24,7 +24,7 @@ function Preview({
             <Header theme={board.theme} organizationLogo={organization?.logo} />
             <div
                 className={`${
-                    landingPage ? 'md:h-[32em] h-[34em]' : 'h-[50rem]'
+                    landingPage ? 'md:h-[32em] h-[22em]' : 'h-[50rem]'
                 }`}
             >
                 <Board board={board} />

--- a/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
@@ -11,7 +11,6 @@ function Preview({
 }: {
     board: TBoard
     organization?: TOrganization
-    landingPage?: boolean
 }) {
     return (
         <div

--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -247,6 +247,10 @@
         @apply inline-flex rounded-full bg-success h-em-0.75 w-em-0.75 left-[calc(50%-(0.75em/2))] bottom-[calc(50%-(0.75em/2))];
     }
 
+    .previewContainer {
+        @apply rounded p-4 bg-primary border border-secondary;
+    }
+
     .table-custom-nth-child {
         &:nth-child(10n + 1),
         &:nth-child(10n + 2),

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -8,7 +8,7 @@ import {
     Paragraph,
     UnorderedList,
 } from '@entur/typography'
-import { Preview } from './(admin)/components/Preview'
+import { PreviewCarousel } from './(admin)/components/PreviewCarousel'
 import { previewBoards } from '../src/Shared/utils/previewBoards'
 import { Welcome } from './components/Welcome'
 import { Link as EnturLink } from '@entur/typography'
@@ -54,7 +54,7 @@ async function Landing() {
 
             <div className="flex flex-col mx-auto items-center justify-start py-4 container overflow-hidden pb-10">
                 <div className="flex flex-col items-center justify-start gap-4 py-4 w-full">
-                    <Preview boards={previewBoards} />
+                    <PreviewCarousel boards={previewBoards} />
 
                     <div className="xl:w-1/2">
                         <Heading2>Kort om Tavla</Heading2>

--- a/tavla/src/Shared/utils/previewBoards.ts
+++ b/tavla/src/Shared/utils/previewBoards.ts
@@ -21,6 +21,19 @@ export const previewBoards: TBoard[] = [
                 type: 'stop_place',
                 uuid: '1s9E_8qW_e2-cWii94rl4',
             },
+            {
+                columns: [
+                    'line',
+                    'destination',
+                    'time',
+                    'realtime',
+                    'platform',
+                ],
+                placeId: 'NSR:StopPlace:59853',
+                name: 'Stavanger bussterminal, Stavanger',
+                type: 'stop_place',
+                uuid: 'hV659BA6dvQiRCIbNdIJR',
+            },
         ],
     },
     {
@@ -53,6 +66,18 @@ export const previewBoards: TBoard[] = [
         },
         theme: 'light',
         tiles: [
+            {
+                columns: ['line', 'destination', 'time', 'realtime'],
+                placeId: 'NSR:StopPlace:6479',
+                name: 'CC vest, Oslo',
+                type: 'stop_place',
+                uuid: '8y-eAK8DVbuNQS8JYxTMf',
+                walkingDistance: {
+                    distance: 441,
+                    visible: true,
+                },
+            },
+
             {
                 columns: ['line', 'destination', 'time', 'realtime'],
                 placeId: 'NSR:StopPlace:58856',


### PR DESCRIPTION
Hele tavler i preview-karusellen, kan nå vise logo, klokke og flere tiles. OBS: bruker samme komponent som preview i både demo og edit så gjerne sjekk at det ikke er ødelagt

![Screenshot 2024-09-18 at 11 42 00](https://github.com/user-attachments/assets/ed085fcf-e054-4512-b0af-8bd19a048b14)

Mobil:

![Screenshot 2024-09-18 at 12 01 19](https://github.com/user-attachments/assets/59007233-f3ef-4e9d-9e27-81b164fa5cba)

