### PR TITLE
chore(edit): refactor three getBoard-functions to one common

### DIFF
--- a/tavla/app/(admin)/boards/components/TagModal/actions.ts
+++ b/tavla/app/(admin)/boards/components/TagModal/actions.ts
@@ -9,9 +9,13 @@ import { firestore } from 'firebase-admin'
 import { TTag } from 'types/meta'
 import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
 import { getBoard } from 'Board/scenarios/Board/firebase'
+import { notFound } from 'next/navigation'
 
 async function fetchTags({ bid }: { bid: TBoardID }) {
     const board = await getBoard(bid)
+    if (!board) {
+        return notFound()
+    }
 
     const access = await hasBoardEditorAccess(board.id)
     if (!access) throw 'auth/operation-not-allowed'

--- a/tavla/app/(admin)/boards/components/TagModal/actions.ts
+++ b/tavla/app/(admin)/boards/components/TagModal/actions.ts
@@ -8,15 +8,15 @@ import { TBoardID } from 'types/settings'
 import { firestore } from 'firebase-admin'
 import { TTag } from 'types/meta'
 import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
+import { getBoard } from 'Board/scenarios/Board/firebase'
 
 async function fetchTags({ bid }: { bid: TBoardID }) {
-    const board = await firestore().collection('boards').doc(bid).get()
-    if (!board.exists) throw 'board/not-found'
+    const board = await getBoard(bid)
 
     const access = await hasBoardEditorAccess(board.id)
     if (!access) throw 'auth/operation-not-allowed'
 
-    return (board.data()?.meta?.tags as TTag[]) ?? []
+    return (board?.meta?.tags as TTag[]) ?? []
 }
 
 export async function removeTag(

--- a/tavla/app/(admin)/edit/[id]/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/actions.ts
@@ -5,19 +5,13 @@ import {
 } from 'app/(admin)/utils/firebase'
 import { firestore } from 'firebase-admin'
 import { redirect } from 'next/navigation'
-import { TBoard, TBoardID } from 'types/settings'
 import { TTile } from 'types/tile'
 import { getWalkingDistance } from 'app/(admin)/components/TileSelector/utils'
 import { TLocation } from 'types/meta'
 import { revalidatePath } from 'next/cache'
-import { makeBoardCompatible } from './compatibility'
+import { TBoardID } from 'types/settings'
 
 initializeAdminApp()
-
-export async function getBoard(bid: TBoardID) {
-    const board = await firestore().collection('boards').doc(bid).get()
-    return makeBoardCompatible({ id: board.id, ...board.data() } as TBoard)
-}
 
 export async function addTile(bid: TBoardID, tile: TTile) {
     const access = await hasBoardEditorAccess(bid)

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
@@ -11,8 +11,9 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { TFontSize, TLocation } from 'types/meta'
 import { TBoard, TBoardID, TOrganizationID } from 'types/settings'
-import { getBoard, getWalkingDistanceTile } from '../../actions'
+import { getWalkingDistanceTile } from '../../actions'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
+import { getBoard } from 'Board/scenarios/Board/firebase'
 
 initializeAdminApp()
 

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { TBoardID } from 'types/settings'
 import { addTile, getWalkingDistanceTile } from './actions'
 import { Heading1, Heading2 } from '@entur/typography'
@@ -27,6 +27,9 @@ export type TProps = {
 export async function generateMetadata({ params }: TProps): Promise<Metadata> {
     const { id } = params
     const board = await getBoard(id)
+    if (!board) {
+        return notFound()
+    }
     return {
         title: `${board.meta?.title ?? DEFAULT_BOARD_NAME} | Entur Tavla`,
     }
@@ -37,6 +40,9 @@ export default async function EditPage({ params }: TProps) {
     if (!user || !user.uid) return redirect('/')
 
     const board = await getBoard(params.id)
+    if (!board) {
+        return notFound()
+    }
     const organization = await getOrganizationForBoard(params.id)
 
     const access = await hasBoardEditorAccess(params.id)

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 import { TBoardID } from 'types/settings'
-import { addTile, getBoard, getWalkingDistanceTile } from './actions'
+import { addTile, getWalkingDistanceTile } from './actions'
 import { Heading1, Heading2 } from '@entur/typography'
 import { MetaSettings } from './components/MetaSettings'
 import { TileSelector } from 'app/(admin)/components/TileSelector'
@@ -18,6 +18,7 @@ import { Preview } from './components/Preview'
 import { ActionsMenu } from './components/ActionsMenu'
 import { ThemeSelect } from './components/ThemeSelect'
 import { TileList } from './components/TileList'
+import { getBoard } from 'Board/scenarios/Board/firebase'
 
 export type TProps = {
     params: { id: TBoardID }

--- a/tavla/app/(admin)/utils/firebase.ts
+++ b/tavla/app/(admin)/utils/firebase.ts
@@ -1,12 +1,6 @@
 'use server'
 import admin, { auth, firestore } from 'firebase-admin'
-import {
-    TBoard,
-    TBoardID,
-    TOrganization,
-    TOrganizationID,
-    TUser,
-} from 'types/settings'
+import { TBoardID, TOrganization, TOrganizationID, TUser } from 'types/settings'
 import { getUserFromSessionCookie } from './server'
 import {
     getBoardsForOrganization,
@@ -37,11 +31,6 @@ export async function verifySession(session?: string) {
     } catch {
         return null
     }
-}
-
-export async function getBoard(bid: TBoardID) {
-    const board = await firestore().collection('boards').doc(bid).get()
-    return { id: board.id, ...board.data() } as TBoard
 }
 
 export async function getUser() {

--- a/tavla/src/Board/scenarios/Board/firebase.ts
+++ b/tavla/src/Board/scenarios/Board/firebase.ts
@@ -1,4 +1,6 @@
+import { makeBoardCompatible } from 'app/(admin)/edit/[id]/compatibility'
 import admin, { firestore } from 'firebase-admin'
+import { notFound } from 'next/navigation'
 import { TBoard, TBoardID, TOrganization } from 'types/settings'
 
 initializeAdminApp()
@@ -14,7 +16,10 @@ async function initializeAdminApp() {
 
 export async function getBoard(bid: TBoardID) {
     const board = await firestore().collection('boards').doc(bid).get()
-    return { id: board.id, ...board.data() } as TBoard
+    if (!board.exists) {
+        notFound()
+    }
+    return makeBoardCompatible({ id: board.id, ...board.data() } as TBoard)
 }
 
 export async function getOrganizationWithBoard(bid: TBoardID) {

--- a/tavla/src/Board/scenarios/Board/firebase.ts
+++ b/tavla/src/Board/scenarios/Board/firebase.ts
@@ -1,6 +1,5 @@
 import { makeBoardCompatible } from 'app/(admin)/edit/[id]/compatibility'
 import admin, { firestore } from 'firebase-admin'
-import { notFound } from 'next/navigation'
 import { TBoard, TBoardID, TOrganization } from 'types/settings'
 
 initializeAdminApp()
@@ -17,7 +16,7 @@ async function initializeAdminApp() {
 export async function getBoard(bid: TBoardID) {
     const board = await firestore().collection('boards').doc(bid).get()
     if (!board.exists) {
-        notFound()
+        return undefined
     }
     return makeBoardCompatible({ id: board.id, ...board.data() } as TBoard)
 }


### PR DESCRIPTION
Tre getBoard-funksjoner er nå kombinert til én.

I tillegg går det ikke lenger an å gå inn på en random tavle-url og få opp en tom tavle (tavla.entur.no/123), det gir nå 404-side. Obs: må kjøres opp med yarn build-start for å sjekke dette.

