### PR TITLE
fix(edit): cancel-button in TileCard triggers modal

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -453,7 +453,15 @@ function TileCard({
                             >
                                 Lagre valg
                             </SubmitButton>
-                            <Button variant="secondary" aria-label="avbryt">
+                            <Button
+                                variant="secondary"
+                                aria-label="avbryt"
+                                type="button"
+                                onClick={() => {
+                                    if (changed) return setConfirmOpen(true)
+                                    return setIsOpen(false)
+                                }}
+                            >
                                 Avbryt
                             </Button>
                             <NegativeButton


### PR DESCRIPTION
Når man trykker på "Avbryt"-knappen i TileCard (og har gjort endringer) åpnes bekreftelses-modalen hvor du får mulighet til å lagre en gang til. Trykker man avbryt igjen lagres ikke endringene.

<img width="570" alt="Screenshot 2024-11-22 at 10 38 20" src="https://github.com/user-attachments/assets/c5904ff8-342b-410e-9b1b-cd6c4f06c75c">
