### PR TITLE
feat(monitoring): install prometheus and add /actuator/prometheus endpoint

### DIFF
--- a/tavla/app/actuator/prometheus/route.ts
+++ b/tavla/app/actuator/prometheus/route.ts
@@ -1,0 +1,15 @@
+import client from 'prom-client'
+
+const collectDefaultMetrics = client.collectDefaultMetrics
+const Registry = client.Registry
+const register = new Registry()
+collectDefaultMetrics({ register })
+
+export async function GET() {
+    const metrics = await register.metrics()
+    return new Response(metrics, {
+        headers: {
+            'Content-Type': register.contentType,
+        },
+    })
+}

--- a/tavla/helm/tavla/values.yaml
+++ b/tavla/helm/tavla/values.yaml
@@ -7,6 +7,9 @@ common:
         trafficType: public
     service:
         internalPort: 3000
+    deployment:
+        prometheus:
+            path: /actuator/prometheus
     container:
         image: <+artifacts.primary.image>
         cpu: 0.3
@@ -46,6 +49,7 @@ common:
                     periodSeconds: 5
                     successThreshold: 1
                     timeoutSeconds: 1
+
     configmap:
         enabled: true
         data:

--- a/tavla/package.json
+++ b/tavla/package.json
@@ -54,6 +54,7 @@
         "pino": "9.5.0",
         "pino-pretty": "11.3.0",
         "posthog-js": "1.176.0",
+        "prom-client": "15.1.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "sharp": "0.33.5",

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -3302,7 +3302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:~1.9.0":
+"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.4.0, @opentelemetry/api@npm:~1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
   checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
@@ -4827,6 +4827,13 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 56a52b7d3634e30002b1eda740d2517a22fa8e9e2eb088e919f37c030a0ed86e364ab59e472fc770fc8751308054bb1c892979d150e11d9e11ac33bcc1b5d16e
   languageName: node
   linkType: hard
 
@@ -12080,6 +12087,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:15.1.3":
+  version: 15.1.3
+  resolution: "prom-client@npm:15.1.3"
+  dependencies:
+    "@opentelemetry/api": ^1.4.0
+    tdigest: ^0.1.1
+  checksum: 9a57f3c16f39aa9a03da021883a4231c0bb56fc9d02f6ef9c28f913379f275640a5a33b98d9946ebf53c71011a29b580e9d2d6e3806cb1c229a3f59c65993968
+  languageName: node
+  linkType: hard
+
 "promise-breaker@npm:^6.0.0":
   version: 6.0.0
   resolution: "promise-breaker@npm:6.0.0"
@@ -14134,6 +14151,7 @@ __metadata:
     postcss: 8.4.47
     posthog-js: 1.176.0
     prettier: 3.3.3
+    prom-client: 15.1.3
     react: 18.3.1
     react-dom: 18.3.1
     sharp: 0.33.5
@@ -14150,6 +14168,15 @@ __metadata:
     debug: 4.3.1
     is2: ^2.0.6
   checksum: ea1bd3f7789a79bb228382e7314167357cd2a2dc3e17521393739075b85e3df0009c53aab4aaa9d180a59791ab152fe87079adaf05242c411b1778a41e543863
+  languageName: node
+  linkType: hard
+
+"tdigest@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "tdigest@npm:0.1.2"
+  dependencies:
+    bintrees: 1.0.2
+  checksum: 44de8246752b6f8c2924685f969fd3d94c36949f22b0907e99bef2b2220726dd8467f4730ea96b06040b9aa2587c0866049640039d1b956952dfa962bc2075a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Installerer pakken prom-client og setter opp endepunktet /actuator/prometheus som viser default metrics, vi kan senere sette opp custom metrics. Neste steg er å få metrics inn i grafana. Metrics på endepunktet ser sånn ut i dag:
![Screenshot 2024-10-31 at 08 51 19](https://github.com/user-attachments/assets/21ace8c2-5441-43da-a404-57ce1e6f5a90)




Vi har prøvd å følge guiden i Entur developer docs: https://enturas.atlassian.net/wiki/spaces/ESP/pages/1120960798/Metric+collection men litt usikker på om vi har gjort konfigurasjonen riktig med helm. @AlexanderBrevig hvis du har tid hadde det vært supert om du kunne ta en titt på denne PR-en og bekrefte at vi ikke mangler noe for at dette skal funke i dev og prod 😃