### PR TITLE
fix(organizations): add missing revalidatepath on org settings

### DIFF
--- a/tavla/app/(admin)/organizations/components/DefaultColumns/actions.ts
+++ b/tavla/app/(admin)/organizations/components/DefaultColumns/actions.ts
@@ -4,6 +4,7 @@ import {
     userCanEditOrganization,
 } from 'app/(admin)/utils/firebase'
 import { firestore } from 'firebase-admin'
+import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { TColumn } from 'types/column'
 import { TOrganizationID } from 'types/settings'
@@ -17,4 +18,5 @@ export async function saveColumns(oid: TOrganizationID, columns: TColumn[]) {
     await firestore().collection('organizations').doc(oid).update({
         'defaults.columns': columns,
     })
+    revalidatePath(`/organizations/${oid}`)
 }

--- a/tavla/app/(admin)/organizations/components/FontSelect/actions.ts
+++ b/tavla/app/(admin)/organizations/components/FontSelect/actions.ts
@@ -4,6 +4,7 @@ import {
     userCanEditOrganization,
 } from 'app/(admin)/utils/firebase'
 import { firestore } from 'firebase-admin'
+import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { TFontSize } from 'types/meta'
 import { TOrganizationID } from 'types/settings'
@@ -17,4 +18,5 @@ export async function setFontSize(oid: TOrganizationID, fontSize: TFontSize) {
     await firestore().collection('organizations').doc(oid).update({
         'defaults.font': fontSize,
     })
+    revalidatePath(`/organizations/${oid}`)
 }

--- a/tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/actions.ts
+++ b/tavla/app/(admin)/organizations/components/MemberAdministration/CountiesSelect/actions.ts
@@ -4,6 +4,7 @@ import {
     userCanEditOrganization,
 } from 'app/(admin)/utils/firebase'
 import { firestore } from 'firebase-admin'
+import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { TCountyID, TOrganizationID } from 'types/settings'
 
@@ -19,4 +20,5 @@ export async function setCounties(
     await firestore().collection('organizations').doc(oid).update({
         'defaults.counties': countiesList,
     })
+    revalidatePath(`/organizations/${oid}`)
 }


### PR DESCRIPTION
La på revalidatePath på column, font og county select, så man ser de oppdaterte verdiene med en gang istedenfor å måtte refreshe siden