### PR TITLE
style(tooltips): increase size of tooltip icons and align with headings

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -42,7 +42,7 @@ function Footer({
                     content="Skriv en kort tekst som skal vises nederst i tavlen."
                     placement="top"
                 >
-                    <ValidationInfoIcon className="mb-2" />
+                    <ValidationInfoIcon className="mb-3" size={20} />
                 </Tooltip>
             </div>
             <div className="h-full">

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
@@ -27,7 +27,7 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
                     content="Under innstillingene til hvert stoppested kan du velge om gåavstanden, fra tavlens adresse til selve stoppestedet, skal vises"
                     placement="top"
                 >
-                    <ValidationInfoIcon className="mb-2" />
+                    <ValidationInfoIcon className="md:mb-2 mb-3" size={20} />
                 </Tooltip>
             </div>
             <div className="h-full">

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -366,16 +366,12 @@ function TileCard({
                                 )}
                         </div>
 
-                        <Heading4>Kolonner</Heading4>
-                        <div className="flex flex-row items-center gap-2">
-                            <SubParagraph>
-                                Her bestemmer du hvilke kolonner som skal vises
-                                i tavlen.
-                            </SubParagraph>
+                        <div className="flex flex-row items-baseline gap-1">
+                            <Heading4>Kolonner</Heading4>
                             <Tooltip
                                 aria-hidden
                                 placement="top"
-                                content="Vis forklaring"
+                                content="Vis forklaring på kolonner"
                             >
                                 <IconButton
                                     type="button"
@@ -385,6 +381,12 @@ function TileCard({
                                     <QuestionIcon />
                                 </IconButton>
                             </Tooltip>
+                        </div>
+                        <div className="flex flex-row items-center gap-2">
+                            <SubParagraph>
+                                Her bestemmer du hvilke kolonner som skal vises
+                                i tavlen.
+                            </SubParagraph>
                         </div>
                         <ColumnModal
                             isOpen={isColumnModalOpen}

--- a/tavla/app/(admin)/organizations/components/DefaultColumns/index.tsx
+++ b/tavla/app/(admin)/organizations/components/DefaultColumns/index.tsx
@@ -51,22 +51,24 @@ function DefaultColumns({
 
     return (
         <div className="box flex flex-col gap-1">
-            <Heading2>Kolonner</Heading2>
-            <div className="flex flex-row  items-center mb-8 gap-2">
-                <Paragraph margin="none">
-                    Velg hvilke kolonner som skal være standard når det
-                    opprettes en ny tavle.
-                </Paragraph>
+            <div className="flex flex-row items-baseline">
+                <Heading2>Kolonner</Heading2>
                 <Tooltip aria-hidden placement="top" content="Vis forklaring">
                     <IconButton
                         type="button"
                         aria-label="Vis forklaring på kolonner"
                         onClick={() => setIsOpen(true)}
                     >
-                        <QuestionIcon />
+                        <QuestionIcon size={24} />
                     </IconButton>
                 </Tooltip>
             </div>
+
+            <Paragraph margin="none">
+                Velg hvilke kolonner som skal være standard når det opprettes en
+                ny tavle.
+            </Paragraph>
+
             <ColumnModal isOpen={open} setIsOpen={setIsOpen} />
 
             <form action={action}>


### PR DESCRIPTION
Mye fra kortet som ikke kan gjøres pga designsystemet. Har økt størrelse og satt til å være ved siden av overskriften på kolonner.

Før:
![Screenshot 2024-10-10 at 10 48 43](https://github.com/user-attachments/assets/6b9f1518-fa36-44d1-9644-dcda254f5c91)

![Screenshot 2024-10-10 at 10 49 26](https://github.com/user-attachments/assets/7110d531-1ec7-43a8-9d48-07cb3b611d6b)

Nå:
![Screenshot 2024-10-10 at 10 49 54](https://github.com/user-attachments/assets/ec6f2c48-0e49-43ab-88f7-810f7ae428e8)
![Screenshot 2024-10-10 at 10 50 13](https://github.com/user-attachments/assets/86fa526c-a502-4474-9d21-87eb60c476c6)

I org settings:

![Screenshot 2024-10-10 at 10 50 32](https://github.com/user-attachments/assets/7ea37e89-c24d-4151-a8cb-86e6d5d0c8ef)
