### PR TITLE
style(organizations): add button to empty org page

### DIFF
--- a/tavla/app/(admin)/boards/components/BoardTable/index.tsx
+++ b/tavla/app/(admin)/boards/components/BoardTable/index.tsx
@@ -17,7 +17,7 @@ function BoardTable({
     if (isEmpty(boardsWithOrg))
         return (
             <IllustratedInfo
-                title="Her var det tomt"
+                title="Her var det tomt!"
                 description="Du har ikke laget noen tavler ennå"
             >
                 <PrimaryButton as={Link} href="?board">

--- a/tavla/app/(admin)/components/IllustratedInfo/index.tsx
+++ b/tavla/app/(admin)/components/IllustratedInfo/index.tsx
@@ -15,7 +15,7 @@ function IllustratedInfo({
         <div className="flex flex-col items-center bg-secondary rounded pb-16">
             <Image src={animals} aria-hidden="true" alt="" />
             <Heading2 className="my-4">{title}</Heading2>
-            <LeadParagraph margin="bottom">{description}</LeadParagraph>
+            <LeadParagraph className="text-center">{description}</LeadParagraph>
             {children}
         </div>
     )

--- a/tavla/app/(admin)/organizations/components/Organizations.tsx
+++ b/tavla/app/(admin)/organizations/components/Organizations.tsx
@@ -6,9 +6,7 @@ import NextLink from 'next/link'
 import { Actions } from './Actions'
 import { IllustratedInfo } from 'app/(admin)/components/IllustratedInfo'
 import { isEmpty } from 'lodash'
-import { PrimaryButton } from '@entur/button'
-import { AddIcon } from '@entur/icons'
-import { CreateBoard } from 'app/(admin)/components/CreateBoard'
+import { CreateOrganization } from './CreateOrganization'
 
 function Organizations({
     userId,
@@ -23,9 +21,7 @@ function Organizations({
                 title="Her var det tomt!"
                 description="Du har ikke opprettet noen organisasjoner ennå."
             >
-                <PrimaryButton as={Link} href="?create">
-                    Opprett organisasjon <AddIcon /> <CreateBoard />
-                </PrimaryButton>
+                <CreateOrganization />
             </IllustratedInfo>
         )
     return (

--- a/tavla/app/(admin)/organizations/components/Organizations.tsx
+++ b/tavla/app/(admin)/organizations/components/Organizations.tsx
@@ -6,6 +6,9 @@ import NextLink from 'next/link'
 import { Actions } from './Actions'
 import { IllustratedInfo } from 'app/(admin)/components/IllustratedInfo'
 import { isEmpty } from 'lodash'
+import { PrimaryButton } from '@entur/button'
+import { AddIcon } from '@entur/icons'
+import { CreateBoard } from 'app/(admin)/components/CreateBoard'
 
 function Organizations({
     userId,
@@ -17,9 +20,13 @@ function Organizations({
     if (isEmpty(organizations))
         return (
             <IllustratedInfo
-                title="Her var det tomt"
-                description="Du er ikke en del av noen organisasjoner ennå"
-            />
+                title="Her var det tomt!"
+                description="Du har ikke opprettet noen organisasjoner ennå."
+            >
+                <PrimaryButton as={Link} href="?create">
+                    Opprett organisasjon <AddIcon /> <CreateBoard />
+                </PrimaryButton>
+            </IllustratedInfo>
         )
     return (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">


### PR DESCRIPTION
Endret ordlyd og lagt til opprett-knapp på tom organisasjons-side, så den matcher tom tavle-siden.
![Screenshot 2024-11-21 at 09 09 31](https://github.com/user-attachments/assets/0f3c45f5-6761-4b95-885f-2230add09473)
