### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+### Tittel
+
+#### Motivasjon
+(Hvorfor gjør vi denne endringen?)
+
+#### Endringer
+(Beskriv endringene gjort, og legg gjerne ved bilder!)
+
+#### Sjekkliste for Review
+- [ ] (Hva skal reviewers sjekke før denne PR-en godkjennes?)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ### Tittel
-
+---
 #### Motivasjon
 (Hvorfor gjør vi denne endringen?)
 


### PR DESCRIPTION
### Legg til PR-template
---
#### Motivasjon
For å standardisere PR-er, vil vi at alle skal bruke samme mal. Da blir det lettere å senere gå tilbake for å se hva som har blitt gjort.

#### Endringer
- Legger til `pull_request_template.md` i .github-mappen

#### Sjekkliste for review
- [ ] Se om du finner noe du vil legge til! Dessverre går det ikke an å sjekke at det "funker" enda, fordi templaten vil bli satt som standard kun etter at den er merget inn i main.