### PR TITLE
fix(edit): allow removing tile after whitelistedLines is set

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/TileCard/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/actions.ts
@@ -9,12 +9,26 @@ import {
     initializeAdminApp,
 } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
+import { SWITCH_DATE, NEW_LINE_IDS, OLD_LINE_IDS } from '../../compatibility'
 
 initializeAdminApp()
 
 export async function deleteTile(bid: TBoardID, tile: TTile) {
     const access = await hasBoardOwnerAccess(bid)
     if (!access) return redirect('/')
+
+    // TODO: refactor 15. december when new lines are active
+    if (tile.whitelistedLines) {
+        if (Date.now() < Date.parse(SWITCH_DATE.toString())) {
+            tile.whitelistedLines = tile.whitelistedLines.filter(
+                (line) => !NEW_LINE_IDS.includes(line),
+            )
+        } else {
+            tile.whitelistedLines = tile.whitelistedLines.filter(
+                (line) => !OLD_LINE_IDS.includes(line),
+            )
+        }
+    }
 
     await firestore()
         .collection('boards')

--- a/tavla/app/(admin)/edit/[id]/components/TileList/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileList/index.tsx
@@ -16,10 +16,10 @@ function TileList({
     bid?: TBoardID
     setDemoBoard?: Dispatch<SetStateAction<TBoard>>
 }) {
-    const [array, setArray] = useState<TTile[]>(board.tiles)
+    const [tileArray, setTileArray] = useState<TTile[]>(board.tiles)
 
     useEffect(() => {
-        setArray(board.tiles)
+        setTileArray(board.tiles)
     }, [board.tiles])
 
     const moveItem = (index: number, direction: string) => {
@@ -35,7 +35,7 @@ function TileList({
         newArray[newIndex] = newArray[index] as TTile
         newArray[index] = oldElement as TTile
 
-        setArray(newArray)
+        setTileArray(newArray)
         if (bid === 'demo' && setDemoBoard) {
             const newBoard: TBoard = { ...board, tiles: newArray }
             setDemoBoard(newBoard ?? board)
@@ -46,7 +46,7 @@ function TileList({
     const debouncedSave = debounce(moveItem, 150)
     return (
         <div className="flex flex-col gap-4">
-            {array.map((tile, index) => (
+            {tileArray.map((tile, index) => (
                 <TileCard
                     key={tile.uuid}
                     bid={bid ?? board.id ?? ''}


### PR DESCRIPTION
Fikser bug der det ikke gikk an å slette stoppested når whitelistedLines var satt, fordi codespace endringen gjorde at objektet i firebase ikke var lik tile-objektet hos klient. 


La på en sjekk som kan delvis fjernes etter 15. desember