### PR TITLE
style(edit): remove transportMode icons from platform dropdown on mobile

### DIFF
--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -69,7 +69,7 @@ function SmallTravelTag({
                 <TransportIcon
                     className={`h-6 fill-background ${
                         publicCode && !isOnlyWhiteSpace(publicCode)
-                            ? 'md:block hidden w-6'
+                            ? 'max-sm:hidden sm:block lg:hidden xl:block w-6'
                             : 'block w-4'
                     }`}
                     transportMode={transportMode}

--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -67,10 +67,10 @@ function SmallTravelTag({
         >
             {icons && (
                 <TransportIcon
-                    className={`block h-6 fill-background ${
+                    className={`h-6 fill-background ${
                         publicCode && !isOnlyWhiteSpace(publicCode)
-                            ? 'w-6'
-                            : 'w-4'
+                            ? 'md:block hidden w-6'
+                            : 'block w-4'
                     }`}
                     transportMode={transportMode}
                 />


### PR DESCRIPTION
Før:
![Screenshot 2024-10-10 at 09 53 41](https://github.com/user-attachments/assets/301bb358-dca5-44dc-bf60-cb80d94616c5)

Nå:
![Screenshot 2024-10-10 at 09 54 04](https://github.com/user-attachments/assets/785d034e-6e39-4f47-996e-dfb5dcbcf2ae)

