### PR TITLE
fix(boards): check duplicate tags across all user boards

### DIFF
--- a/tavla/app/(admin)/boards/components/TagModal/actions.ts
+++ b/tavla/app/(admin)/boards/components/TagModal/actions.ts
@@ -32,11 +32,8 @@ async function getAllTags() {
         ({ board }) => board,
     ) as TBoard[]
 
-    const allTags = allBoards.reduce((tags: TTag[], board: TBoard) => {
-        const boardTags = board.meta?.tags ?? []
-        return [...tags, ...boardTags]
-    }, [])
-    return (allTags as TTag[]) ?? []
+    const allTags = allBoards.flatMap((board: TBoard) => board.meta?.tags ?? [])
+    return allTags as TTag[]
 }
 
 export async function removeTag(


### PR DESCRIPTION
### Description
This PR checks tags for all user board to check for duplicate tags.

### Motivation
When adding new tags for a board, we only check for duplicates for the current board and not every board a user has. Therefore, an user can add the tag "Privat" in board 1 and "privAT" in board two, and get two different tags with the same name (in uppercase).

### Changes
- Added `getAllTags` to get all tags a user has created across their boards
- rename `fetchTags` to `fetchBoardTags` to highlight its use

### Result

When adding  tag to a new empty board named '_legg til org_':

![image](https://github.com/user-attachments/assets/af6a1eb1-d152-45fd-b730-9291b7a45594)
