### PR TITLE
style(board): full screen bg color on mobile

### DIFF
--- a/tavla/pages/[id].tsx
+++ b/tavla/pages/[id].tsx
@@ -88,21 +88,33 @@ function BoardPage({
     }, [])
 
     return (
-        <div className="root" data-theme={updatedBoard.theme ?? 'dark'}>
-            <Head>
-                <title>{title}</title>
-            </Head>
-            <div className="rootContainer">
-                <Header
-                    theme={updatedBoard.theme}
-                    organizationLogo={organization?.logo}
-                />
-                <Board board={updatedBoard} />
-                <Footer
-                    board={updatedBoard}
-                    logo={organization?.logo !== undefined}
-                    orgFooter={organization?.footer}
-                />
+        <div>
+            <style jsx global>
+                {`
+                    body {
+                        background-color: ${updatedBoard.theme === 'dark'
+                            ? 'black'
+                            : 'white'};
+                    }
+                `}
+            </style>
+
+            <div className="root" data-theme={updatedBoard.theme ?? 'dark'}>
+                <Head>
+                    <title>{title}</title>
+                </Head>
+                <div className="rootContainer">
+                    <Header
+                        theme={updatedBoard.theme}
+                        organizationLogo={organization?.logo}
+                    />
+                    <Board board={updatedBoard} />
+                    <Footer
+                        board={updatedBoard}
+                        logo={organization?.logo !== undefined}
+                        orgFooter={organization?.footer}
+                    />
+                </div>
             </div>
         </div>
     )

--- a/tavla/public/site.webmanifest
+++ b/tavla/public/site.webmanifest
@@ -13,7 +13,6 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+
     "display": "standalone"
 }


### PR DESCRIPTION
### Full Bg Color on mobile
---
#### Motivasjon
Vår kontaktperson fra Chilligroup ønsker å ha lik bakgrunnsfarge på mobilvisning av tavla, så det blir en bedre brukeropplevelse for deres sluttbrukere.

#### Endringer
La til bg color på body i pages, som er basert på board sitt theme. Det gjør at hele siden har lik farge på mobilvisning

## Før
![min  Entur tavla](https://github.com/user-attachments/assets/47a6fb0b-67e3-4a1f-86aa-69c04d47c8ba)
![IMG_1801](https://github.com/user-attachments/assets/b336c437-1b90-4596-833f-31eaef2f8085)

## Etter

![testfooter  Entur tavla](https://github.com/user-attachments/assets/d95900d6-9f17-4e58-af20-84375123a80d)
![IMG_1802](https://github.com/user-attachments/assets/9ba20b15-1580-4aff-9cc2-a834f3a65f91)

#### Sjekkliste for Review
- [ ] Test at tavlevisningen dekker hele skjermen på Iphone, og at å oppdatere også gir samme farge 
