### PR TITLE
fix(board): use coordinates to get walking distance for multimodal coordinates

### DIFF
--- a/tavla/app/(admin)/components/TileSelector/utils.ts
+++ b/tavla/app/(admin)/components/TileSelector/utils.ts
@@ -41,7 +41,7 @@ export async function getWalkingDistance(from: TCoordinate, to: TCoordinate) {
             },
             to: {
                 longitude: to.lng,
-                latitude: from.lat,
+                latitude: to.lat,
             },
         })
         return response.trip.tripPatterns[0]?.duration

--- a/tavla/app/(admin)/components/TileSelector/utils.ts
+++ b/tavla/app/(admin)/components/TileSelector/utils.ts
@@ -1,9 +1,13 @@
 import { getFormFeedbackForError } from 'app/(admin)/utils'
-import { WalkDistanceQuery } from 'graphql/index'
+import {
+    QuayCoordinatesQuery,
+    StopPlaceCoordinatesQuery,
+    WalkDistanceQuery,
+} from 'graphql/index'
 import { fetchQuery } from 'graphql/utils'
 import { nanoid } from 'nanoid'
 import { DEFAULT_ORGANIZATION_COLUMNS } from 'types/column'
-import { TLocation } from 'types/meta'
+import { TCoordinate } from 'types/meta'
 import { TOrganization } from 'types/settings'
 import { TTile } from 'types/tile'
 
@@ -26,22 +30,50 @@ export function formDataToTile(data: FormData, organization?: TOrganization) {
     } as TTile
 }
 
