### PR TITLE
feat(settings): show error alert to user if firebase fail in edit and organization

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
@@ -1,5 +1,6 @@
 'use server'
 import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
+import { TFormFeedback } from 'app/(admin)/utils'
 import {
     hasBoardEditorAccess,
     initializeAdminApp,
@@ -12,7 +13,11 @@ import { TBoardID } from 'types/settings'
 
 initializeAdminApp()
 
-export async function setFooter(bid: TBoardID, data: FormData) {
+export async function setFooter(
+    state: TFormFeedback | undefined,
+    bid: TBoardID,
+    data: FormData,
+) {
     const access = hasBoardEditorAccess(bid)
     if (!access) return redirect('/')
 

--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -71,7 +71,7 @@ function Footer({
                         Vis infomelding fra organisasjonen.
                     </Switch>
                 )}
-                <div>
+                <div className="mt-4">
                     <FormError
                         {...getFormFeedbackForField('general', footerState)}
                     />

--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -6,9 +6,11 @@ import { Heading3 } from '@entur/typography'
 import { SubmitButton } from 'components/Form/SubmitButton'
 import { TBoardID, TFooter } from 'types/settings'
 import { setFooter as setFooterAction } from './actions'
-import { useState } from 'react'
+import { useActionState, useState } from 'react'
 import { Tooltip } from '@entur/tooltip'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import { FormError } from 'app/(admin)/components/FormError'
 
 function Footer({
     bid,
@@ -22,15 +24,25 @@ function Footer({
     const { addToast } = useToast()
     const [override, setOverride] = useState(footer?.override ?? false)
 
-    const setFooter = async (data: FormData) => {
-        const formFeedback = await setFooterAction(bid, data)
+    const setFooter = async (
+        state: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
+        const formFeedback = await setFooterAction(state, bid, data)
+
         if (!formFeedback) {
             addToast('Infomelding lagret!')
         }
+        return formFeedback
     }
 
+    const [footerState, setFooterFormAction] = useActionState(
+        setFooter,
+        undefined,
+    )
+
     return (
-        <form className="box flex flex-col" action={setFooter}>
+        <form className="box flex flex-col" action={setFooterFormAction}>
             <div className="flex flex-row items-center gap-2">
                 <Heading3 margin="bottom">Infomelding</Heading3>
 
@@ -59,6 +71,11 @@ function Footer({
                         Vis infomelding fra organisasjonen.
                     </Switch>
                 )}
+                <div>
+                    <FormError
+                        {...getFormFeedbackForField('general', footerState)}
+                    />
+                </div>
             </div>
             <div className="flex flex-row mt-8 justify-end">
                 <SubmitButton

--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -36,13 +36,10 @@ function Footer({
         return formFeedback
     }
 
-    const [footerState, setFooterFormAction] = useActionState(
-        setFooter,
-        undefined,
-    )
+    const [footerState, footerFormAction] = useActionState(setFooter, undefined)
 
     return (
-        <form className="box flex flex-col" action={setFooterFormAction}>
+        <form className="box flex flex-col" action={footerFormAction}>
             <div className="flex flex-row items-center gap-2">
                 <Heading3 margin="bottom">Infomelding</Heading3>
 

--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -9,7 +9,6 @@ import { setFooter as setFooterAction } from './actions'
 import { useState } from 'react'
 import { Tooltip } from '@entur/tooltip'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
-import { fireToastFeedback } from 'app/(admin)/utils'
 
 function Footer({
     bid,
@@ -24,8 +23,10 @@ function Footer({
     const [override, setOverride] = useState(footer?.override ?? false)
 
     const setFooter = async (data: FormData) => {
-        const result = await setFooterAction(bid, data)
-        fireToastFeedback(addToast, result, 'Infomelding lagret!')
+        const formFeedback = await setFooterAction(bid, data)
+        if (!formFeedback) {
+            addToast('Infomelding lagret!')
+        }
     }
 
     return (
@@ -62,7 +63,7 @@ function Footer({
             <div className="flex flex-row mt-8 justify-end">
                 <SubmitButton
                     variant="secondary"
-                    aria-label="Lagre kolonner"
+                    aria-label="Lagre infomelding"
                     className="max-sm:w-full"
                 >
                     Lagre infomelding

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useToast } from '@entur/alert'
 import { SearchableDropdown } from '@entur/dropdown'
 import { ValidationInfoFilledIcon } from '@entur/icons'
@@ -5,7 +6,6 @@ import { Tooltip } from '@entur/tooltip'
 import { Heading3 } from '@entur/typography'
 import { saveLocation as saveLocationAction } from 'app/(admin)/edit/[id]/components/MetaSettings/actions'
 import { usePointSearch } from 'app/(admin)/hooks/usePointSearch'
-import { fireToastFeedback } from 'app/(admin)/utils'
 import ClientOnly from 'app/components/NoSSR/ClientOnly'
 import { SubmitButton } from 'components/Form/SubmitButton'
 
@@ -18,8 +18,10 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
     const { addToast } = useToast()
 
     const saveLocation = async () => {
-        const result = await saveLocationAction(bid, selectedPoint?.value)
-        fireToastFeedback(addToast, result, 'Adresse oppdatert!')
+        const formFeedback = await saveLocationAction(bid, selectedPoint?.value)
+        if (!formFeedback) {
+            addToast('Adresse oppdatert!')
+        }
     }
 
     return (

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Adress.tsx
@@ -4,10 +4,13 @@ import { SearchableDropdown } from '@entur/dropdown'
 import { ValidationInfoFilledIcon } from '@entur/icons'
 import { Tooltip } from '@entur/tooltip'
 import { Heading3 } from '@entur/typography'
+import { FormError } from 'app/(admin)/components/FormError'
 import { saveLocation as saveLocationAction } from 'app/(admin)/edit/[id]/components/MetaSettings/actions'
 import { usePointSearch } from 'app/(admin)/hooks/usePointSearch'
+import { getFormFeedbackForField } from 'app/(admin)/utils'
 import ClientOnly from 'app/components/NoSSR/ClientOnly'
 import { SubmitButton } from 'components/Form/SubmitButton'
+import { useActionState } from 'react'
 
 import { TLocation } from 'types/meta'
 import { TBoardID } from 'types/settings'
@@ -22,10 +25,16 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
         if (!formFeedback) {
             addToast('Adresse oppdatert!')
         }
+        return formFeedback
     }
 
+    const [locationState, saveLocationFormAction] = useActionState(
+        saveLocation,
+        undefined,
+    )
+
     return (
-        <form action={saveLocation} className="box flex flex-col">
+        <form action={saveLocationFormAction} className="box flex flex-col">
             <div className="flex flex-row items-center gap-2">
                 <Heading3 margin="bottom">Adresse</Heading3>
 
@@ -51,6 +60,11 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
                         clearable
                     />
                 </ClientOnly>
+            </div>
+            <div className="mt-4">
+                <FormError
+                    {...getFormFeedbackForField('general', locationState)}
+                />
             </div>
             <div className="flex flex-row mt-8 justify-end">
                 <SubmitButton variant="secondary" className="max-sm:w-full">

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/FontSelect.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/FontSelect.tsx
@@ -6,21 +6,36 @@ import { saveFont as saveFontAction } from './actions'
 import { TBoardID } from 'types/settings'
 import { useToast } from '@entur/alert'
 import { FontChoiceChip } from './FontChoiceChip'
+import { useActionState } from 'react'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import { FormError } from 'app/(admin)/components/FormError'
 
 function FontSelect({ bid, font }: { bid: TBoardID; font: TFontSize }) {
     const { addToast } = useToast()
 
-    const saveFont = async (data: FormData) => {
+    const saveFont = async (
+        state: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
         const formFeedback = await saveFontAction(bid, data)
         if (!formFeedback) {
             addToast('Tekststørrelse lagret!')
         }
+        return formFeedback
     }
 
+    const [fontState, setFontFormAction] = useActionState(saveFont, undefined)
+
     return (
-        <form action={saveFont} className="box flex flex-col justify-between">
+        <form
+            action={setFontFormAction}
+            className="box flex flex-col justify-between"
+        >
             <Heading3 margin="bottom">Tekststørrelse </Heading3>
-            <FontChoiceChip font={font}></FontChoiceChip>
+            <FontChoiceChip font={font} />
+            <div className="mt-4">
+                <FormError {...getFormFeedbackForField('general', fontState)} />
+            </div>
             <div className="flex flex-row mt-8 justify-end">
                 <SubmitButton variant="secondary" className="max-sm:w-full">
                     Lagre tekststørrelse

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/FontSelect.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/FontSelect.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { Heading3 } from '@entur/typography'
+import { SubmitButton } from 'components/Form/SubmitButton'
+import { TFontSize } from 'types/meta'
+import { saveFont as saveFontAction } from './actions'
+import { TBoardID } from 'types/settings'
+import { useToast } from '@entur/alert'
+import { FontChoiceChip } from './FontChoiceChip'
+
+function FontSelect({ bid, font }: { bid: TBoardID; font: TFontSize }) {
+    const { addToast } = useToast()
+
+    const saveFont = async (data: FormData) => {
+        const formFeedback = await saveFontAction(bid, data)
+        if (!formFeedback) {
+            addToast('Tekststørrelse lagret!')
+        }
+    }
+
+    return (
+        <form action={saveFont} className="box flex flex-col justify-between">
+            <Heading3 margin="bottom">Tekststørrelse </Heading3>
+            <FontChoiceChip font={font}></FontChoiceChip>
+            <div className="flex flex-row mt-8 justify-end">
+                <SubmitButton variant="secondary" className="max-sm:w-full">
+                    Lagre tekststørrelse
+                </SubmitButton>
+            </div>
+        </form>
+    )
+}
+
+export { FontSelect }

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/FontSelect.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/FontSelect.tsx
@@ -24,11 +24,11 @@ function FontSelect({ bid, font }: { bid: TBoardID; font: TFontSize }) {
         return formFeedback
     }
 
-    const [fontState, setFontFormAction] = useActionState(saveFont, undefined)
+    const [fontState, fontFormAction] = useActionState(saveFont, undefined)
 
     return (
         <form
-            action={setFontFormAction}
+            action={fontFormAction}
             className="box flex flex-col justify-between"
         >
             <Heading3 margin="bottom">Tekststørrelse </Heading3>

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Organization.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Organization.tsx
@@ -1,0 +1,80 @@
+'use client'
+import { Dropdown } from '@entur/dropdown'
+import { Checkbox } from '@entur/form'
+import { Heading3 } from '@entur/typography'
+import { FormError } from 'app/(admin)/components/FormError'
+import { useOrganizations } from 'app/(admin)/hooks/useOrganizations'
+import { getFormFeedbackForField } from 'app/(admin)/utils'
+import ClientOnly from 'app/components/NoSSR/ClientOnly'
+import { SubmitButton } from 'components/Form/SubmitButton'
+import { useState, useActionState } from 'react'
+import { TBoardID, TOrganization } from 'types/settings'
+import { moveBoard as moveBoardAction } from './actions'
+import { useToast } from '@entur/alert'
+
+function Organization({
+    bid,
+    organization,
+}: {
+    bid: TBoardID
+    organization?: TOrganization
+}) {
+    const { addToast } = useToast()
+
+    const { organizations, selectedOrganization, setSelectedOrganization } =
+        useOrganizations(organization)
+    const [personal, setPersonal] = useState(organization ? false : true)
+
+    const moveBoard = async () => {
+        const formFeedback = await moveBoardAction(
+            bid,
+            personal,
+            selectedOrganization?.value.id,
+            organization?.id,
+        )
+        if (!formFeedback) {
+            addToast('Tavlen ble flyttet til organisasjon!')
+        }
+        return formFeedback
+    }
+
+    const [moveBoardState, moveBordFormAction] = useActionState(
+        moveBoard,
+        undefined,
+    )
+    return (
+        <form action={moveBordFormAction} className="box flex flex-col">
+            <Heading3 margin="bottom">Organisasjon</Heading3>
+            <ClientOnly>
+                <Dropdown
+                    items={organizations}
+                    label="Dine organisasjoner"
+                    selectedItem={selectedOrganization}
+                    onChange={setSelectedOrganization}
+                    clearable
+                    className="mb-4"
+                    aria-required="true"
+                    disabled={personal}
+                />
+            </ClientOnly>
+            <Checkbox
+                defaultChecked={personal}
+                onChange={() => setPersonal(!personal)}
+                name="personal"
+                className="!mb-4"
+            >
+                Privat tavle
+            </Checkbox>
+            <FormError
+                {...getFormFeedbackForField('organization', moveBoardState)}
+            />
+            <div className="flex flex-row mt-8 justify-end">
+                <SubmitButton variant="secondary" className="max-sm:w-full">
+                    Lagre organisasjon
+                </SubmitButton>
+            </div>
+        </form>
+    )
+}
+
+export { Organization }

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Organization.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Organization.tsx
@@ -61,13 +61,17 @@ function Organization({
                 defaultChecked={personal}
                 onChange={() => setPersonal(!personal)}
                 name="personal"
-                className="!mb-4"
             >
                 Privat tavle
             </Checkbox>
-            <FormError
-                {...getFormFeedbackForField('organization', moveBoardState)}
-            />
+            <div className="mt-4">
+                <FormError
+                    {...getFormFeedbackForField('organization', moveBoardState)}
+                />
+                <FormError
+                    {...getFormFeedbackForField('general', moveBoardState)}
+                />
+            </div>
             <div className="flex flex-row mt-8 justify-end">
                 <SubmitButton variant="secondary" className="max-sm:w-full">
                     Lagre organisasjon

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Title.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Title.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { useToast } from '@entur/alert'
+import { Heading3 } from '@entur/typography'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import ClientOnlyTextField from 'app/components/NoSSR/TextField'
+import { SubmitButton } from 'components/Form/SubmitButton'
+import { useActionState } from 'react'
+import { saveTitle as saveTitleAction } from './actions'
+import { TBoardID } from 'types/settings'
+
+function Title({ bid, title }: { bid: TBoardID; title: string }) {
+    const { addToast } = useToast()
+
+    const saveTitle = async (
+        state: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
+        const formFeedback = await saveTitleAction(state, bid, data)
+        if (!formFeedback) {
+            addToast('Navnet på tavlen er lagret!')
+        }
+        return formFeedback
+    }
+    const [titleState, saveTitleFormAction] = useActionState(
+        saveTitle,
+        undefined,
+    )
+    return (
+        <form action={saveTitleFormAction} className="box flex flex-col">
+            <Heading3 margin="bottom">Navn</Heading3>
+            <div className="h-full">
+                <ClientOnlyTextField
+                    name="name"
+                    className="w-full"
+                    defaultValue={title}
+                    label="Navn på tavlen"
+                    maxLength={50}
+                    {...getFormFeedbackForField('name', titleState)}
+                />
+            </div>
+            <div className="flex flex-row justify-end mt-8">
+                <SubmitButton variant="secondary" className="max-sm:w-full">
+                    Lagre navn
+                </SubmitButton>
+            </div>
+        </form>
+    )
+}
+export { Title }

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/Title.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/Title.tsx
@@ -7,6 +7,7 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { useActionState } from 'react'
 import { saveTitle as saveTitleAction } from './actions'
 import { TBoardID } from 'types/settings'
+import { FormError } from 'app/(admin)/components/FormError'
 
 function Title({ bid, title }: { bid: TBoardID; title: string }) {
     const { addToast } = useToast()
@@ -36,6 +37,11 @@ function Title({ bid, title }: { bid: TBoardID; title: string }) {
                     label="Navn på tavlen"
                     maxLength={50}
                     {...getFormFeedbackForField('name', titleState)}
+                />
+            </div>
+            <div className="mt-4">
+                <FormError
+                    {...getFormFeedbackForField('general', titleState)}
                 />
             </div>
             <div className="flex flex-row justify-end mt-8">

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
@@ -110,15 +110,13 @@ export async function moveBoard(
         return getFormFeedbackForError('create/organization-missing')
 
     if (fromOrganization) {
-        const canEditFromOrganization =
-            await userCanEditOrganization(fromOrganization)
-        if (!canEditFromOrganization) return redirect('/')
+        const canEdit = await userCanEditOrganization(fromOrganization)
+        if (!canEdit) return redirect('/')
     }
 
     if (toOrganization) {
-        const canEditToOrganization =
-            await userCanEditOrganization(toOrganization)
-        if (!canEditToOrganization) return redirect('/')
+        const canEdit = await userCanEditOrganization(toOrganization)
+        if (!canEdit) return redirect('/')
     }
 
     try {

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
@@ -109,12 +109,11 @@ export async function moveBoard(
     if (!personal && !toOrganization)
         return getFormFeedbackForError('create/organization-missing')
 
-    if (!toOrganization)
-        if (fromOrganization) {
-            const canEditFromOrganization =
-                await userCanEditOrganization(fromOrganization)
-            if (!canEditFromOrganization) return redirect('/')
-        }
+    if (fromOrganization) {
+        const canEditFromOrganization =
+            await userCanEditOrganization(fromOrganization)
+        if (!canEditFromOrganization) return redirect('/')
+    }
 
     if (toOrganization) {
         const canEditToOrganization =

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/index.tsx
@@ -1,28 +1,10 @@
-'use client'
-import { Checkbox } from '@entur/form'
-import { Heading3 } from '@entur/typography'
 import { TMeta } from 'types/meta'
-import {
-    moveBoard as moveBoardAction,
-    saveFont as saveFontAction,
-    saveTitle as saveTitleAction,
-} from './actions'
 import { TBoardID, TOrganization } from 'types/settings'
-import { FontChoiceChip } from './FontChoiceChip'
-import { SubmitButton } from 'components/Form/SubmitButton'
 import { Address } from './Adress'
 import { DEFAULT_BOARD_NAME } from 'app/(admin)/utils/constants'
-import { useToast } from '@entur/alert'
-import { Dropdown } from '@entur/dropdown'
-import { useOrganizations } from 'app/(admin)/hooks/useOrganizations'
-import { useActionState, useState } from 'react'
-import {
-    TFormFeedback,
-    fireToastFeedback,
-    getFormFeedbackForField,
-} from 'app/(admin)/utils'
-import ClientOnlyTextField from 'app/components/NoSSR/TextField'
-import ClientOnly from 'app/components/NoSSR/ClientOnly'
+import { Organization } from './Organization'
+import { FontSelect } from './FontSelect'
+import { Title } from './Title'
 
 function MetaSettings({
     bid,
@@ -33,98 +15,12 @@ function MetaSettings({
     meta: TMeta
     organization?: TOrganization
 }) {
-    const { addToast } = useToast()
-    const { organizations, selectedOrganization, setSelectedOrganization } =
-        useOrganizations(organization)
-    const [personal, setPersonal] = useState(organization ? false : true)
-
-    const saveTitleWithParams = async (
-        state: TFormFeedback | undefined,
-        data: FormData,
-    ) => {
-        const result = await saveTitleAction(state, bid, data)
-        fireToastFeedback(addToast, result, 'Tittel oppdatert!')
-        return result
-    }
-    const [titleState, saveTitle] = useActionState(
-        saveTitleWithParams,
-        undefined,
-    )
-
-    const saveFont = async (data: FormData) => {
-        const result = await saveFontAction(bid, data)
-        fireToastFeedback(addToast, result, 'Tekststørrelse lagret!')
-    }
-
-    const moveBoard = async () => {
-        const result = await moveBoardAction(
-            bid,
-            personal ? undefined : selectedOrganization?.value.id,
-            organization?.id,
-        )
-        fireToastFeedback(addToast, result, 'Organisasjon lagret!')
-    }
-
     return (
         <>
-            <form action={saveTitle} className="box flex flex-col">
-                <Heading3 margin="bottom">Navn</Heading3>
-                <div className="h-full">
-                    <ClientOnlyTextField
-                        name="name"
-                        className="w-full"
-                        defaultValue={meta?.title ?? DEFAULT_BOARD_NAME}
-                        label="Navn på tavlen"
-                        maxLength={50}
-                        {...getFormFeedbackForField('name', titleState)}
-                    />
-                </div>
-                <div className="flex flex-row justify-end mt-8">
-                    <SubmitButton variant="secondary" className="max-sm:w-full">
-                        Lagre navn
-                    </SubmitButton>
-                </div>
-            </form>
+            <Title bid={bid} title={meta?.title ?? DEFAULT_BOARD_NAME} />
             <Address bid={bid} location={meta?.location} />
-            <form
-                action={saveFont}
-                className="box flex flex-col justify-between"
-            >
-                <Heading3 margin="bottom">Tekststørrelse </Heading3>
-                <FontChoiceChip font={meta?.fontSize ?? 'medium'} />
-                <div className="flex flex-row mt-8 justify-end">
-                    <SubmitButton variant="secondary" className="max-sm:w-full">
-                        Lagre tekststørrelse
-                    </SubmitButton>
-                </div>
-            </form>
-            <form action={moveBoard} className="box flex flex-col">
-                <Heading3 margin="bottom">Organisasjon</Heading3>
-                <ClientOnly>
-                    <Dropdown
-                        items={organizations}
-                        label="Dine organisasjoner"
-                        selectedItem={selectedOrganization}
-                        onChange={setSelectedOrganization}
-                        clearable
-                        className="mb-4"
-                        aria-required="true"
-                        disabled={personal}
-                    />
-                </ClientOnly>
-                <Checkbox
-                    checked={personal}
-                    onChange={() => setPersonal(!personal)}
-                    name="personal"
-                >
-                    Privat tavle
-                </Checkbox>
-                <div className="flex flex-row mt-8 justify-end">
-                    <SubmitButton variant="secondary" className="max-sm:w-full">
-                        Lagre organisasjon
-                    </SubmitButton>
-                </div>
-            </form>
+            <FontSelect bid={bid} font={meta?.fontSize ?? 'medium'} />
+            <Organization bid={bid} organization={organization} />
         </>
     )
 }

--- a/tavla/app/(admin)/edit/[id]/components/ThemeSelect/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/ThemeSelect/index.tsx
@@ -7,7 +7,6 @@ import { Heading3 } from '@entur/typography'
 import { useToast } from '@entur/alert'
 import { themeToDropdownItem, themes } from 'app/(admin)/edit/utils'
 import { setTheme as setThemeAction } from './actions'
-import { fireToastFeedback } from 'app/(admin)/utils'
 
 function ThemeSelect({ board }: { board: TBoard }) {
     const [selectedTheme, setSelectedTheme] =
@@ -17,11 +16,13 @@ function ThemeSelect({ board }: { board: TBoard }) {
     const { addToast } = useToast()
 
     const setTheme = async () => {
-        const result = await setThemeAction(
+        const formFeedback = await setThemeAction(
             board.id ?? '',
             selectedTheme?.value ?? 'dark',
         )
-        fireToastFeedback(addToast, result, 'Fargetema lagret!')
+        if (!formFeedback) {
+            addToast('Fargetema lagret!')
+        }
     }
 
     return (

--- a/tavla/app/(admin)/organizations/components/CountiesSelect/index.tsx
+++ b/tavla/app/(admin)/organizations/components/CountiesSelect/index.tsx
@@ -7,7 +7,6 @@ import { setCounties as setCountiesAction } from './actions'
 import { Heading2, Paragraph } from '@entur/typography'
 import { useToast } from '@entur/alert'
 import { SubmitButton } from 'components/Form/SubmitButton'
-import { fireToastFeedback } from 'app/(admin)/utils'
 
 function CountiesSelect({
     oid,
@@ -20,8 +19,10 @@ function CountiesSelect({
     const { addToast } = useToast()
 
     const setCounties = async (data: FormData) => {
-        const result = await setCountiesAction(oid, data)
-        fireToastFeedback(addToast, result, 'Fylker lagret!')
+        const formFeedback = await setCountiesAction(oid, data)
+        if (!formFeedback) {
+            addToast('Fylker lagret!')
+        }
     }
 
     return (

--- a/tavla/app/(admin)/organizations/components/CountiesSelect/index.tsx
+++ b/tavla/app/(admin)/organizations/components/CountiesSelect/index.tsx
@@ -7,6 +7,9 @@ import { setCounties as setCountiesAction } from './actions'
 import { Heading2, Paragraph } from '@entur/typography'
 import { useToast } from '@entur/alert'
 import { SubmitButton } from 'components/Form/SubmitButton'
+import { useActionState } from 'react'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import { FormError } from 'app/(admin)/components/FormError'
 
 function CountiesSelect({
     oid,
@@ -18,12 +21,21 @@ function CountiesSelect({
     const { counties } = useCountiesSearch(oid)
     const { addToast } = useToast()
 
-    const setCounties = async (data: FormData) => {
+    const setCounties = async (
+        state: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
         const formFeedback = await setCountiesAction(oid, data)
         if (!formFeedback) {
             addToast('Fylker lagret!')
         }
+        return formFeedback
     }
+
+    const [countiesState, countiesFormAction] = useActionState(
+        setCounties,
+        undefined,
+    )
 
     return (
         <div className="box flex flex-col gap-1">
@@ -32,7 +44,7 @@ function CountiesSelect({
                 Velg hvilke fylker som skal være standard når det opprettes en
                 ny tavle.
             </Paragraph>
-            <form action={setCounties}>
+            <form action={countiesFormAction}>
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-x-2">
                     {counties()
                         .sort(
@@ -54,6 +66,11 @@ function CountiesSelect({
                                 {county.label}
                             </Checkbox>
                         ))}
+                </div>
+                <div className="mt-4">
+                    <FormError
+                        {...getFormFeedbackForField('general', countiesState)}
+                    />
                 </div>
                 <div className="flex flex-row w-full mt-8 justify-end">
                     <SubmitButton

--- a/tavla/app/(admin)/organizations/components/DefaultColumns/index.tsx
+++ b/tavla/app/(admin)/organizations/components/DefaultColumns/index.tsx
@@ -24,18 +24,20 @@ function DefaultColumns({
     const { addToast } = useToast()
     const [open, setIsOpen] = useState(false)
 
-    const handleSaveColumns = async (
+    const saveColumns = async (
         state: TFormFeedback | undefined,
         data: FormData,
     ) => {
-        const result = await saveColumnsAction(state, oid, data)
-        if (result === undefined) {
+        const formFeedback = await saveColumnsAction(state, oid, data)
+        if (!formFeedback) {
             addToast('Kolonner lagret!')
         }
-
-        return result
+        return formFeedback
     }
-    const [state, saveColumns] = useActionState(handleSaveColumns, undefined)
+    const [state, saveColumnsFormAction] = useActionState(
+        saveColumns,
+        undefined,
+    )
 
     return (
         <div className="box flex flex-col gap-1">
@@ -64,7 +66,7 @@ function DefaultColumns({
 
             <ColumnModal isOpen={open} setIsOpen={setIsOpen} />
 
-            <form action={saveColumns}>
+            <form action={saveColumnsFormAction}>
                 <div className="flex flex-row flex-wrap gap-4">
                     {Object.entries(Columns).map(([key, information]) => (
                         <FilterChip
@@ -79,8 +81,9 @@ function DefaultColumns({
                         </FilterChip>
                     ))}
                 </div>
-                <div className="mt-8" aria-live="polite">
+                <div className="mt-4" aria-live="polite">
                     <FormError {...getFormFeedbackForField('column', state)} />
+                    <FormError {...getFormFeedbackForField('general', state)} />
                 </div>
                 <div className="flex flex-row w-full mt-8 justify-end">
                     <SubmitButton

--- a/tavla/app/(admin)/organizations/components/FontSelect/index.tsx
+++ b/tavla/app/(admin)/organizations/components/FontSelect/index.tsx
@@ -6,7 +6,6 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { useToast } from '@entur/alert'
 import { TOrganizationID } from 'types/settings'
 import { Heading2, Paragraph } from '@entur/typography'
-import { fireToastFeedback } from 'app/(admin)/utils'
 
 function FontSelect({
     oid,
@@ -18,8 +17,10 @@ function FontSelect({
     const { addToast } = useToast()
 
     const setFontSize = async (data: FormData) => {
-        const result = await setFontSizeAction(oid, data)
-        fireToastFeedback(addToast, result, 'Tekststørrelse lagret!')
+        const formFeedback = await setFontSizeAction(oid, data)
+        if (!formFeedback) {
+            addToast('Tekststørrelse lagret!')
+        }
     }
 
     return (
@@ -34,7 +35,6 @@ function FontSelect({
                 action={setFontSize}
             >
                 <FontChoiceChip font={font ?? 'medium'} />
-
                 <div className="flex flex-row w-full mt-8 justify-end">
                     <SubmitButton
                         variant="secondary"

--- a/tavla/app/(admin)/organizations/components/FontSelect/index.tsx
+++ b/tavla/app/(admin)/organizations/components/FontSelect/index.tsx
@@ -6,6 +6,9 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { useToast } from '@entur/alert'
 import { TOrganizationID } from 'types/settings'
 import { Heading2, Paragraph } from '@entur/typography'
+import { useActionState } from 'react'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import { FormError } from 'app/(admin)/components/FormError'
 
 function FontSelect({
     oid,
@@ -16,12 +19,21 @@ function FontSelect({
 }) {
     const { addToast } = useToast()
 
-    const setFontSize = async (data: FormData) => {
+    const setFontSize = async (
+        state: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
         const formFeedback = await setFontSizeAction(oid, data)
         if (!formFeedback) {
             addToast('Tekststørrelse lagret!')
         }
+        return formFeedback
     }
+
+    const [fontState, fontSizeFormAction] = useActionState(
+        setFontSize,
+        undefined,
+    )
 
     return (
         <div className="box flex flex-col gap-1">
@@ -32,9 +44,14 @@ function FontSelect({
             </Paragraph>
             <form
                 className="flex flex-col justify-between h-full"
-                action={setFontSize}
+                action={fontSizeFormAction}
             >
                 <FontChoiceChip font={font ?? 'medium'} />
+                <div className="mt-4">
+                    <FormError
+                        {...getFormFeedbackForField('general', fontState)}
+                    />
+                </div>
                 <div className="flex flex-row w-full mt-8 justify-end">
                     <SubmitButton
                         variant="secondary"

--- a/tavla/app/(admin)/organizations/components/Footer/index.tsx
+++ b/tavla/app/(admin)/organizations/components/Footer/index.tsx
@@ -5,14 +5,15 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { TOrganizationID } from 'types/settings'
 import { setFooter as setFooterAction } from './actions'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
-import { fireToastFeedback } from 'app/(admin)/utils'
 
 function Footer({ oid, footer }: { oid?: TOrganizationID; footer?: string }) {
     const { addToast } = useToast()
 
     const setOrgFooter = async (data: FormData) => {
-        const result = await setFooterAction(oid, data)
-        fireToastFeedback(addToast, result, 'Infomelding lagret!')
+        const formFeedback = await setFooterAction(oid, data)
+        if (!formFeedback) {
+            addToast('Infomelding lagret!')
+        }
     }
 
     return (

--- a/tavla/app/(admin)/organizations/components/Footer/index.tsx
+++ b/tavla/app/(admin)/organizations/components/Footer/index.tsx
@@ -5,30 +5,52 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { TOrganizationID } from 'types/settings'
 import { setFooter as setFooterAction } from './actions'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
+import { useActionState } from 'react'
+import { FormError } from 'app/(admin)/components/FormError'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
 
 function Footer({ oid, footer }: { oid?: TOrganizationID; footer?: string }) {
     const { addToast } = useToast()
 
-    const setOrgFooter = async (data: FormData) => {
+    const setOrgFooter = async (
+        state: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
         const formFeedback = await setFooterAction(oid, data)
         if (!formFeedback) {
             addToast('Infomelding lagret!')
         }
+        return formFeedback
     }
 
+    const [orgFooterState, orgFooterFormAction] = useActionState(
+        setOrgFooter,
+        undefined,
+    )
+
     return (
-        <form className="box flex flex-col gap-1 " action={setOrgFooter}>
+        <form className="box flex flex-col gap-1 " action={orgFooterFormAction}>
             <Heading2>Infomelding</Heading2>
             <Paragraph>
                 Skriv en kort tekst som skal vises nederst i tavlen.
             </Paragraph>
 
             <div className="flex flex-col justify-between h-full">
-                <ClientOnlyTextField
-                    label="Infomelding"
-                    name="footer"
-                    defaultValue={footer ?? ''}
-                />
+                <div>
+                    <ClientOnlyTextField
+                        label="Infomelding"
+                        name="footer"
+                        defaultValue={footer ?? ''}
+                    />
+                    <div className="mt-4">
+                        <FormError
+                            {...getFormFeedbackForField(
+                                'general',
+                                orgFooterState,
+                            )}
+                        />
+                    </div>
+                </div>
                 <div className="flex flex-row w-full mt-8 justify-end">
                     <SubmitButton
                         variant="secondary"

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -1,4 +1,3 @@
-import { AddToastPayload } from '@entur/alert/dist/ToastProvider'
 import { VariantType } from '@entur/form'
 import { FirebaseError } from 'firebase/app'
 import { TOrganization, TUserID } from 'types/settings'
@@ -248,23 +247,6 @@ export function getFormFeedbackForError(
         form_type: 'general',
         feedback: 'En feil har oppstått.',
         variant: 'error',
-    }
-}
-
-export function fireToastFeedback(
-    addToast: (payload: AddToastPayload | string) => void,
-    formFeedback: TFormFeedback | undefined,
-    successMessage: string,
-) {
-    if (formFeedback === undefined) {
-        addToast(successMessage)
-    } else if (formFeedback.form_type === 'general') {
-        const content =
-            getFormFeedbackForField('general', formFeedback)?.feedback || ''
-        addToast({
-            content: content,
-            variant: 'info',
-        })
     }
 }
 


### PR DESCRIPTION
- Lagt til at man viser en alert i stedet for toast.
- De ulike innstillingene i `MetaSettings.tsx` er også skilt ut i fire andre kompoenter: `Title.tsx`, `Address.tsx`, `Organization.tsx` og `FontSelect.tsx`. Synes det ble ryddigere sånn. Legger også opp til mer gjenbrukbarhet i fremtiden hvis vi vil gjøre noe her.
- I all hovedsak er det lagt på en `<FormError />` overalt, sammen med en `useActionState()`