### PR TITLE
feat(sentry): capture error in Sentry when departure fetch fails

### DIFF
--- a/tavla/README.md
+++ b/tavla/README.md
@@ -25,7 +25,7 @@ The project integrates with Sentry for error tracking and performance monitoring
 2. Add the following lines to your `.env.local` file:
 
 ```bash
-SENTRY_DSN_URL=your-sentry-dsn-url
+PUBLIC_NEXT_SENTRY_DSN_URL=your-sentry-dsn-url
 SENTRY_AUTH_TOKEN=your-sentry-auth-token
 ```
 

--- a/tavla/README.md
+++ b/tavla/README.md
@@ -25,7 +25,7 @@ The project integrates with Sentry for error tracking and performance monitoring
 2. Add the following lines to your `.env.local` file:
 
 ```bash
-PUBLIC_NEXT_SENTRY_DSN_URL=your-sentry-dsn-url
+NEXT_PUBLIC_SENTRY_DSN_URL=your-sentry-dsn-url
 SENTRY_AUTH_TOKEN=your-sentry-auth-token
 ```
 

--- a/tavla/helm/tavla/values.yaml
+++ b/tavla/helm/tavla/values.yaml
@@ -30,7 +30,7 @@ common:
                       name: sentry
                       key: auth-token
 
-            - name: SENTRY_DSN_URL
+            - name: NEXT_PUBLIC_SENTRY_DSN_URL
               valueFrom:
                   secretKeyRef:
                       name: sentry

--- a/tavla/pages/[id].tsx
+++ b/tavla/pages/[id].tsx
@@ -121,7 +121,7 @@ const getTileData = async (board: TBoard) => {
                     Sentry.captureException(error, {
                         extra: {
                             message:
-                                'server-side fetching of stopPlace data failed',
+                                'Server-side fetching of departures for stopPlace failed',
                             queryVariables: variables,
                         },
                     })
@@ -142,7 +142,8 @@ const getTileData = async (board: TBoard) => {
                 } catch (error) {
                     Sentry.captureException(error, {
                         extra: {
-                            message: 'server-side fetching of quay data failed',
+                            message:
+                                'Server-side fetching of departures for quay failed',
                             queryVariables: variables,
                         },
                     })

--- a/tavla/sentry.client.config.ts
+++ b/tavla/sentry.client.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
-    dsn: process.env.SENTRY_DSN_URL,
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN_URL,
 
     tracesSampleRate: 1,
 

--- a/tavla/sentry.edge.config.ts
+++ b/tavla/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
-    dsn: process.env.SENTRY_DSN_URL,
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN_URL,
 
     tracesSampleRate: 1,
 

--- a/tavla/sentry.server.config.ts
+++ b/tavla/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
-    dsn: process.env.SENTRY_DSN_URL,
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN_URL,
 
     tracesSampleRate: 1,
 

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -43,18 +43,16 @@ export function QuayTile({
     }
 
     if (error || !data || !data.quay) {
-        Sentry.captureException(
-            new Error(
-                error
-                    ? 'Unknown error occurred while fetching quay departures'
-                    : 'Departure fetch for quay returned no data',
-            ),
-            {
-                extra: {
-                    quayId: placeId,
+        if (!error) {
+            Sentry.captureException(
+                new Error('Departure fetch for quay returned no data'),
+                {
+                    extra: {
+                        quayId: placeId,
+                    },
                 },
-            },
-        )
+            )
+        }
         return (
             <Tile>
                 <DataFetchingFailed

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -11,6 +11,7 @@ import {
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
 import { TTheme } from 'types/settings'
+import * as Sentry from '@sentry/nextjs'
 
 export function QuayTile({
     placeId,
@@ -42,6 +43,18 @@ export function QuayTile({
     }
 
     if (error || !data || !data.quay) {
+        Sentry.captureException(
+            new Error(
+                error
+                    ? 'Unknown error occurred while fetching quay departures'
+                    : 'Departure fetch for quay returned no data',
+            ),
+            {
+                extra: {
+                    quayId: placeId,
+                },
+            },
+        )
         return (
             <Tile>
                 <DataFetchingFailed

--- a/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -42,18 +42,16 @@ export function StopPlaceTile({
     }
 
     if (error || !data || !data.stopPlace) {
-        Sentry.captureException(
-            new Error(
-                error
-                    ? 'Unknown error occurred while fetching stopPlace departures'
-                    : 'Departure fetch for stopPlace returned no data',
-            ),
-            {
-                extra: {
-                    stopPlaceId: placeId,
+        if (!error) {
+            Sentry.captureException(
+                new Error('Departure fetch for stopPlace returned no data'),
+                {
+                    extra: {
+                        stopPlaceId: placeId,
+                    },
                 },
-            },
-        )
+            )
+        }
         return (
             <Tile>
                 <DataFetchingFailed

--- a/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -10,6 +10,7 @@ import {
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
 import { TTheme } from 'types/settings'
+import * as Sentry from '@sentry/nextjs'
 
 export function StopPlaceTile({
     placeId,
@@ -41,6 +42,18 @@ export function StopPlaceTile({
     }
 
     if (error || !data || !data.stopPlace) {
+        Sentry.captureException(
+            new Error(
+                error
+                    ? 'Unknown error occurred while fetching stopPlace departures'
+                    : 'Departure fetch for stopPlace returned no data',
+            ),
+            {
+                extra: {
+                    stopPlaceId: placeId,
+                },
+            },
+        )
         return (
             <Tile>
                 <DataFetchingFailed


### PR DESCRIPTION
Denne PR-en fikser sentry-konfigurasjonen vår så dsn-variabelen også er tilgjengelig på klientens browser (og vi får tak i feil derfra).

I tillegg legges det på en custom error-catching når fetch fra journeyplanner feiler, timer ut eller ikke returnerer noe data.

edit: legger også på custom feilmelding når server-side fetch feiler.

For å teste dette lokalt må du først:
- kommentere ut `enabled: process.env.NODE_ENV !== 'development',` fra de tre sentry-config-filene
- sjekke at localhost-feilmeldinger ikke er filtrert bort i sentry-prosjektet (inn på sentry web client)
- endre dsn-variabelnavnet på env.local til `NEXT_PUBLIC_SENTRY_DSN_URL`

så må du kræsje fetch, f eks ved å endre timeout-verdien til et veldig lavt tall.

Bør dukke opp i sentry:
![Screenshot 2024-11-29 at 11 07 22](https://github.com/user-attachments/assets/c086d874-9a18-4182-8965-ba7bc74b0675)
