### PR TITLE
feat(board): add scrolling in mobile view for boards with many tiles

### DIFF
--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -25,7 +25,7 @@ function Board({ board, style }: { board: TBoard; style?: CSSProperties }) {
 
     return (
         <div
-            className={`max-sm:overflow-scroll grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
+            className={`max-sm:overflow-y-scroll grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
                 board.meta?.fontSize || defaultFontSize(board),
             )} `}
             style={{

--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -25,7 +25,7 @@ function Board({ board, style }: { board: TBoard; style?: CSSProperties }) {
 
     return (
         <div
-            className={`grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
+            className={`max-sm:overflow-scroll grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
                 board.meta?.fontSize || defaultFontSize(board),
             )} `}
             style={{

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -53,7 +53,7 @@ export function QuayTile({
         .join(' ')
 
     return (
-        <Tile className="flex flex-col">
+        <Tile className="flex flex-col max-sm:min-h-[30vh]">
             <TableHeader
                 heading={displayName ?? heading}
                 walkingDistance={walkingDistance}

--- a/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -48,7 +48,7 @@ export function StopPlaceTile({
     }
 
     return (
-        <Tile className="flex flex-col">
+        <Tile className="flex flex-col max-sm:min-h-[30vh]">
             <TableHeader
                 heading={displayName ?? data.stopPlace.name}
                 walkingDistance={walkingDistance}


### PR DESCRIPTION
### Tillat scrolling på mobil for tavler med mange stoppesteder
---
#### Motivasjon
Som vi snakket med SJ om, kan vi forbedre tavlevisningen på mobil slik at den ikke viser kun én avgang på hvert stoppested når man har mange stoppesteder (som de har). Ved å gjøre denne endringen styrker vi samarbeidet vårt med en viktig partner av Entur.

#### Endringer
Gjort Board-komponenten scrollable når den tar opp over 100% av skjermhøyden. Hver tile vil minimum ta opp 30 view height, men mer om man har færre tiles.

Board med mange tiles (scrollbar på siden, men den synes ikke her):
<img width="467" alt="Screenshot 2025-01-10 at 12 36 42" src="https://github.com/user-attachments/assets/4807a4de-8f39-4510-8a09-b38c5241cf87" />

Board med få tiles ser ut som før og kan ikke scrolles:
<img width="515" alt="Screenshot 2025-01-10 at 12 37 53" src="https://github.com/user-attachments/assets/8aeaeb19-279a-4c84-9f90-9989761be3c7" />


#### Sjekkliste for Review
- [ ] Sjekk at mobilvisningen ser bra ut når man har både én og mange tiles
- [ ] Sjekk at endringen ikke ødelegger vanlig, desktop tavlevisning
- [ ] Sjekk i browserstack at endringen ikke ødelegger noe for eldre nettlesere / forskjellige typer mobil-nettlesere
