### PR TITLE
fix(edit): change wrong aria-label and add label to preview div

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -469,7 +469,7 @@ function TileCard({
                                     }
                                     addToast(`${tile.name} fjernet!`)
                                 }}
-                                aria-label="Slett stoppested"
+                                aria-label="Fjern stoppested"
                                 type="button"
                             >
                                 <DeleteIcon />

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -84,7 +84,11 @@ export default async function EditPage(props: TProps) {
                     />
 
                     <TileList board={board} />
-                    <div data-theme={board.theme ?? 'dark'} className="pt-8">
+                    <div
+                        data-theme={board.theme ?? 'dark'}
+                        className="pt-8"
+                        aria-label="Forhåndsvisning av Tavla"
+                    >
                         <Preview board={board} organization={organization} />
                     </div>
                 </div>


### PR DESCRIPTION
### Fiks UU på edit-siden
---
#### Motivasjon
Vi endrer slik at siden oppfyller UU-krav
#### Endringer
- Endret aria-label på knapp så den matcher den faktiske teksten på knappen
- Lagt på aria-label på div rundt preview av tavla så det går an å gå forbi den

#### Sjekkliste for Review
- [ ] Sjekk med voiceover at det går an å skippe seg forbi preview
