### PR TITLE
fix(edit): remove direction from platform selector

### DIFF
--- a/tavla/app/(admin)/hooks/useQuaySearch.ts
+++ b/tavla/app/(admin)/hooks/useQuaySearch.ts
@@ -1,9 +1,7 @@
 import { QuaysSearchQuery } from 'graphql/index'
 import { isNotNullOrUndefined } from 'utils/typeguards'
-import { TDirectionType } from 'types/graphql-schema'
 import { NormalizedDropdownItemType } from '@entur/dropdown'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { countBy } from 'lodash'
 import { useQuery } from 'hooks/useQuery'
 import { SmallTravelTag } from 'components/TravelTag'
 
@@ -11,26 +9,11 @@ function getPlatformLabel(
     index: number,
     publicCode?: string | null,
     description?: string | null,
-    directionTypes?: (TDirectionType | null | undefined)[] | null,
 ) {
     if (!publicCode && !description) {
-        return `${index + 1} ${getDirection(directionTypes)}`
+        return `${index + 1}`
     }
     return [publicCode, description].filter(isNotNullOrUndefined).join(' ')
-}
-
-function getDirection(
-    directionTypes?: (TDirectionType | null | undefined)[] | null,
-) {
-    const directionCount = countBy(directionTypes)
-    const direction = Object.keys(directionCount).filter(
-        (k) =>
-            directionCount[k] ==
-            Math.max.apply(null, Object.values(directionCount)),
-    )[0]
-
-    if (direction === 'inbound') return '- Retning sentrum'
-    return ''
 }
 
 function useQuaySearch(stopPlaceId: string, icons = true) {
@@ -53,7 +36,6 @@ function useQuaySearch(stopPlaceId: string, icons = true) {
                         index,
                         quay.publicCode,
                         quay.description,
-                        quay.journeyPatterns.map((jp) => jp?.directionType),
                     ),
                     icons: quay.lines
                         ?.sort((l1, l2) => {

--- a/tavla/src/Shared/graphql/index.ts
+++ b/tavla/src/Shared/graphql/index.ts
@@ -211,10 +211,6 @@ export type TQuaysSearchQuery = {
                 __typename?: 'StopPlace'
                 transportMode: Array<Types.TTransportMode | null> | null
             } | null
-            journeyPatterns: Array<{
-                __typename?: 'JourneyPattern'
-                directionType: Types.TDirectionType | null
-            } | null>
             lines: Array<{
                 __typename?: 'Line'
                 id: string
@@ -560,9 +556,6 @@ export const QuaysSearchQuery = new TypedDocumentString(`
       description
       stopPlace {
         transportMode
-      }
-      journeyPatterns {
-        directionType
       }
       ...lines
     }

--- a/tavla/src/Shared/graphql/queries/quaySearch.graphql
+++ b/tavla/src/Shared/graphql/queries/quaySearch.graphql
@@ -7,9 +7,7 @@ query quaysSearch($stopPlaceId: String!) {
             stopPlace {
                 transportMode
             }
-            journeyPatterns {
-                directionType
-            }
+
             ...lines
         }
     }

--- a/tavla/src/Shared/types/graphql-schema.ts
+++ b/tavla/src/Shared/types/graphql-schema.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-export type Maybe<T> = T | null
+/* eslint-disable */ export type Maybe<T> = T | null
 export type InputMaybe<T> = Maybe<T>
 export type Exact<T extends { [key: string]: unknown }> = {
     [K in keyof T]: T[K]


### PR DESCRIPTION
Fjerner koden som bruker journeyPattern til å slenge på "- Retning sentrum" på noen plattformer, da team data har bekreftet at disse ikke er pålitelige. Fjernet derfor også journeyPattern fra graphQL-spørringen, den ble ikke brukt til noe annet.

Ref. brukermeldt bug der "- Retning sentrum" på Kværner lå på feil plattform på Kværner, den ser nå sånn ut:
![Screenshot 2024-10-24 at 12 22 48](https://github.com/user-attachments/assets/c1c38379-a072-41c2-9615-dfa582165310)
