### PR TITLE
feat(security): add security headers 

### DIFF
--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -1,6 +1,10 @@
 const { PHASE_DEVELOPMENT_SERVER } = require('next/constants')
 const { withSentryConfig } = require("@sentry/nextjs");
 
+const cspHeader = `
+    frame-ancestors 'none';
+`
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
@@ -21,10 +25,54 @@ const nextConfig = {
             },
         ],
         dangerouslyAllowSVG: true,
-	contentDispositionType: 'attachment',
+        contentDispositionType: 'attachment',
         contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     },
+    async headers() {
+        return [
+            {         
+                source: '/(.*)?',
+                headers: [
+                    {
+                        key: 'Strict-Transport-Security',
+                        value: 'max-age=63072000; includeSubDomains; preload'
+                    },
+                    {
+                        key: 'Content-Security-Policy',
+                        value: cspHeader.replace(/\n/g, ''),
+                    },
+                    {
+                        key: 'X-Content-Type-Options',
+                        value: 'nosniff'
+                    },
+                    {
+                        key: 'Referrer-Policy',
+                        value: 'strict-origin-when-cross-origin'
+                    },
+                ]
+            },
+            {         
+                source: '/:id(\\w{20})',
+                headers: [
+                    {
+                        key: 'Strict-Transport-Security',
+                        value: 'max-age=63072000; includeSubDomains; preload'
+                    },
+                    {
+                        key: 'X-Content-Type-Options',
+                        value: 'nosniff'
+                    },
+                    {
+                        key: 'Referrer-Policy',
+                        value: 'strict-origin-when-cross-origin'
+                    },
+                ]
+            },
+        ]
+    }
 }
+
+
 
 module.exports = async (phase, { defaultConfig }) => {
     if (phase === PHASE_DEVELOPMENT_SERVER) {

--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -4,7 +4,6 @@ import { StopPlaceTile } from '../StopPlaceTile'
 import { QuayTile } from '../QuayTile'
 import { Tile } from 'components/Tile'
 import { defaultFontSize, getFontScale } from 'Board/scenarios/Board/utils'
-import { CSSProperties } from 'react'
 
 function BoardTile({ tileSpec }: { tileSpec: TTile }) {
     switch (tileSpec.type) {
@@ -15,7 +14,7 @@ function BoardTile({ tileSpec }: { tileSpec: TTile }) {
     }
 }
 
-function Board({ board, style }: { board: TBoard; style?: CSSProperties }) {
+function Board({ board }: { board: TBoard }) {
     if (!board.tiles || !board.tiles.length)
         return (
             <Tile className="flex items-center justify-center">
@@ -28,9 +27,6 @@ function Board({ board, style }: { board: TBoard; style?: CSSProperties }) {
             className={`max-sm:overflow-y-scroll grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
                 board.meta?.fontSize || defaultFontSize(board),
             )} `}
-            style={{
-                ...style,
-            }}
         >
             {board.tiles.map((tile, index) => {
                 return <BoardTile key={index} tileSpec={tile} />

--- a/tavla/src/Shared/components/Header/index.tsx
+++ b/tavla/src/Shared/components/Header/index.tsx
@@ -3,26 +3,18 @@ import TavlaLogoBlue from 'assets/logos/Tavla-blue.svg'
 import Image from 'next/image'
 import { TLogo, TTheme } from 'types/settings'
 import { Clock } from 'components/Clock'
-import classNames from 'classnames'
 
 function Header({
     theme,
-    className,
     organizationLogo,
 }: {
     theme?: TTheme
-    className?: string
     organizationLogo?: TLogo | null
 }) {
     const tavlaLogo = theme === 'light' ? TavlaLogoBlue : TavlaLogoWhite
 
     return (
-        <div
-            className={classNames(
-                'flex flex-row justify-between items-center gap-em-3',
-                className,
-            )}
-        >
+        <div className="flex flex-row justify-between items-center gap-em-3">
             <div className="relative w-full h-full">
                 <Image
                     src={organizationLogo ?? tavlaLogo}


### PR DESCRIPTION
### Legge til sikkerhetsheadere i responsene våre
---
#### Motivasjon
Vi vil legge til ulike security headers slik at man ikke kan misbruke nettsiden vår, og for å hindre ulike angrep. 

#### Endringer
Per nå er det bare lagt til i config-filen vår ulike headere. For hele admin-siden er det lagt til at man ikke kan legge den i en iframe for å hindre at folk kan late som de er oss, uten at de er det (ved hjelp av `frame-ancestors none`). Det er ikke lagt til noen CSP-headere for selve tavlevisningen siden vi vil at det skal være mulig for brukere å bruke denne i en iframe på sin nettside/løsning. Det er en ny oppgave på å legge til CSP-headere for begge sidene hvor man vil bruke `nonce` for å tillate innlasting av script, styles osv som vi bruker. 

#### Sjekkliste for Review
- [ ] Sjekk at disse headerne ligger i responsen man får fra siden 
- [ ] Sjekk at `frame-ancestors` IKKE ligger på tavlevisning responsen
- [ ] Sjekk at man får lastet inn alt som vanlig på tavlevisning og at man får logget inn som vanlig
