### PR TITLE
fix(login): show unauthenticated error message rather than too-many-requests

### DIFF
--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -47,7 +47,18 @@ function Email() {
             const uid = await credential.user.getIdToken()
             const error = await login(uid)
             if (error && auth.currentUser) {
-                await sendEmailVerification(auth.currentUser)
+                try {
+                    await sendEmailVerification(auth.currentUser)
+                } catch (e: unknown) {
+                    // if email verification returns too-many-requests, verification email was sent very recently
+                    // user should not be shown the too-many-requests feedback
+                    if (
+                        e instanceof FirebaseError &&
+                        e.code != 'auth/too-many-requests'
+                    ) {
+                        return getFormFeedbackForError(e)
+                    }
+                }
                 return getFormFeedbackForError(error, email)
             }
         } catch (e: unknown) {


### PR DESCRIPTION
### Vis riktig feilmelding når bruker logger på uverifisert konto
---
#### Motivasjon
Om en bruker i dag forsøker å logge på konto rett etter at den ble opprettet (og verifiseringsmail er sendt) vises feilmelding om at konto er låst. Dette stemmer ikke, men skjer fordi påloggingsforsøket trigger nok en verifiseringsmail, veldig kort tid etter at forrige er sendt, og firebase svarer på denne requesten med too-many-requests-feilmelding.
Isteden vil vi at bruker får se riktig feilmelding, nemlig at konto ikke er verifisert enda, og at bruker må sjekke e-posten sin.


Har sett at andre har hatt samme bug (stackoverflow og reddit) men ikke fra noen offisielle kilder, men dette løser hvertfall problemet.


#### Endringer
Lagt på følgende sjekk: dersom funksjonen sendEmailVerification returnerer en too-many-requests feilmelding OG innlogging ikke har fungert, vis heller feilmeldingen fra innloggingsforsøket (mest sannsynlig unverified) heller enn too-many-requests. 

Jeg la på kommentarer i koden fordi det er litt vanskelig å skjønne hvorfor vi gjør den sjekken.

#### Sjekkliste for Review
- [ ] Prøv å opprette en ny bruker, og deretter logge inn gjentatte ganger før konto er verifisert. Sjekk at unverified-feilmeldingen dukker opp, ikke konto låst-feilmeldingen.
- [ ] Sjekk at verifiseringsløpet ellers fungerer som vanlig, og at man får logget inn etter verifisering

**OBS:** sjekkene må gjøres i dev (altså yarn build-start), da auth emulator ikke trigger samme too-many-requests-feilmelding.
