### PR TITLE
chore(board): remove logging 

### DIFF
--- a/tavla/pages/[id].tsx
+++ b/tavla/pages/[id].tsx
@@ -10,16 +10,11 @@ import { useRefresh } from 'hooks/useRefresh'
 import { getBackendUrl } from 'utils/index'
 import Head from 'next/head'
 import { useEffect } from 'react'
-import { logger } from 'utils/logger'
-import { IncomingMessage } from 'http'
 
-const log = logger.child({ module: 'board' })
 export async function getServerSideProps({
     params,
-    req,
 }: {
     params: { id: string }
-    req: IncomingMessage
 }) {
     const { id } = params
 
@@ -32,13 +27,6 @@ export async function getServerSideProps({
     }
 
     const organization = await getOrganizationWithBoard(id)
-
-    if (!req.headers['next-router-prefetch']) {
-        log.info({
-            boardID: board.id,
-            organization: organization?.name,
-        })
-    }
 
     return {
         props: {


### PR DESCRIPTION
Til vi vet hva vi skal logge, og hvordan vi skal gjøre det, så fjerner vi bare midlertidlig logging på tavlevisningen. Inntil videre fjerner vi ikke middlewaren, men har det som en todo å gjøre det hvis vi finner ut at vi ikke skal custom-logge noe fra løsningen vår.