### PR TITLE
fix(footer): no whitespace text

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
@@ -1,5 +1,5 @@
 'use server'
-import { TFormFeedback } from 'app/(admin)/utils'
+import { isOnlyWhiteSpace } from 'app/(admin)/edit/utils'
 import {
     hasBoardEditorAccess,
     initializeAdminApp,
@@ -17,15 +17,20 @@ export async function setFooter(bid: TBoardID, data: FormData) {
     const access = hasBoardEditorAccess(bid)
     if (!access) return redirect('/')
 
-    const footerText = data.get('footer') as string
-    const override = (data.get('override') as string) === 'on'
+    const message = data.get('footer') as string
+    const shouldOverrideOrgFooter = (data.get('override') as string) === 'on'
 
     let newFooter = {}
 
-    if (footerText && footerText.trim() !== '') {
-        newFooter = { footer: footerText, override: override }
+    const validFooter =
+        message && !isOnlyWhiteSpace(message) && message.trim() !== ''
+
+    if (validFooter) {
+        newFooter = { footer: message, override: shouldOverrideOrgFooter }
+    } else if (shouldOverrideOrgFooter) {
+        newFooter = { override: shouldOverrideOrgFooter }
     } else {
-        newFooter = { override: override }
+        newFooter = firestore.FieldValue.delete()
     }
     try {
         await firestore().collection('boards').doc(bid).update({

--- a/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
@@ -1,5 +1,4 @@
 'use server'
-import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
 import { TFormFeedback } from 'app/(admin)/utils'
 import {
     hasBoardEditorAccess,
@@ -14,28 +13,25 @@ import * as Sentry from '@sentry/nextjs'
 
 initializeAdminApp()
 
-export async function setFooter(
-    state: TFormFeedback | undefined,
-    bid: TBoardID,
-    data: FormData,
-) {
+export async function setFooter(bid: TBoardID, data: FormData) {
     const access = hasBoardEditorAccess(bid)
     if (!access) return redirect('/')
 
     const footerText = data.get('footer') as string
     const override = (data.get('override') as string) === 'on'
 
+    let newFooter = {}
+
+    if (footerText && footerText.trim() !== '') {
+        newFooter = { footer: footerText, override: override }
+    } else {
+        newFooter = { override: override }
+    }
     try {
-        await firestore()
-            .collection('boards')
-            .doc(bid)
-            .update({
-                footer: {
-                    footer: !isEmptyOrSpaces(footerText) ? footerText : '',
-                    override: override,
-                },
-                'meta.dateModified': Date.now(),
-            })
+        await firestore().collection('boards').doc(bid).update({
+            footer: newFooter,
+            'meta.dateModified': Date.now(),
+        })
         revalidatePath(`edit/${bid}`)
     } catch (error) {
         Sentry.captureException(error, {

--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -58,7 +58,6 @@ function Footer({
                     defaultValue={footer?.footer ?? ''}
                     readOnly={override && organizationBoard}
                     className="w-full mb-2"
-                    {...getFormFeedbackForField('user', footerState)}
                 />
                 {organizationBoard && (
                     <Switch

--- a/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/index.tsx
@@ -28,7 +28,7 @@ function Footer({
         state: TFormFeedback | undefined,
         data: FormData,
     ) => {
-        const formFeedback = await setFooterAction(state, bid, data)
+        const formFeedback = await setFooterAction(bid, data)
 
         if (!formFeedback) {
             addToast('Infomelding lagret!')
@@ -57,7 +57,8 @@ function Footer({
                     name="footer"
                     defaultValue={footer?.footer ?? ''}
                     readOnly={override && organizationBoard}
-                    className="w-full"
+                    className="w-full mb-2"
+                    {...getFormFeedbackForField('user', footerState)}
                 />
                 {organizationBoard && (
                     <Switch

--- a/tavla/app/(admin)/edit/utils.ts
+++ b/tavla/app/(admin)/edit/utils.ts
@@ -120,7 +120,7 @@ export function isEmptyOrSpaces(str?: string) {
     return str === undefined || str.match(/^ *$/) !== null
 }
 export function isOnlyWhiteSpace(str: string) {
-    if (str === undefined || str === '') return false
+    if (str === undefined || str === null || str === '') return false
 
     return str.trim() === ''
 }

--- a/tavla/app/(admin)/organizations/components/Footer/actions.ts
+++ b/tavla/app/(admin)/organizations/components/Footer/actions.ts
@@ -18,15 +18,16 @@ export async function setFooter(
     if (!access) return redirect('/')
 
     const message = data.get('footer') as string
-    if (isOnlyWhiteSpace(message)) {
-        return getFormFeedbackForError('footer/empty')
-    }
+
+    const validMessage =
+        message && !isOnlyWhiteSpace(message) && message.trim() !== ''
+
     try {
         await firestore()
             .collection('organizations')
             .doc(oid)
             .update({
-                footer: message ?? firestore.FieldValue.delete(),
+                footer: validMessage ? message : firestore.FieldValue.delete(),
             })
         revalidatePath(`organizations/${oid}`)
     } catch (error) {

--- a/tavla/app/(admin)/organizations/components/Footer/actions.ts
+++ b/tavla/app/(admin)/organizations/components/Footer/actions.ts
@@ -1,5 +1,5 @@
 'use server'
-import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
+import { isOnlyWhiteSpace } from 'app/(admin)/edit/utils'
 import { getFormFeedbackForError } from 'app/(admin)/utils'
 import { userCanEditOrganization } from 'app/(admin)/utils/firebase'
 import { handleError } from 'app/(admin)/utils/handleError'
@@ -18,15 +18,15 @@ export async function setFooter(
     if (!access) return redirect('/')
 
     const message = data.get('footer') as string
-
+    if (isOnlyWhiteSpace(message)) {
+        return getFormFeedbackForError('footer/empty')
+    }
     try {
         await firestore()
             .collection('organizations')
             .doc(oid)
             .update({
-                footer: !isEmptyOrSpaces(message)
-                    ? message
-                    : firestore.FieldValue.delete(),
+                footer: message ?? firestore.FieldValue.delete(),
             })
         revalidatePath(`organizations/${oid}`)
     } catch (error) {

--- a/tavla/app/(admin)/organizations/components/Footer/index.tsx
+++ b/tavla/app/(admin)/organizations/components/Footer/index.tsx
@@ -5,9 +5,9 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { TOrganizationID } from 'types/settings'
 import { setFooter as setFooterAction } from './actions'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
-import { useActionState } from 'react'
 import { FormError } from 'app/(admin)/components/FormError'
 import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import { useActionState } from 'react'
 
 function Footer({ oid, footer }: { oid?: TOrganizationID; footer?: string }) {
     const { addToast } = useToast()

--- a/tavla/app/(admin)/organizations/components/Footer/index.tsx
+++ b/tavla/app/(admin)/organizations/components/Footer/index.tsx
@@ -8,7 +8,6 @@ import ClientOnlyTextField from 'app/components/NoSSR/TextField'
 import { FormError } from 'app/(admin)/components/FormError'
 import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
 import { useActionState } from 'react'
-
 function Footer({ oid, footer }: { oid?: TOrganizationID; footer?: string }) {
     const { addToast } = useToast()
 
@@ -22,7 +21,6 @@ function Footer({ oid, footer }: { oid?: TOrganizationID; footer?: string }) {
         }
         return formFeedback
     }
-
     const [orgFooterState, orgFooterFormAction] = useActionState(
         setOrgFooter,
         undefined,

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -22,6 +22,7 @@ export type TFormFeedback = {
 }
 
 export type TError = FirebaseError | string
+
 export function getFormFeedbackForField(
     form_type: InputType,
     feedback?: TFormFeedback,
@@ -239,6 +240,13 @@ export function getFormFeedbackForError(
                 form_type: 'file',
                 feedback: 'Noe gikk galt. Vennligst prøv igjen senere',
                 variant: 'error',
+            }
+        }
+        case 'footer/empty': {
+            return {
+                form_type: 'user',
+                feedback: 'Infomelding må inneholde tall eller bokstaver',
+                variant: 'warning',
             }
         }
         case 'firebase/general': {

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -242,13 +242,6 @@ export function getFormFeedbackForError(
                 variant: 'error',
             }
         }
-        case 'footer/empty': {
-            return {
-                form_type: 'user',
-                feedback: 'Infomelding må inneholde tall eller bokstaver',
-                variant: 'warning',
-            }
-        }
         case 'firebase/general': {
             return {
                 form_type: 'general',


### PR DESCRIPTION
## Don't store whitespace Footer text

### Result
In Organization
![image](https://github.com/user-attachments/assets/6a16b088-c1e7-4a6f-8911-b0a122548455)
In Board
![image](https://github.com/user-attachments/assets/b51dfc6e-3763-4cb2-9797-cc15b2c6eb1f)


### Motivation
We previously stored footers with only whitespaces in our db and we want to avoid that.

### Changes
- Show the user a warning message when they try to store a footer containing only whitespace (board and organization). Our designer has approved the visual changes 🎨 
- If the footer is empty, delete the field (board and organization) in out db. In board, the override is still stored if the footer is empty

### Bugs 🐛 
1. When org and board footer is set, the switch turns off for a couple of seconds after override is set, before returning to its intended state (similar to fontsize ).  
### Checklist
- [ ] Verify you can't save whitespace footer, and you see the warning
- [ ] Verify that the override behaviour still works
- [ ] Verify that you are able to empty the footer (i.e save nothing)

Thanks