### PR TITLE
chore(board): transform old line ids to new

### DIFF
--- a/tavla/app/(admin)/edit/[id]/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/actions.ts
@@ -10,12 +10,13 @@ import { TTile } from 'types/tile'
 import { getWalkingDistance } from 'app/(admin)/components/TileSelector/utils'
 import { TLocation } from 'types/meta'
 import { revalidatePath } from 'next/cache'
+import { makeBoardCompatible } from './compatibility'
 
 initializeAdminApp()
 
 export async function getBoard(bid: TBoardID) {
     const board = await firestore().collection('boards').doc(bid).get()
-    return { id: board.id, ...board.data() } as TBoard
+    return makeBoardCompatible({ id: board.id, ...board.data() } as TBoard)
 }
 
 export async function addTile(bid: TBoardID, tile: TTile) {

--- a/tavla/app/(admin)/edit/[id]/compatibility.ts
+++ b/tavla/app/(admin)/edit/[id]/compatibility.ts
@@ -1,0 +1,99 @@
+// TODO: remove 15. december when new lines are active
+// Remember to do a migration script in Firestore beforehand
+
+import { TBoard } from 'types/settings'
+import { TTile } from 'types/tile'
+
+export const SWITCH_DATE = Date.UTC(2024, 11, 15)
+
+export function makeBoardCompatible(board: TBoard): TBoard {
+    const updatedTiles = board.tiles.map(({ whitelistedLines, ...tile }) => ({
+        ...tile,
+        whitelistedLines: whitelistedLines?.flatMap(oldLineIdsToNew),
+    })) as TTile[]
+
+    return { ...board, tiles: updatedTiles }
+}
+
+function oldLineIdsToNew(lineId: string): string | string[] {
+    switch (lineId) {
+        case 'VYG:Line:41':
+            return [lineId, 'VYG:Line:F4']
+        case 'VYG:Line:45':
+            return [lineId, 'VYG:Line:R40']
+        case 'VYG:Line:43':
+            return [lineId, 'VYG:Line:L4']
+        case 'FLB:Line:42':
+            return [lineId, 'VYG:Line:R45']
+        case 'VYG:Line:70':
+            return [lineId, 'VYG:Line:F1']
+        case 'NSB:Line:R20':
+            return [lineId, 'VYG:Line:RE20']
+        case 'NSB:Line:RX20':
+            return [lineId, 'VYG:Line:RX20']
+        case 'NSB:Line:L21':
+            return [lineId, 'VYG:Line:R21']
+        case 'NSB:Line:L22':
+            return [lineId, 'VYG:Line:R22']
+        case 'NSB:Line:R23':
+            return [lineId, 'VYG:Line:R23']
+        case 'NSB:Line:R23x':
+            return [lineId, 'VYG:Line:R23x']
+        case 'NSB:Line:L2':
+            return [lineId, 'VYG:Line:L2']
+        case 'NSB:Line:L2x':
+            return [lineId, 'VYG:Line:L2x']
+        case 'GJB:Line:R30':
+            return [lineId, 'VYG:Line:RE30']
+        case 'GJB:Line:L3':
+            return [lineId, 'VYG:Line:R31']
+        case 'NSB:Line:R10':
+            return [lineId, 'VYG:Line:RE10']
+        case 'NSB:Line:R11':
+            return [lineId, 'VYG:Line:RE11']
+        case 'NSB:Line:RX11':
+            return [lineId, 'VYG:Line:RX11']
+        case 'NSB:Line:L12':
+            return [lineId, 'VYG:Line:R12']
+        case 'NSB:Line:L13':
+            return [lineId, 'VYG:Line:R13']
+        case 'NSB:Line:R13x':
+            return [lineId, 'VYG:Line:R13x']
+        case 'NSB:Line:L14':
+            return [lineId, 'VYG:Line:R14']
+        case 'NSB:Line:52':
+            return [lineId, 'VYG:Line:R55']
+        case 'NSB:Line:L1':
+            return [lineId, 'VYG:Line:L1']
+
+        default:
+            return lineId
+    }
+}
+
+export const OLD_LINE_IDS = [
+    'VYG:Line:41',
+    'VYG:Line:45',
+    'VYG:Line:43',
+    'FLB:Line:42',
+    'VYG:Line:70',
+    'NSB:Line:R20',
+    'NSB:Line:RX20',
+    'NSB:Line:L21',
+    'NSB:Line:L22',
+    'NSB:Line:R23',
+    'NSB:Line:R23x',
+    'NSB:Line:L2',
+    'NSB:Line:L2x',
+    'GJB:Line:R30',
+    'GJB:Line:L3',
+    'NSB:Line:R10',
+    'NSB:Line:R11',
+    'NSB:Line:RX11',
+    'NSB:Line:L12',
+    'NSB:Line:L13',
+    'NSB:Line:R13x',
+    'NSB:Line:L14',
+    'NSB:Line:52',
+    'NSB:Line:L1',
+]

--- a/tavla/app/(admin)/edit/[id]/compatibility.ts
+++ b/tavla/app/(admin)/edit/[id]/compatibility.ts
@@ -4,7 +4,7 @@
 import { TBoard } from 'types/settings'
 import { TTile } from 'types/tile'
 
-export const SWITCH_DATE = Date.UTC(2024, 11, 15)
+export const SWITCH_DATE = new Date(2024, 11, 15)
 
 export function makeBoardCompatible(board: TBoard): TBoard {
     const updatedTiles = board.tiles.map(({ whitelistedLines, ...tile }) => ({

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -151,7 +151,7 @@ function TileCard({
         )
 
     // TODO: remove 15. december when new lines are active
-    if (Date.now() < SWITCH_DATE) {
+    if (Date.now() < Date.parse(SWITCH_DATE.toString())) {
         lines = lines.filter((line) => OLD_LINE_IDS.includes(line.id))
     } else {
         lines = lines.filter((line) => !OLD_LINE_IDS.includes(line.id))

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -50,6 +50,7 @@ import {
     getFormFeedbackForField,
 } from 'app/(admin)/utils'
 import { useFormState } from 'react-dom'
+import { OLD_LINE_IDS, SWITCH_DATE } from '../../compatibility'
 
 function TileCard({
     bid,
@@ -140,7 +141,7 @@ function TileCard({
         setIsOpen(false)
     }
 
-    const lines = useLines(tile)
+    let lines = useLines(tile)
 
     if (!lines)
         return (
@@ -148,6 +149,13 @@ function TileCard({
                 Laster...
             </div>
         )
+
+    // TODO: remove 15. december when new lines are active
+    if (Date.now() < SWITCH_DATE) {
+        lines = lines.filter((line) => OLD_LINE_IDS.includes(line.id))
+    } else {
+        lines = lines.filter((line) => !OLD_LINE_IDS.includes(line.id))
+    }
 
     const uniqLines = uniqBy(lines, 'id')
 


### PR DESCRIPTION
Laget en transformer som mapper alle gamle linjeIDer til nye linjeIDer. Grunnen til at vi tar med både gammel og ny linjeId er slik at vi klarer å hente ut avganger nå for de gamle linjeIDene, og når skiftet skjer (15. desember), så klarer vi å hente ut nye avganger med de nye IDene uten å måtte gjøre noen kodeendringer og "passe på" at det funker. Det som skjer nå er at vi sender både gammel og ny ID inn til journey-planner, og får tilbake avganger på de linjene som faktisk har avganger.

Det var et annet litt mer tricky case som handlet om at de nye linjeIDene er allerede lagt inn som linjer i GraphQL, derav vi får to av samme linjer i prod nå:
![image](https://github.com/user-attachments/assets/063e1bf4-1665-49c6-99ec-fd74853abe73)

Det bydde på to litt ulike tilnærminger. 
De to som er like er henholdsvis den gamle og den nye linjeIDen. 

1. Jeg kunne valgt å filtrert bort de gamle linjeIDene i selve kortet, men da ville man i firebase lagret de nye linjeIDene når man trykket "lagre". Det igjen ville gjort at vi måtte laget en ny transformer andre veien, slik at ny linje ble mappet til gammel linje for å få ut avgangene frem til 15. desember. Da måtte vi hatt to tranformatorer på en måte; en som mapper fra gammel til ny, og en som mapper fra ny til gammel til 15. desember. 

2. Nå har jeg gjort det slik at vi frem til `SWITCH_DATE` (15. desember) filtrer ut de nye linjeIDene slik at de gamle linjeIDene fortsatt blir lagret til Firebase. Når det blir 15. desember, så filtrerer vi heller ut de gamle, og lagrer de nye. Det eneste man trenger å tenke på da er å fjerne hele `compatibility.ts`-filen en gang etter 15. desember. 

Jeg valgte alternativ 2, men ser ingen umiddelbare fordel med noen av de. Gjerne kom med innspill om det kan gjøres bedre! 

Nå: 
![image](https://github.com/user-attachments/assets/bde713b9-daca-43e8-89c4-ffeb8c0218e1)
