### PR TITLE
fix(boards): set board name to be link in table in mobile view

### DIFF
--- a/tavla/app/(admin)/boards/components/Column/Name.tsx
+++ b/tavla/app/(admin)/boards/components/Column/Name.tsx
@@ -6,15 +6,9 @@ import Link from 'next/link'
 function Name({ board }: { board: TBoard }) {
     return (
         <Column column="name">
-            <Link
-                href={`/edit/${board.id}`}
-                className="hidden sm:block hover:underline"
-            >
+            <Link href={`/edit/${board.id}`} className="hover:underline">
                 {board.meta.title ?? DEFAULT_BOARD_NAME}
             </Link>
-            <p className="block sm:hidden">
-                {board.meta.title ?? DEFAULT_BOARD_NAME}
-            </p>
         </Column>
     )
 }


### PR DESCRIPTION
Tavle-navn i tabellen på /boards er nå clickable på mobil
![Screenshot 2024-11-21 at 08 53 06](https://github.com/user-attachments/assets/ff3c3028-7855-4e6a-86ad-4e00f398e146)
