### PR TITLE
chore(MetaSettings): change sentry parameter from oid to toOrganization

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
@@ -168,7 +168,7 @@ export async function moveBoard(
             extra: {
                 message: 'Error while moving board to new organization',
                 boardID: bid,
-                newOrg: oid,
+                newOrg: toOrganization,
                 oldOrg: fromOrganization,
             },
         })


### PR DESCRIPTION
Tror en bug sneik seg med når sentry-PR-en ble merga inn.

Prøver å logge organisasjons-ID, men variabelen oid finnes ikke, så endrer til toOrganization