### PR TITLE
fix(graphql): change et-client-name to increase rate limit

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/TileCard/useLines.ts
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/useLines.ts
@@ -1,4 +1,4 @@
-import { GRAPHQL_ENDPOINTS } from 'assets/env'
+import { CLIENT_NAME, GRAPHQL_ENDPOINTS } from 'assets/env'
 import { QuayEditQuery, StopPlaceEditQuery } from 'graphql/index'
 import { useEffect, useState } from 'react'
 import { TQuay } from 'types/graphql-schema'
@@ -12,7 +12,7 @@ function useLines(tile: TTile): TLineFragment[] | null {
         fetch(GRAPHQL_ENDPOINTS['journey-planner'], {
             headers: {
                 'Content-Type': 'application/json',
-                'ET-Client-Name': 'entur-journeyplanner',
+                'ET-Client-Name': CLIENT_NAME,
             },
             body: JSON.stringify({
                 query:

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/useLines.ts
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/useLines.ts
@@ -12,7 +12,7 @@ function useLines(tile: TTile): TLineFragment[] | null {
         fetch(GRAPHQL_ENDPOINTS['journey-planner'], {
             headers: {
                 'Content-Type': 'application/json',
-                'ET-Client-Name': 'tavla-test',
+                'ET-Client-Name': 'entur-journeyplanner',
             },
             body: JSON.stringify({
                 query:

--- a/tavla/src/Shared/assets/env.ts
+++ b/tavla/src/Shared/assets/env.ts
@@ -9,4 +9,4 @@ export const GRAPHQL_ENDPOINTS: Record<TEndpointNames, string> = {
 export const COUNTY_ENDPOINT = 'https://ws.geonorge.no/kommuneinfo/v1/fylker'
 export const GEOCODER_ENDPOINT = 'https://api.entur.io/geocoder/v1'
 
-export const CLIENT_NAME = 'entur-tavla-staging'
+export const CLIENT_NAME = 'entur-tavla'

--- a/tavla/src/Shared/graphql/utils.ts
+++ b/tavla/src/Shared/graphql/utils.ts
@@ -1,4 +1,4 @@
-import { GRAPHQL_ENDPOINTS, TEndpointNames } from 'assets/env'
+import { CLIENT_NAME, GRAPHQL_ENDPOINTS, TEndpointNames } from 'assets/env'
 import { TypedDocumentString } from './index'
 
 export async function fetcher<Data, Variables>([
@@ -9,7 +9,7 @@ export async function fetcher<Data, Variables>([
     return fetch(GRAPHQL_ENDPOINTS[endpointName], {
         headers: {
             'Content-Type': 'application/json',
-            'ET-Client-Name': 'entur-journeyplanner',
+            'ET-Client-Name': CLIENT_NAME,
         },
         body: JSON.stringify({ query, variables }),
         method: 'POST',

--- a/tavla/src/Shared/graphql/utils.ts
+++ b/tavla/src/Shared/graphql/utils.ts
@@ -9,7 +9,7 @@ export async function fetcher<Data, Variables>([
     return fetch(GRAPHQL_ENDPOINTS[endpointName], {
         headers: {
             'Content-Type': 'application/json',
-            'ET-Client-Name': 'tavla-test',
+            'ET-Client-Name': 'entur-journeyplanner',
         },
         body: JSON.stringify({ query, variables }),
         method: 'POST',


### PR DESCRIPTION
Endrer et-client-name til "entur-tavla", som er den standarden developer docs anbefaler: https://developer.entur.org/pages-journeyplanner-journeyplanner

Ble anbefalt dette etter å ha spurt om økning i open-admins, vi er nå en del av enturs delte rate limits og har økt til 10 000.
![Screenshot 2024-09-26 at 12 15 45](https://github.com/user-attachments/assets/10143ae9-b8a3-43a5-b129-9afd29f443e0)
