### PR TITLE
feat(dependabot): schedule dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ updates:
     - package-ecosystem: "npm"
       directory: "/tavla"
       schedule:
-          interval: "daily"
-          time: "10:00"
+          interval: "weekly"
+          day: "monday"
+          time: "08:00"
           timezone: "Europe/Amsterdam"
       commit-message:
           prefix: "chore(deps):"


### PR DESCRIPTION
Det er mer hensiktsmessig å oppdatere pakker én gang i uka. Sikkerhetsoppdateringer kommer likevel så fort det er nye vulnerabilities. 

Interval "daily" er fin å ha i begynnelsen, men er nå ikke nødvendig lenger.

-> "weekly"
- Mandag
- 08:00

