### PR TITLE
fix(organization): delete board from organization collection

### DIFF
--- a/tavla/app/(admin)/organizations/components/Organizations.tsx
+++ b/tavla/app/(admin)/organizations/components/Organizations.tsx
@@ -1,7 +1,7 @@
 import { TOrganization } from 'types/settings'
 import EnturLogoBlue from 'assets/logos/Tavla-blue.svg'
 import Image from 'next/image'
-import { Link, Paragraph } from '@entur/typography'
+import { Link } from '@entur/typography'
 import NextLink from 'next/link'
 import { Actions } from './Actions'
 import { IllustratedInfo } from 'app/(admin)/components/IllustratedInfo'
@@ -22,50 +22,34 @@ function Organizations({
             />
         )
     return (
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
             {organizations.map((organization) => (
                 <div
-                    className="w-full h-64 border rounded-md shadow-sm"
+                    className=" border rounded-md shadow-sm"
                     key={organization.id}
                 >
-                    <div className="h-full w-full grid grid-rows-2">
-                        <div className="flex align-center justify-center relative">
+                    <div className="flex flex-col">
+                        <div className="h-36 flex align-center justify-center relative">
                             <Image
                                 src={organization.logo ?? EnturLogoBlue}
                                 alt="Logo til organisasjonen"
                                 fill
                                 objectFit="contain"
-                                className="py-4 px-16"
+                                className="py-12 px-8"
                             />
                         </div>
-                        <div className="bg-gray-100 p-4">
-                            <div className="flex flex-row justify-between">
-                                <Link
-                                    as={NextLink}
-                                    href={`/organizations/${organization.id}`}
-                                    className="!text-xl !font-bold"
-                                >
-                                    {organization.name}
-                                </Link>
-                                <Actions
-                                    organization={organization}
-                                    userId={userId}
-                                />
-                            </div>
-                            <Paragraph className="py-2 !text-xs" margin="none">
-                                Rolle:{' '}
-                                {organization.owners?.includes(userId)
-                                    ? 'Eier'
-                                    : 'Medlem'}
-                            </Paragraph>
-                            <Paragraph className="!text-xs" margin="none">
-                                Antall tavler: {organization.boards?.length}
-                            </Paragraph>
-                            <Paragraph className="!text-xs" margin="none">
-                                Antall medlemmer:{' '}
-                                {(organization.editors?.length ?? 0) +
-                                    (organization.owners?.length ?? 0)}
-                            </Paragraph>
+                        <div className="bg-gray-100 p-4 flex flex-row justify-between gap-4">
+                            <Link
+                                as={NextLink}
+                                href={`/organizations/${organization.id}`}
+                                className="!text-xl !font-bold truncate"
+                            >
+                                {organization.name}
+                            </Link>
+                            <Actions
+                                organization={organization}
+                                userId={userId}
+                            />
                         </div>
                     </div>
                 </div>

--- a/tavla/app/(admin)/organizations/page.tsx
+++ b/tavla/app/(admin)/organizations/page.tsx
@@ -20,7 +20,7 @@ async function OrganizationsPage() {
     const organizations = await getOrganizationsForUser()
 
     return (
-        <div className="container pb-20">
+        <div className="container pb-20 md:pb-40">
             <Heading1>Organisasjoner</Heading1>
             <div className="flex flex-col mx-auto md:flex-row justify-between mb-6 md:mb-0 md:gap-4">
                 <Paragraph className=" w-full md:w-3/4">


### PR DESCRIPTION
Problem: 
- If a board was in an organization, and the board got deleted, the board was not removed from the organization-collection in Firestore. Hence, the number of "antall tavler" on the organizations-page was wrong. This is now removed. 

New look:
![image](https://github.com/user-attachments/assets/907bca29-01f0-440a-be09-1a9ebc224fa5)
