### PR TITLE
chore(sentry): remove duplicate sentry-logging

### DIFF
--- a/tavla/pages/[id].tsx
+++ b/tavla/pages/[id].tsx
@@ -10,54 +10,29 @@ import { useRefresh } from 'hooks/useRefresh'
 import { getBackendUrl } from 'utils/index'
 import Head from 'next/head'
 import { useEffect } from 'react'
-import { GetServerSideProps } from 'next'
-import * as Sentry from '@sentry/nextjs'
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-    try {
-        const { params, req } = context
-        if (!params || !req) {
-            Sentry.captureMessage('Missing params or req in getServerSideProps')
-            return {
-                notFound: true,
-            }
-        }
-        const { id } = params as { id: string }
+export async function getServerSideProps({
+    params,
+}: {
+    params: { id: string }
+}) {
+    const { id } = params
+    const board: TBoard | undefined = await getBoard(id)
 
-        if (!id) {
-            Sentry.captureMessage('Missing board ID in getServerSideProps')
-            return {
-                notFound: true,
-            }
-        }
-
-        const board: TBoard | undefined = await getBoard(id)
-
-        if (!board) {
-            //Sentry.captureMessage('Board is undefined in getServerSideProps')
-            return {
-                notFound: true,
-            }
-        }
-
-        const organization = await getOrganizationWithBoard(id)
-
-        return {
-            props: {
-                board,
-                organization,
-                backend_url: getBackendUrl(),
-            },
-        }
-    } catch (error) {
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Unknown error occurred in getServerSideProps',
-            },
-        })
+    if (!board) {
         return {
             notFound: true,
         }
+    }
+
+    const organization = await getOrganizationWithBoard(id)
+
+    return {
+        props: {
+            board,
+            organization,
+            backend_url: getBackendUrl(),
+        },
     }
 }
 

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -10,7 +10,6 @@ import {
     DataFetchingFailed,
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
-import * as Sentry from '@sentry/nextjs'
 
 export function QuayTile({
     placeId,
@@ -40,16 +39,6 @@ export function QuayTile({
     }
 
     if (error || !data || !data.quay) {
-        if (!error) {
-            Sentry.captureException(
-                new Error('Departure fetch for quay returned no data'),
-                {
-                    extra: {
-                        quayId: placeId,
-                    },
-                },
-            )
-        }
         return (
             <Tile>
                 <DataFetchingFailed

--- a/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -9,7 +9,6 @@ import {
     DataFetchingFailed,
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
-import * as Sentry from '@sentry/nextjs'
 
 export function StopPlaceTile({
     placeId,
@@ -39,16 +38,6 @@ export function StopPlaceTile({
     }
 
     if (error || !data || !data.stopPlace) {
-        if (!error) {
-            Sentry.captureException(
-                new Error('Departure fetch for stopPlace returned no data'),
-                {
-                    extra: {
-                        stopPlaceId: placeId,
-                    },
-                },
-            )
-        }
         return (
             <Tile>
                 <DataFetchingFailed


### PR DESCRIPTION
### Fjern unødvendig Sentry-logging
Vi ønsker å konsekvent kun logge feil til Sentry på nederste nivå (dvs. ved firebase- eller graphQL-kall). Denne PR-en fjerner derfor "dobbel" logging, som lå i index- eller page-filer.

#### Endringer
- fjerner kode vi la til i tavlevisningen for å feilsøke tidligere - inkludert Sentry-logging om noe går galt i getServerSideProps (for dette skal heller fanges der firebase-kallet skjer)
- fjerner Sentry-logging om graphQL-spørring returnerer "tom" data. Vi har heller logging på om en feil oppstår tidligere i prosessen.