### PR TITLE
fix(boards): reduce debouncetimeout

### DIFF
--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -80,7 +80,7 @@ function TileSelector({
                     prepend={<SearchIcon />}
                     selectedItem={selectedStopPlace}
                     onChange={setSelectedStopPlace}
-                    debounceTimeout={1000}
+                    debounceTimeout={150}
                     {...getFormFeedbackForField('stop_place', state)}
                 />
             </div>

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
@@ -49,7 +49,7 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
                     items={pointItems}
                     selectedItem={selectedPoint}
                     onChange={setSelectedPoint}
-                    debounceTimeout={1000}
+                    debounceTimeout={150}
                     clearable
                 />
             </div>


### PR DESCRIPTION

Tried to time the waiting time for the search API to determine an appropriate debounceTimeout for the search, and also used [this post](https://stackoverflow.com/questions/42361485/how-long-should-you-debounce-text-input) as a reference. It seems like it takes around 100ms, so i chose it to be 150ms. 

LMK if we should change it 👍 