### PR TITLE
chore(login): force firebase to invalidate token and refactor cookie functions

### DIFF
--- a/tavla/app/(admin)/actions.ts
+++ b/tavla/app/(admin)/actions.ts
@@ -6,7 +6,7 @@ import {
     TBoard,
     TBoardID,
 } from 'types/settings'
-import { getUser, initializeAdminApp } from './utils/firebase'
+import { getUserWithBoardIds, initializeAdminApp } from './utils/firebase'
 import { getUserFromSessionCookie } from './utils/server'
 import { chunk, concat, isEmpty, flattenDeep } from 'lodash'
 import { redirect } from 'next/navigation'
@@ -134,7 +134,7 @@ export async function getBoards(ids?: TBoardID[]) {
 }
 
 export async function getAllBoardsForUser() {
-    const user = await getUser()
+    const user = await getUserWithBoardIds()
     if (!user) return redirect('/')
 
     const privateBoardIDs = concat(user.owner ?? [], user.editor ?? [])

--- a/tavla/app/(admin)/components/Delete/actions.ts
+++ b/tavla/app/(admin)/components/Delete/actions.ts
@@ -6,7 +6,6 @@ import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { TFormFeedback, getFormFeedbackForError } from 'app/(admin)/utils'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
-import { logout } from '../Login/actions'
 import { handleError } from 'app/(admin)/utils/handleError'
 
 export async function deleteOrganization(
@@ -15,7 +14,7 @@ export async function deleteOrganization(
 ) {
     const user = await getUserFromSessionCookie()
 
-    if (!user) logout()
+    if (!user) redirect('/')
 
     const oid = data.get('oid') as TOrganizationID
     if (!oid) return getFormFeedbackForError('general')

--- a/tavla/app/(admin)/components/Login/actions.ts
+++ b/tavla/app/(admin)/components/Login/actions.ts
@@ -4,12 +4,16 @@ import admin, { auth, firestore } from 'firebase-admin'
 import { TUserID } from 'types/settings'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { initializeAdminApp } from 'app/(admin)/utils/firebase'
+import {
+    initializeAdminApp,
+    revokeUserTokenOnLogout,
+} from 'app/(admin)/utils/firebase'
 import * as Sentry from '@sentry/nextjs'
 
 initializeAdminApp()
 
 export async function logout() {
+    revokeUserTokenOnLogout()
     ;(await cookies()).delete('session')
     revalidatePath('/')
     redirect('/')

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -8,7 +8,7 @@ import { formDataToTile } from 'app/(admin)/components/TileSelector/utils'
 import { revalidatePath } from 'next/cache'
 import { Metadata } from 'next'
 import { getOrganizationForBoard } from './components/TileCard/actions'
-import { getUser, hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
+import { hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
 import { Open } from './components/Buttons/Open'
 import { Copy } from './components/Buttons/Copy'
 import { Footer } from './components/Footer'
@@ -19,6 +19,7 @@ import { ActionsMenu } from './components/ActionsMenu'
 import { ThemeSelect } from './components/ThemeSelect'
 import { TileList } from './components/TileList'
 import { getBoard } from 'Board/scenarios/Board/firebase'
+import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 
 export type TProps = {
     params: Promise<{ id: TBoardID }>
@@ -38,7 +39,7 @@ export async function generateMetadata(props: TProps): Promise<Metadata> {
 
 export default async function EditPage(props: TProps) {
     const params = await props.params
-    const user = await getUser()
+    const user = await getUserFromSessionCookie()
     if (!user || !user.uid) return redirect('/')
 
     const board = await getBoard(params.id)

--- a/tavla/app/(admin)/organizations/page.tsx
+++ b/tavla/app/(admin)/organizations/page.tsx
@@ -1,21 +1,19 @@
 import { Heading1, Paragraph } from '@entur/typography'
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { CreateOrganization } from './components/CreateOrganization'
 import { Metadata } from 'next'
-import { verifySession } from '../utils/firebase'
 import { getOrganizationsForUser } from '../actions'
 import { Organizations } from './components/Organizations'
+import { getUserFromSessionCookie } from '../utils/server'
 
 export const metadata: Metadata = {
     title: 'Organisasjoner | Entur Tavla',
 }
 
 async function OrganizationsPage() {
-    const session = (await cookies()).get('session')
-    const user = await verifySession(session?.value)
+    const user = await getUserFromSessionCookie()
 
-    if (!user) redirect('/#login')
+    if (!user || !user.uid) redirect('/')
 
     const organizations = await getOrganizationsForUser()
 

--- a/tavla/app/(admin)/utils/firebase.ts
+++ b/tavla/app/(admin)/utils/firebase.ts
@@ -34,6 +34,18 @@ export async function verifySession(session?: string) {
     }
 }
 
+export async function revokeUserTokenOnLogout() {
+    const user = await getUser()
+    if (!user || !user.uid) {
+        return null
+    }
+    try {
+        await auth().revokeRefreshTokens(user.uid)
+    } catch {
+        return null
+    }
+}
+
 export async function getUser() {
     const user = await getUserFromSessionCookie()
     if (!user) return null

--- a/tavla/app/(admin)/utils/firebase.ts
+++ b/tavla/app/(admin)/utils/firebase.ts
@@ -35,7 +35,7 @@ export async function verifySession(session?: string) {
 }
 
 export async function revokeUserTokenOnLogout() {
-    const user = await getUser()
+    const user = await getUserFromSessionCookie()
     if (!user || !user.uid) {
         return null
     }
@@ -46,7 +46,7 @@ export async function revokeUserTokenOnLogout() {
     }
 }
 
-export async function getUser() {
+export async function getUserWithBoardIds() {
     const user = await getUserFromSessionCookie()
     if (!user) return null
     const userDoc = await firestore().collection('users').doc(user.uid).get()
@@ -56,7 +56,7 @@ export async function getUser() {
 export async function hasBoardOwnerAccess(bid?: TBoardID) {
     if (!bid) return false
 
-    const user = await getUser()
+    const user = await getUserWithBoardIds()
     const userOwnerAccess = user && user.owner?.includes(bid)
 
     if (user?.uid && !userOwnerAccess) {
@@ -73,7 +73,7 @@ export async function hasBoardOwnerAccess(bid?: TBoardID) {
 export async function hasBoardEditorAccess(bid?: TBoardID) {
     if (!bid) return false
 
-    const user = await getUser()
+    const user = await getUserWithBoardIds()
     const userEditorAccess =
         user && (user.editor?.includes(bid) || user.owner?.includes(bid))
 

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -23,13 +23,10 @@ const rateLimiter = rateLimit({
     interval: 60000,
 })
 export async function POST(request: NextRequest) {
-    const cookies = request.cookies
-    const token = cookies.get('session')?.value
-
     const user = await getUserFromSessionCookie()
     const response = new Response()
     response.headers.set('Content-Type', 'application/json')
-    if (!user || !token) {
+    if (!user || !user.uid) {
         return new Response(JSON.stringify({ error: 'Invalid token' }), {
             status: 401,
             headers: response.headers,
@@ -37,7 +34,7 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-        await rateLimiter.check(response, 5, token)
+        await rateLimiter.check(response, 5, user.uid)
     } catch {
         response.headers.set('Content-Type', 'application/json')
         return new Response(JSON.stringify({ error: 'Too Many Requests' }), {

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -6,7 +6,6 @@ import {
     getConfig,
     initializeAdminApp,
     userCanEditOrganization,
-    verifySession,
 } from 'app/(admin)/utils/firebase'
 import { getDownloadURL } from 'firebase-admin/storage'
 import { nanoid } from 'nanoid'
@@ -15,6 +14,7 @@ import { JSDOM } from 'jsdom'
 import { NextRequest } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import rateLimit from 'utils/rateLimit'
+import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 
 initializeAdminApp()
 
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
     const cookies = request.cookies
     const token = cookies.get('session')?.value
 
-    const user = await verifySession(token)
+    const user = await getUserFromSessionCookie()
     const response = new Response()
     response.headers.set('Content-Type', 'application/json')
     if (!user || !token) {

--- a/tavla/app/demo/page.tsx
+++ b/tavla/app/demo/page.tsx
@@ -1,13 +1,11 @@
 import { Heading1, LeadParagraph } from '@entur/typography'
-import { verifySession } from 'app/(admin)/utils/firebase'
-import { cookies } from 'next/headers'
 import { DemoBoard } from './components/DemoBoard'
 import CreateUserButton from './components/CreateUserButton'
 import { ExpandableInformation } from './components/ExpandableInformation'
+import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 
 async function Demo() {
-    const session = (await cookies()).get('session')?.value
-    const loggedIn = (await verifySession(session)) !== null
+    const loggedIn = (await getUserFromSessionCookie()) !== null
 
     return (
         <main className="container pt-8 pb-20 flex flex-col gap-10">

--- a/tavla/app/layout.tsx
+++ b/tavla/app/layout.tsx
@@ -8,10 +8,9 @@ import { Metadata } from 'next'
 import { EnturToastProvider, PHProvider } from './providers'
 import { Footer } from './(admin)/components/Footer'
 import { TopNavigation } from './(admin)/components/TopNavigation'
-import { cookies } from 'next/headers'
-import { verifySession } from './(admin)/utils/firebase'
 import { ContactForm } from './components/ContactForm'
 import PostHogPageView from './components/PostHogPageView'
+import { getUserFromSessionCookie } from './(admin)/utils/server'
 
 export const metadata: Metadata = {
     title: 'Entur Tavla',
@@ -38,8 +37,7 @@ export const metadata: Metadata = {
 }
 
 async function RootLayout({ children }: { children: ReactNode }) {
-    const session = (await cookies()).get('session')?.value
-    const loggedIn = (await verifySession(session)) !== null
+    const loggedIn = (await getUserFromSessionCookie()) !== null
     return (
         <html lang="nb">
             <PHProvider>

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -13,18 +13,16 @@ import { previewBoards } from '../src/Shared/utils/previewBoards'
 import { Link as EnturLink } from '@entur/typography'
 import { CreateUserButtonLanding } from './components/CreateUserButtonLanding'
 import { DemoButton } from './components/DemoButtonLanding'
-import { cookies } from 'next/headers'
 import { WordCarousel } from './components/WordCarousel/WordCarousel'
-import { verifySession } from './(admin)/utils/firebase'
 import { ImageCarousel } from './components/ImageCarousel/ImageCarousel'
+import { getUserFromSessionCookie } from './(admin)/utils/server'
 
 export const metadata: Metadata = {
     title: 'Forside | Entur Tavla',
 }
 
 async function Landing() {
-    const session = (await cookies()).get('session')?.value
-    const loggedIn = (await verifySession(session)) !== null
+    const loggedIn = (await getUserFromSessionCookie()) !== null
     return (
         <main>
             <div className="bg-secondary">


### PR DESCRIPTION
### Fiks sikkerhetshull i logg ut-funksjon og sett standard for brukertilgang
---
#### Motivasjon
1) Det skal ikke være mulig å "stjele" noens bruker ved å få tak i session cookie etter at de har logget ut. Ved å invalidere token i firebase auth sikrer vi at det ikke kan skje

2) Vi har mange mulige måter å sjekke om en bruker har tilgang til en side/handling eller ikke. Vi ønsker å gjøre dette på samme måte overalt.

#### Endringer
Vi revoker en brukers personlige token på utlogging. Dvs at dersom man har tilgang på noen andres session cookie, kan man ikke lenger sette den manuelt og være innlogget som dem etter at de selv har logget ut. En konsekvens av dette er at dersom du nå logger ut på ett device (eller i én browser), logges du ut av alle


Reduserer fra tre metoder å sjekke om bruker er logget inn, til én:
- `verifySession`-metoden (som vi tidligere brukte rundt om kring) kalles kun inne i funksjonen` getUserFromSessionCookie`, aldri ellers. Alle sjekker på om bruker er logget inn skal fra nå av bruke `getUserFromSessionCookie`
- `getUser` endrer navn til `getUserWIthBoardIds`, fordi den returnerer liste med brukers tavler. Denne skal ikke brukes til å sjekke om bruker er logget inn, kun til å få tak i alle boards for en bruker når det trengs.


#### Sjekkliste for Review
- [ ] Sjekk at utlogging funker, og at du logges ut i alle tabs/nettlesere dersom du har flere åpne, og at du etter utlogging ikke har tillatelse til noen handlinger du ikke skal ha
- [ ] Sjekk at det ikke lenger går an å stjele en session: kopier din egen session-verdi, logg deg ut, og sett den igjen manuelt. Naviger deg så til f.eks /boards og sjekk at du ikke får lov.
