### PR TITLE
fix(compatibility): remove unused code after codespace change

### DIFF
--- a/tavla/app/(admin)/edit/[id]/compatibility.ts
+++ b/tavla/app/(admin)/edit/[id]/compatibility.ts
@@ -4,8 +4,6 @@
 import { TBoard } from 'types/settings'
 import { TTile } from 'types/tile'
 
-export const SWITCH_DATE = new Date(2024, 11, 15)
-
 export function makeBoardCompatible(board: TBoard): TBoard {
     const updatedTiles = board.tiles.map(({ whitelistedLines, ...tile }) => ({
         ...tile,
@@ -19,53 +17,53 @@ export function makeBoardCompatible(board: TBoard): TBoard {
 function oldLineIdsToNew(lineId: string): string | string[] {
     switch (lineId) {
         case 'VYG:Line:41':
-            return [lineId, 'VYG:Line:F4']
+            return 'VYG:Line:F4'
         case 'VYG:Line:45':
-            return [lineId, 'VYG:Line:R40']
+            return 'VYG:Line:R40'
         case 'VYG:Line:43':
-            return [lineId, 'VYG:Line:L4']
+            return 'VYG:Line:L4'
         case 'FLB:Line:42':
-            return [lineId, 'VYG:Line:R45']
+            return 'VYG:Line:R45'
         case 'VYG:Line:70':
-            return [lineId, 'VYG:Line:F1']
+            return 'VYG:Line:F1'
         case 'NSB:Line:R20':
-            return [lineId, 'VYG:Line:RE20']
+            return 'VYG:Line:RE20'
         case 'NSB:Line:RX20':
-            return [lineId, 'VYG:Line:RX20']
+            return 'VYG:Line:RX20'
         case 'NSB:Line:L21':
-            return [lineId, 'VYG:Line:R21']
+            return 'VYG:Line:R21'
         case 'NSB:Line:L22':
-            return [lineId, 'VYG:Line:R22']
+            return 'VYG:Line:R22'
         case 'NSB:Line:R23':
-            return [lineId, 'VYG:Line:R23']
+            return 'VYG:Line:R23'
         case 'NSB:Line:R23x':
-            return [lineId, 'VYG:Line:R23x']
+            return 'VYG:Line:R23x'
         case 'NSB:Line:L2':
-            return [lineId, 'VYG:Line:L2']
+            return 'VYG:Line:L2'
         case 'NSB:Line:L2x':
-            return [lineId, 'VYG:Line:L2x']
+            return 'VYG:Line:L2x'
         case 'GJB:Line:R30':
-            return [lineId, 'VYG:Line:RE30']
+            return 'VYG:Line:RE30'
         case 'GJB:Line:L3':
-            return [lineId, 'VYG:Line:R31']
+            return 'VYG:Line:R31'
         case 'NSB:Line:R10':
-            return [lineId, 'VYG:Line:RE10']
+            return 'VYG:Line:RE10'
         case 'NSB:Line:R11':
-            return [lineId, 'VYG:Line:RE11']
+            return 'VYG:Line:RE11'
         case 'NSB:Line:RX11':
-            return [lineId, 'VYG:Line:RX11']
+            return 'VYG:Line:RX11'
         case 'NSB:Line:L12':
-            return [lineId, 'VYG:Line:R12']
+            return 'VYG:Line:R12'
         case 'NSB:Line:L13':
-            return [lineId, 'VYG:Line:R13']
+            return 'VYG:Line:R13'
         case 'NSB:Line:R13x':
-            return [lineId, 'VYG:Line:R13x']
+            return 'VYG:Line:R13x'
         case 'NSB:Line:L14':
-            return [lineId, 'VYG:Line:R14']
+            return 'VYG:Line:R14'
         case 'NSB:Line:52':
-            return [lineId, 'VYG:Line:R55']
+            return 'VYG:Line:R55'
         case 'NSB:Line:L1':
-            return [lineId, 'VYG:Line:L1']
+            return 'VYG:Line:L1'
 
         default:
             return lineId
@@ -97,31 +95,4 @@ export const OLD_LINE_IDS = [
     'NSB:Line:L14',
     'NSB:Line:52',
     'NSB:Line:L1',
-]
-
-export const NEW_LINE_IDS = [
-    'VYG:Line:F4',
-    'VYG:Line:R40',
-    'VYG:Line:L4',
-    'VYG:Line:R45',
-    'VYG:Line:F1',
-    'VYG:Line:RE20',
-    'VYG:Line:RX20',
-    'VYG:Line:R21',
-    'VYG:Line:R22',
-    'VYG:Line:R23',
-    'VYG:Line:R23x',
-    'VYG:Line:L2',
-    'VYG:Line:L2x',
-    'VYG:Line:RE30',
-    'VYG:Line:R31',
-    'VYG:Line:RE10',
-    'VYG:Line:RE11',
-    'VYG:Line:RX11',
-    'VYG:Line:R12',
-    'VYG:Line:R13',
-    'VYG:Line:R13x',
-    'VYG:Line:R14',
-    'VYG:Line:R55',
-    'VYG:Line:L1',
 ]

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -162,6 +162,7 @@ function TileCard({
             </div>
         )
 
+    // TODO: remove when old lines no longer return any data (2025)
     lines = lines.filter((line) => !OLD_LINE_IDS.includes(line.id))
 
     const uniqLines = uniqBy(lines, 'id')

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -56,7 +56,7 @@ import {
     getFormFeedbackForError,
     getFormFeedbackForField,
 } from 'app/(admin)/utils'
-import { NEW_LINE_IDS, OLD_LINE_IDS, SWITCH_DATE } from '../../compatibility'
+import { OLD_LINE_IDS } from '../../compatibility'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
 
 function TileCard({
@@ -162,12 +162,7 @@ function TileCard({
             </div>
         )
 
-    // TODO: remove 15. december when new lines are active
-    if (Date.now() < Date.parse(SWITCH_DATE.toString())) {
-        lines = lines.filter((line) => !NEW_LINE_IDS.includes(line.id))
-    } else {
-        lines = lines.filter((line) => !OLD_LINE_IDS.includes(line.id))
-    }
+    lines = lines.filter((line) => !OLD_LINE_IDS.includes(line.id))
 
     const uniqLines = uniqBy(lines, 'id')
 


### PR DESCRIPTION
### Fjerne ubrukt kode etter codespace-endringen


#### Motivasjon
Siden det er etter 15. desember, kan vi fjerne de delene av koden som skulle kjøre før switch-datoen.

##### Endringer
- fjerner `SWITCH_DATE `og `NEW_LINE_IDS` som aldri brukes lenger
- fjerner if-sjekken på lines som var der for å håndtere case før 15. desember
- i `makeBoardCompatible`, switcher nå kun fra de gamle til de nye, heller enn å legge til begge som vi gjorde før.

#### Resultat
Det funker nå fint å både laste inn gamle whitelistedlines, og å lagre nye (som lagres med nye id-er)
Legg merke til at filtreringen på lines som skjer i TileCard fortsatt må være der, virker som om både gamle og nye linjer fortsatt sender data når man spør 🤔 
altså: `lines = lines.filter((line) => !OLD_LINE_IDS.includes(line.id))`

#### Sjekkliste

- [ ] åpne en "gammel" tavle med whitelistedLines satt og sjekk at de mappes riktig til de nye avgangene
- [ ] sjekk at lagring av ny tavle med whitelistedLines lagrer de nye linje-IDene heller enn de gamle
- [ ] sjekk at riktige avganger spørres etter i selve tavlevisningen