### PR TITLE
fix(edit): remove overflow of settings and adjust preview size on mobile

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Preview/index.tsx
@@ -14,11 +14,11 @@ function Preview({
 }) {
     return (
         <div
-            className="previewContainer text-2xl"
+            className="previewContainer md:text-2xl"
             data-theme={board?.theme ?? 'dark'}
         >
             <Header theme={board.theme} organizationLogo={organization?.logo} />
-            <div className="h-[50rem]">
+            <div className="md:h-[50rem] h-96">
                 <Board board={board} />
             </div>
             <Footer

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -405,7 +405,7 @@ function TileCard({
                         </div>
 
                         <Heading4>Transportmidler og linjer</Heading4>
-                        <div className="flex flex-row gap-4">
+                        <div className="flex flex-col md:flex-row gap-4">
                             {linesByModeSorted.map(
                                 ({ transportMode, lines }) => (
                                     <TransportModeAndLines
@@ -422,7 +422,7 @@ function TileCard({
                             value={uniqLines.length.toString()}
                         />
 
-                        <div className="flex flex-row justify-start gap-4 mt-8">
+                        <div className="flex flex-col md:flex-row justify-start gap-4 mt-8">
                             <SubmitButton
                                 variant="primary"
                                 aria-label="lagre valg"

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -79,9 +79,9 @@ export default async function EditPage({ params }: TProps) {
                     </div>
                 </div>
 
-                <div className="rounded-md py-8 px-6 flex flex-col gap-4 bg-background">
+                <div className="rounded-md md:py-8 py-2 md:px-6 px-2 flex flex-col gap-4 bg-background">
                     <Heading2>Innstillinger</Heading2>
-                    <div className="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-8">
+                    <div className="grid grid-cols md:grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-8">
                         <MetaSettings
                             bid={params.id}
                             meta={board.meta}


### PR DESCRIPTION
Småplukk i edit på mobil:

- Overflow av metasettings fikset
Før:
![Screenshot 2024-09-26 at 15 05 21](https://github.com/user-attachments/assets/703fad2d-bd5b-466c-824e-29f9e09f3416)
Nå:
![Screenshot 2024-09-26 at 15 05 44](https://github.com/user-attachments/assets/fb627be4-e642-490f-943f-99b813020cf1)

- Overflow i visning av linjer i tilecard:
![Screenshot 2024-09-26 at 15 06 27](https://github.com/user-attachments/assets/ff48f597-8280-414f-8e24-c09ead37a0ac)
Nå:
![Screenshot 2024-09-26 at 15 07 14](https://github.com/user-attachments/assets/ddb8baee-dafe-497c-b179-85dc7fdb3936)

Tavlestørrelse på mobil:
![Screenshot 2024-09-26 at 15 07 38](https://github.com/user-attachments/assets/b411d3e2-d7f5-438d-85f7-6f2623b42154)

Nå:
![Screenshot 2024-09-26 at 15 07 53](https://github.com/user-attachments/assets/5c8375f0-d143-4470-9256-978685eb07d0)

