### PR TITLE
fix(edit): bug where address could not be set

### DIFF
--- a/tavla/app/(admin)/edit/[id]/compatibility.ts
+++ b/tavla/app/(admin)/edit/[id]/compatibility.ts
@@ -13,7 +13,6 @@ export function makeBoardCompatible(board: TBoard): TBoard {
             whitelistedLines: whitelistedLines.flatMap(oldLineIdsToNew),
         }),
     })) as TTile[]
-    
     return { ...board, tiles: updatedTiles }
 }
 

--- a/tavla/app/(admin)/edit/[id]/compatibility.ts
+++ b/tavla/app/(admin)/edit/[id]/compatibility.ts
@@ -9,9 +9,11 @@ export const SWITCH_DATE = new Date(2024, 11, 15)
 export function makeBoardCompatible(board: TBoard): TBoard {
     const updatedTiles = board.tiles.map(({ whitelistedLines, ...tile }) => ({
         ...tile,
-        whitelistedLines: whitelistedLines?.flatMap(oldLineIdsToNew),
+        ...(whitelistedLines && {
+            whitelistedLines: whitelistedLines.flatMap(oldLineIdsToNew),
+        }),
     })) as TTile[]
-
+    
     return { ...board, tiles: updatedTiles }
 }
 


### PR DESCRIPTION
Inni makeBoardCompatible ble whitelistedLines satt til undefined for alle tavler som ikke hadde whitelistedLines fra før av. Fikset at den ikke blir satt til noe hvis den ikke allerede finnes.


Funka lokalt for meg, filtreringen på gamle til nye linje-IDer skjer også i selve TileCard så trenger ikke ta høyde for de som ikke har satt whitelisted lines her.