-export async function getWalkingDistance(
-    placeId?: string,
-    location?: TLocation,
-) {
-    if (!placeId) return getFormFeedbackForError()
-    if (!location) return undefined
+export async function getWalkingDistance(from: TCoordinate, to: TCoordinate) {
+    if (!to) return getFormFeedbackForError()
+    if (!from) return undefined
     try {
         const response = await fetchQuery(WalkDistanceQuery, {
-            placeId: placeId,
-            location: {
-                longitude: location.coordinate?.lng ?? 0,
-                latitude: location.coordinate?.lat ?? 0,
+            from: {
+                longitude: from.lng,
+                latitude: from.lat,
+            },
+            to: {
+                longitude: to.lng,
+                latitude: from.lat,
             },
         })
         return response.trip.tripPatterns[0]?.duration
     } catch (error) {
         return getFormFeedbackForError()
+    }
+}
+
+export async function getStopPlaceCoordinates(stopPlaceId: string) {
+    try {
+        const response = await fetchQuery(StopPlaceCoordinatesQuery, {
+            id: stopPlaceId,
+        })
+        return {
+            lat: response.stopPlace?.latitude ?? 0,
+            lng: response.stopPlace?.longitude ?? 0,
+        } as TCoordinate
+    } catch (error) {
+        throw new Error('Failed to get stop place coordinates')
+    }
+}
+
+export async function getQuayCoordinates(quayId: string) {
+    try {
+        const response = await fetchQuery(QuayCoordinatesQuery, {
+            id: quayId,
+        })
+        return {
+            lat: response.quay?.latitude ?? 0,
+            lng: response.quay?.longitude ?? 0,
+        } as TCoordinate
+    } catch (error) {
+        throw new Error('Failed to get quay coordinates')
     }
 }

--- a/tavla/app/(admin)/components/TileSelector/utils.ts
+++ b/tavla/app/(admin)/components/TileSelector/utils.ts
@@ -1,4 +1,3 @@
-import { getFormFeedbackForError } from 'app/(admin)/utils'
 import {
     QuayCoordinatesQuery,
     StopPlaceCoordinatesQuery,
@@ -31,8 +30,7 @@ export function formDataToTile(data: FormData, organization?: TOrganization) {
 }
 
 export async function getWalkingDistance(from: TCoordinate, to: TCoordinate) {
-    if (!to) return getFormFeedbackForError()
-    if (!from) return undefined
+    if (!from || !to) return undefined
     try {
         const response = await fetchQuery(WalkDistanceQuery, {
             from: {
@@ -46,7 +44,7 @@ export async function getWalkingDistance(from: TCoordinate, to: TCoordinate) {
         })
         return response.trip.tripPatterns[0]?.duration
     } catch (error) {
-        return getFormFeedbackForError()
+        throw new Error('Failed to get walking distance')
     }
 }
 

--- a/tavla/src/Shared/graphql/index.ts
+++ b/tavla/src/Shared/graphql/index.ts
@@ -161,6 +161,20 @@ export type TGetQuayQuery = {
     } | null
 }
 
+export type TQuayCoordinatesQueryVariables = Types.Exact<{
+    id: Types.Scalars['String']
+}>
+
+export type TQuayCoordinatesQuery = {
+    __typename?: 'QueryType'
+    quay: {
+        __typename?: 'Quay'
+        id: string
+        longitude: number | null
+        latitude: number | null
+    } | null
+}
+
 export type TQuayEditQueryVariables = Types.Exact<{
     placeId: Types.Scalars['String']
 }>
@@ -306,6 +320,20 @@ export type TStopPlaceQuery = {
     } | null
 }
 
+export type TStopPlaceCoordinatesQueryVariables = Types.Exact<{
+    id: Types.Scalars['String']
+}>
+
+export type TStopPlaceCoordinatesQuery = {
+    __typename?: 'QueryType'
+    stopPlace: {
+        __typename?: 'StopPlace'
+        id: string
+        longitude: number | null
+        latitude: number | null
+    } | null
+}
+
 export type TStopPlaceEditQueryVariables = Types.Exact<{
     placeId: Types.Scalars['String']
 }>
@@ -338,8 +366,8 @@ export type TStopPlaceNameQuery = {
 }
 
 export type TWalkDistanceQueryVariables = Types.Exact<{
-    placeId: Types.Scalars['String']
-    location: Types.TInputCoordinates
+    from: Types.TInputCoordinates
+    to: Types.TInputCoordinates
 }>
 
 export type TWalkDistanceQuery = {
@@ -524,6 +552,18 @@ fragment situation on PtSituationElement {
     language
   }
 }`) as unknown as TypedDocumentString<TGetQuayQuery, TGetQuayQueryVariables>
+export const QuayCoordinatesQuery = new TypedDocumentString(`
+    query quayCoordinates($id: String!) {
+  quay(id: $id) {
+    id
+    longitude
+    latitude
+  }
+}
+    `) as unknown as TypedDocumentString<
+    TQuayCoordinatesQuery,
+    TQuayCoordinatesQueryVariables
+>
 export const QuayEditQuery = new TypedDocumentString(`
     query quayEdit($placeId: String!) {
   quay(id: $placeId) {
@@ -639,6 +679,18 @@ fragment situation on PtSituationElement {
     language
   }
 }`) as unknown as TypedDocumentString<TStopPlaceQuery, TStopPlaceQueryVariables>
+export const StopPlaceCoordinatesQuery = new TypedDocumentString(`
+    query stopPlaceCoordinates($id: String!) {
+  stopPlace(id: $id) {
+    id
+    longitude
+    latitude
+  }
+}
+    `) as unknown as TypedDocumentString<
+    TStopPlaceCoordinatesQuery,
+    TStopPlaceCoordinatesQueryVariables
+>
 export const StopPlaceEditQuery = new TypedDocumentString(`
     query stopPlaceEdit($placeId: String!) {
   stopPlace(id: $placeId) {
@@ -671,10 +723,10 @@ export const StopPlaceNameQuery = new TypedDocumentString(`
     TStopPlaceNameQueryVariables
 >
 export const WalkDistanceQuery = new TypedDocumentString(`
-    query walkDistance($placeId: String!, $location: InputCoordinates!) {
+    query walkDistance($from: InputCoordinates!, $to: InputCoordinates!) {
   trip(
-    from: {coordinates: $location}
-    to: {place: $placeId}
+    from: {coordinates: $from}
+    to: {coordinates: $to}
     modes: {directMode: foot, transportModes: []}
   ) {
     tripPatterns {

--- a/tavla/src/Shared/graphql/queries/quayCoordinates.graphql
+++ b/tavla/src/Shared/graphql/queries/quayCoordinates.graphql
@@ -1,0 +1,7 @@
+query quayCoordinates($id: String!) {
+    quay(id: $id) {
+        id
+        longitude
+        latitude
+    }
+}

--- a/tavla/src/Shared/graphql/queries/stopPlaceCoordinate.graphql
+++ b/tavla/src/Shared/graphql/queries/stopPlaceCoordinate.graphql
@@ -1,0 +1,7 @@
+query stopPlaceCoordinates($id: String!) {
+    stopPlace(id: $id) {
+        id
+        longitude
+        latitude
+    }
+}

--- a/tavla/src/Shared/graphql/queries/walkingDistance.graphql
+++ b/tavla/src/Shared/graphql/queries/walkingDistance.graphql
@@ -1,7 +1,7 @@
-query walkDistance($placeId: String!, $location: InputCoordinates!) {
+query walkDistance($from: InputCoordinates!, $to: InputCoordinates!) {
     trip(
-        from: { coordinates: $location }
-        to: { place: $placeId }
+        from: { coordinates: $from }
+        to: { coordinates: $to }
         modes: { directMode: foot, transportModes: [] }
     ) {
         tripPatterns {


### PR DESCRIPTION
I dagens løsning støtter vi ikke ut å hente koordinater for multimodale stopp. Et multimodalt stopp er et stopp som har flere plattformer. F. eks er Oslo S og Jernbanetorget et multimodalt stopp. I spørringen i dag når man skal hente ut gåavstand, så henter man ikke ut koordinatene til multimodalen, men kordinatet til første quayen som ligger under multimodalen. 

Bakgrunn: hvis man har en tavle satt opp i RG5, så viser det at gåavstanden til Dronningens gate er 4 minutter og til Oslo S 3 minutter. Dette er veldig rart da Oslo S er lengre unna enn Dronningens gate. Se slack her: https://entur.slack.com/archives/C9QDFPPQV/p1723182790373569 og her: [Message in Slack](https://entur.slack.com/archives/C071P1WECR0/p1723117138779809).

### Endringer: 

- Skriver om walkingDistanceQuery til å ta inn `from` og `to` som koordinater.
- Legger til to nye spørringer: `quayCoordinates` og `stopPlaceCoordinates`.
 -> Disse to brukes for å hente ut koordinater til stoppestedet basert på om det er en quay eller stopPlace.

> [!NOTE]  
> Gjerne dobbeltsjekk at det stemmer for ditt favorittstoppested🛑

