### PR TITLE
feat(boards): add board counter and change modal heading

### DIFF
--- a/tavla/app/(admin)/boards/page.tsx
+++ b/tavla/app/(admin)/boards/page.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import { getAllBoardsForUser } from 'app/(admin)/actions'
 import { initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
-import { Heading1 } from '@entur/typography'
+import { Heading1, Label } from '@entur/typography'
 import { uniq } from 'lodash'
 
 initializeAdminApp()
@@ -33,6 +33,7 @@ async function OrganizationsBoardsPage() {
                 <Search />
                 <FilterButton filterOptions={uniqueTags} />
             </div>
+            <Label>Antall tavler: {boardsWithOrg.length}</Label>
             <BoardTable boardsWithOrg={boardsWithOrg} />
         </div>
     )

--- a/tavla/app/(admin)/components/CreateBoard/NameAndOrganizationSelector.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/NameAndOrganizationSelector.tsx
@@ -23,7 +23,7 @@ function NameAndOrganizationSelector() {
 
     return (
         <form action={action} className="md:px-10">
-            <Heading2>Velg navn og organisasjon for tavlen</Heading2>
+            <Heading2>Opprett tavle</Heading2>
             <Paragraph className="!mb-4">
                 Gi tavlen et navn og legg den til i en organisasjon. Velger du
                 en organisasjon vil alle i organisasjonen ha tilgang til tavlen.


### PR DESCRIPTION
### Vis bruker hvor mange tavler de har og endre overskrift i opprett-modal
---
#### Motivasjon
Spurt om av en fylkesoperatør. To småplukk i én.

#### Endringer
Legger til teller over board-tabellen:
<img width="864" alt="Screenshot 2025-01-08 at 08 38 51" src="https://github.com/user-attachments/assets/e590abaa-075c-48c0-a560-2db91620ff50" />

Endrer overskrift:
<img width="859" alt="Screenshot 2025-01-08 at 08 47 18" src="https://github.com/user-attachments/assets/7a462daf-25cd-4c52-ae3c-3ed72b30b5ec" />



#### Sjekkliste for Review
- [ ] Sjekk at counter viser riktig antall
