### PR TITLE
chore(user): remove unused editor field form user and organization

### DIFF
--- a/tavla/app/(admin)/actions.ts
+++ b/tavla/app/(admin)/actions.ts
@@ -8,7 +8,7 @@ import {
 } from 'types/settings'
 import { getUserWithBoardIds, initializeAdminApp } from './utils/firebase'
 import { getUserFromSessionCookie } from './utils/server'
-import { chunk, concat, isEmpty, flattenDeep } from 'lodash'
+import { chunk, isEmpty, flattenDeep } from 'lodash'
 import { redirect } from 'next/navigation'
 import { FIREBASE_DEV_CONFIG, FIREBASE_PRD_CONFIG } from './utils/constants'
 import { userInOrganization } from './utils'
@@ -54,12 +54,7 @@ export async function getOrganizationsForUser() {
             .where('owners', 'array-contains', user.uid)
             .get()
 
-        const editor = firestore()
-            .collection('organizations')
-            .where('editors', 'array-contains', user.uid)
-            .get()
-
-        const queries = await Promise.all([owner, editor])
+        const queries = await Promise.all([owner])
         return queries
             .map((q) =>
                 q.docs.map((d) => ({ ...d.data(), id: d.id }) as TOrganization),
@@ -137,7 +132,7 @@ export async function getAllBoardsForUser() {
     const user = await getUserWithBoardIds()
     if (!user) return redirect('/')
 
-    const privateBoardIDs = concat(user.owner ?? [], user.editor ?? [])
+    const privateBoardIDs = user.owner ?? []
     const privateBoards = (await getBoards(privateBoardIDs)).map((board) => ({
         board,
     }))

--- a/tavla/app/(admin)/boards/components/TagModal/actions.ts
+++ b/tavla/app/(admin)/boards/components/TagModal/actions.ts
@@ -2,7 +2,7 @@
 import { TFormFeedback, getFormFeedbackForError } from 'app/(admin)/utils'
 import { uniq } from 'lodash'
 import { revalidatePath } from 'next/cache'
-import { hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
+import { userCanEditBoard } from 'app/(admin)/utils/firebase'
 import { TBoard, TBoardID } from 'types/settings'
 import { firestore } from 'firebase-admin'
 import { TTag } from 'types/meta'
@@ -19,7 +19,7 @@ async function fetchBoardTags({ bid }: { bid: TBoardID }) {
         return notFound()
     }
 
-    const access = await hasBoardEditorAccess(board.id)
+    const access = await userCanEditBoard(board.id)
     if (!access) {
         redirect('/')
     }
@@ -45,7 +45,7 @@ export async function removeTag(
     const bid = data.get('bid') as string
     const tag = data.get('tag') as string
 
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) throw 'auth/operation-not-allowed'
     const tags = await fetchBoardTags({ bid })
 
@@ -77,7 +77,7 @@ export async function addTag(
     if (isEmptyOrSpaces(tag))
         return getFormFeedbackForError('tags/name-missing')
 
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) throw 'auth/operation-not-allowed'
 
     const allTags = await getAllTags()

--- a/tavla/app/(admin)/edit/[id]/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 import {
-    hasBoardEditorAccess,
+    userCanEditBoard,
     initializeAdminApp,
 } from 'app/(admin)/utils/firebase'
 import { firestore } from 'firebase-admin'
@@ -19,7 +19,7 @@ import * as Sentry from '@sentry/nextjs'
 initializeAdminApp()
 
 export async function addTile(bid: TBoardID, tile: TTile) {
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {
@@ -72,7 +72,7 @@ export async function getWalkingDistanceTile(
     }
 }
 export async function saveUpdatedTileOrder(bid: TBoardID, tiles: TTile[]) {
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {

--- a/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/Footer/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 import { isOnlyWhiteSpace } from 'app/(admin)/edit/utils'
 import {
-    hasBoardEditorAccess,
+    userCanEditBoard,
     initializeAdminApp,
 } from 'app/(admin)/utils/firebase'
 import { handleError } from 'app/(admin)/utils/handleError'
@@ -14,7 +14,7 @@ import * as Sentry from '@sentry/nextjs'
 initializeAdminApp()
 
 export async function setFooter(bid: TBoardID, data: FormData) {
-    const access = hasBoardEditorAccess(bid)
+    const access = userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     const message = data.get('footer') as string

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/actions.ts
@@ -1,8 +1,7 @@
 'use server'
 import { getFormFeedbackForError, TFormFeedback } from 'app/(admin)/utils'
 import {
-    hasBoardEditorAccess,
-    hasBoardOwnerAccess,
+    userCanEditBoard,
     initializeAdminApp,
     userCanEditOrganization,
 } from 'app/(admin)/utils/firebase'
@@ -29,7 +28,7 @@ export async function saveTitle(
     if (isEmptyOrSpaces(name))
         return getFormFeedbackForError('board/tiles-name-missing')
 
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {
@@ -53,7 +52,7 @@ export async function saveTitle(
 }
 
 export async function saveFont(bid: TBoardID, data: FormData) {
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     const font = data.get('font') as TFontSize
@@ -76,7 +75,7 @@ export async function saveFont(bid: TBoardID, data: FormData) {
 }
 
 export async function saveLocation(bid: TBoardID, location?: TLocation) {
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     const board = await getBoard(bid)
@@ -123,7 +122,7 @@ export async function moveBoard(
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 
-    const access = await hasBoardOwnerAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     if (!personal && !toOrganization)

--- a/tavla/app/(admin)/edit/[id]/components/RefreshButton/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/RefreshButton/actions.ts
@@ -1,12 +1,12 @@
 'use server'
 
-import { hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
+import { userCanEditBoard } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
 import { TBoard } from 'types/settings'
 import { getBackendUrl } from 'utils/index'
 
 export async function refreshBoard(board: TBoard) {
-    const access = await hasBoardEditorAccess(board.id)
+    const access = await userCanEditBoard(board.id)
     if (!access) return redirect('/')
 
     const res = await fetch(`${getBackendUrl()}/refresh/${board.id}`, {

--- a/tavla/app/(admin)/edit/[id]/components/ThemeSelect/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/ThemeSelect/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 import {
-    hasBoardEditorAccess,
+    userCanEditBoard,
     initializeAdminApp,
 } from 'app/(admin)/utils/firebase'
 import { handleError } from 'app/(admin)/utils/handleError'
@@ -13,7 +13,7 @@ import * as Sentry from '@sentry/nextjs'
 initializeAdminApp()
 
 export async function setTheme(bid: TBoardID, theme?: TTheme) {
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/actions.ts
@@ -4,8 +4,7 @@ import { TBoard, TBoardID, TOrganization } from 'types/settings'
 import { TTile } from 'types/tile'
 import { revalidatePath } from 'next/cache'
 import {
-    hasBoardEditorAccess,
-    hasBoardOwnerAccess,
+    userCanEditBoard,
     initializeAdminApp,
 } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
@@ -14,7 +13,7 @@ import * as Sentry from '@sentry/nextjs'
 initializeAdminApp()
 
 export async function deleteTile(bid: TBoardID, tile: TTile) {
-    const access = await hasBoardOwnerAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {
@@ -42,7 +41,7 @@ export async function deleteTile(bid: TBoardID, tile: TTile) {
 }
 
 export async function saveTile(bid: TBoardID, tile: TTile) {
-    const access = await hasBoardEditorAccess(bid)
+    const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -8,7 +8,7 @@ import { formDataToTile } from 'app/(admin)/components/TileSelector/utils'
 import { revalidatePath } from 'next/cache'
 import { Metadata } from 'next'
 import { getOrganizationForBoard } from './components/TileCard/actions'
-import { hasBoardEditorAccess } from 'app/(admin)/utils/firebase'
+import { userCanEditBoard } from 'app/(admin)/utils/firebase'
 import { Open } from './components/Buttons/Open'
 import { Copy } from './components/Buttons/Copy'
 import { Footer } from './components/Footer'
@@ -48,7 +48,7 @@ export default async function EditPage(props: TProps) {
     }
     const organization = await getOrganizationForBoard(params.id)
 
-    const access = await hasBoardEditorAccess(params.id)
+    const access = await userCanEditBoard(params.id)
     if (!access) return redirect('/')
     return (
         <div className="bg-gray-50">

--- a/tavla/app/(admin)/organizations/[id]/page.tsx
+++ b/tavla/app/(admin)/organizations/[id]/page.tsx
@@ -9,7 +9,6 @@ import { DefaultColumns } from '../components/DefaultColumns'
 import { getOrganizationIfUserHasAccess } from 'app/(admin)/actions'
 import { initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
-import { concat } from 'lodash'
 import { auth } from 'firebase-admin'
 import { UidIdentifier } from 'firebase-admin/lib/auth/identifier'
 import { Footer } from '../components/Footer'
@@ -44,7 +43,7 @@ async function EditOrganizationPage(props: TProps) {
     if (!organization || !organization?.owners?.includes(user.uid))
         return <div>Du har ikke tilgang til denne organisasjonen</div>
 
-    const uids = concat(organization.owners ?? [], organization.editors ?? [])
+    const uids = organization.owners ?? []
     const usersReq = await auth().getUsers(
         uids.map(
             (uid) =>

--- a/tavla/app/(admin)/organizations/components/CreateOrganization/actions.ts
+++ b/tavla/app/(admin)/organizations/components/CreateOrganization/actions.ts
@@ -32,7 +32,6 @@ export async function createOrganization(
             .add({
                 name: name.substring(0, 50),
                 owners: [user.uid],
-                editors: [],
                 boards: [],
                 defaults: {
                     columns: DEFAULT_ORGANIZATION_COLUMNS,

--- a/tavla/app/(admin)/organizations/components/MemberAdministration/actions.ts
+++ b/tavla/app/(admin)/organizations/components/MemberAdministration/actions.ts
@@ -24,7 +24,6 @@ export async function removeUser(
             .doc(organizationId)
             .update({
                 owners: admin.firestore.FieldValue.arrayRemove(uid),
-                editors: admin.firestore.FieldValue.arrayRemove(uid),
             })
 
         revalidatePath('/')

--- a/tavla/app/(admin)/utils/firebase.ts
+++ b/tavla/app/(admin)/utils/firebase.ts
@@ -53,20 +53,7 @@ export async function getUserWithBoardIds() {
     return { ...userDoc.data(), uid: userDoc.id } as TUser
 }
 
-export async function hasBoardOwnerAccess(bid?: TBoardID) {
-    if (!bid) return false
-
-    const user = await getUserWithBoardIds()
-    const userOwnerAccess = user && user.owner?.includes(bid)
-
-    if (user?.uid && !userOwnerAccess) {
-        const organization = await getOrganizationWithBoard(bid)
-        return organization && organization.owners?.includes(user.uid)
-    }
-    return userOwnerAccess
-}
-
-export async function hasBoardEditorAccess(bid?: TBoardID) {
+export async function userCanEditBoard(bid?: TBoardID) {
     if (!bid) return false
 
     const user = await getUserWithBoardIds()
@@ -81,7 +68,7 @@ export async function hasBoardEditorAccess(bid?: TBoardID) {
 
 export async function deleteBoard(bid: TBoardID) {
     const user = await getUserFromSessionCookie()
-    const access = await hasBoardOwnerAccess(bid)
+    const access = await userCanEditBoard(bid)
 
     if (!user || !access) throw 'auth/operation-not-allowed'
 

--- a/tavla/app/(admin)/utils/firebase.ts
+++ b/tavla/app/(admin)/utils/firebase.ts
@@ -61,11 +61,7 @@ export async function hasBoardOwnerAccess(bid?: TBoardID) {
 
     if (user?.uid && !userOwnerAccess) {
         const organization = await getOrganizationWithBoard(bid)
-        return (
-            organization &&
-            (organization.editors?.includes(user.uid) ||
-                organization.owners?.includes(user.uid))
-        )
+        return organization && organization.owners?.includes(user.uid)
     }
     return userOwnerAccess
 }
@@ -74,16 +70,11 @@ export async function hasBoardEditorAccess(bid?: TBoardID) {
     if (!bid) return false
 
     const user = await getUserWithBoardIds()
-    const userEditorAccess =
-        user && (user.editor?.includes(bid) || user.owner?.includes(bid))
+    const userEditorAccess = user && user.owner?.includes(bid)
 
     if (user?.uid && !userEditorAccess) {
         const organization = await getOrganizationWithBoard(bid)
-        return (
-            organization &&
-            (organization.editors?.includes(user.uid) ||
-                organization.owners?.includes(user.uid))
-        )
+        return organization && organization.owners?.includes(user.uid)
     }
     return userEditorAccess
 }
@@ -112,7 +103,6 @@ export async function deleteBoard(bid: TBoardID) {
                 .doc(user.uid)
                 .update({
                     owner: admin.firestore.FieldValue.arrayRemove(bid),
-                    editor: admin.firestore.FieldValue.arrayRemove(bid),
                 })
         }
     } catch (error) {

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -269,10 +269,5 @@ export function userInOrganization(
     uid?: TUserID,
     organization?: TOrganization,
 ) {
-    return (
-        uid &&
-        organization &&
-        (organization.owners?.includes(uid) ||
-            organization.editors?.includes(uid))
-    )
+    return uid && organization && organization.owners?.includes(uid)
 }

--- a/tavla/src/Shared/types/settings.ts
+++ b/tavla/src/Shared/types/settings.ts
@@ -22,14 +22,12 @@ export type TUser = {
     uid?: TUserID
     email?: string
     owner?: TBoardID[]
-    editor?: TBoardID[]
 }
 
 export type TOrganization = {
     id?: TOrganizationID
     name?: string
     owners?: TUserID[]
-    editors?: TUserID[]
     boards?: TBoardID[]
     logo?: TLogo
     defaults?: TDefaults
@@ -45,7 +43,7 @@ export type TDefaults = {
 export type TInvite = {
     uid: TUserID
     type: 'board' | 'organization'
-    access: 'owner' | 'editor'
+    access: 'owner'
 }
 
 export type TFooter = {


### PR DESCRIPTION
### Fjern ubrukt "editor"-funksjonalitet fra brukere og organisasjoner
---
#### Motivasjon
Vi har i dag feltene "editor" på brukere og "editors" på organisasjoner som alltid er tomme lister. Opprinnelig tenkte man at man skulle skille på en editor og owner av en tavle, men funksjonaliteten har ligget ubrukt i 10 mnd. Vi vil fjerne for å redusere teknisk gjeld og gjøre koden mer forståelig.

#### Endringer
Når en organisasjon opprettes, opprettes ikke editors-feltet. Editor/editors fjernet fra sjekken på om en bruker har tillatelse til å endre på en tavle eller organisasjon, og feltene er fjernet fra tilsvarende type-deklarasjoner.

#### Sjekkliste for Review
- [x] Sjekk at det å opprette organisasjoner eller tavler i organisasjoner fortsatt fungerer som det skal, og at de brukerne som skal ha tilgang, har tilgang
- [x] Sjekk at nye organisasjoner og brukere mangler editor-feltet i firestore
- [x] Sjekk at brukere / orgs som tidligere har hatt editor felt fortsatt har det, men at dette ikke har noen effekt på oppførsel
- [x] Sjekk at jeg ikke har glemt å fjerne noe editor-funksjonalitet i koden
