### PR TITLE
feat(edit): move walking distance to meta settings

### DIFF
--- a/tavla/app/(admin)/edit/[id]/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/actions.ts
@@ -67,7 +67,6 @@ export async function getWalkingDistanceTile(
         ...tile,
         walkingDistance: {
             distance: Number(walkingDistance),
-            visible: tile.walkingDistance?.visible ?? false,
         },
     }
 }

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/WalkingDistance.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/WalkingDistance.tsx
@@ -38,9 +38,10 @@ function WalkingDistance({
 
     return (
         <form action={saveLocationFormAction} className="box flex flex-col">
-            <Heading3 margin="bottom">Gåavstand</Heading3>
+            <Heading3 margin="bottom">Gangavstand</Heading3>
             <SubParagraph className="mb-2">
-                Vis gåavstand fra tavlens adresse til hvert stoppested.
+                Om du legger inn tavlens adresse, vises gangavstanden fra tavlen
+                til hvert stoppested.
             </SubParagraph>
 
             <div className="h-full">

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/WalkingDistance.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/WalkingDistance.tsx
@@ -1,9 +1,7 @@
 'use client'
 import { useToast } from '@entur/alert'
 import { SearchableDropdown } from '@entur/dropdown'
-import { ValidationInfoFilledIcon } from '@entur/icons'
-import { Tooltip } from '@entur/tooltip'
-import { Heading3 } from '@entur/typography'
+import { Heading3, SubParagraph } from '@entur/typography'
 import { FormError } from 'app/(admin)/components/FormError'
 import { saveLocation as saveLocationAction } from 'app/(admin)/edit/[id]/components/MetaSettings/actions'
 import { usePointSearch } from 'app/(admin)/hooks/usePointSearch'
@@ -14,7 +12,13 @@ import { useActionState } from 'react'
 import { TLocation } from 'types/meta'
 import { TBoardID } from 'types/settings'
 
-function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
+function WalkingDistance({
+    bid,
+    location,
+}: {
+    bid: TBoardID
+    location?: TLocation
+}) {
     const { pointItems, selectedPoint, setSelectedPoint } =
         usePointSearch(location)
     const { addToast } = useToast()
@@ -34,21 +38,11 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
 
     return (
         <form action={saveLocationFormAction} className="box flex flex-col">
-            <div className="flex flex-row items-center gap-2">
-                <Heading3 margin="bottom">Adresse</Heading3>
+            <Heading3 margin="bottom">Gåavstand</Heading3>
+            <SubParagraph className="mb-2">
+                Vis gåavstand fra tavlens adresse til hvert stoppested.
+            </SubParagraph>
 
-                <Tooltip
-                    content="Under innstillingene til hvert stoppested kan du velge om gåavstanden, fra tavlens adresse til selve stoppestedet, skal vises"
-                    placement="top"
-                    id="tooltip-address"
-                >
-                    <ValidationInfoFilledIcon
-                        className="md:mb-2 mb-3"
-                        size={20}
-                        aria-labelledby="tooltip-address"
-                    />
-                </Tooltip>
-            </div>
             <div className="h-full">
                 <SearchableDropdown
                     label="Hvor befinner tavlen seg?"
@@ -73,4 +67,4 @@ function Address({ bid, location }: { bid: TBoardID; location?: TLocation }) {
     )
 }
 
-export { Address }
+export { WalkingDistance }

--- a/tavla/app/(admin)/edit/[id]/components/MetaSettings/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/MetaSettings/index.tsx
@@ -1,10 +1,10 @@
 import { TMeta } from 'types/meta'
 import { TBoardID, TOrganization } from 'types/settings'
-import { Address } from './Adress'
 import { DEFAULT_BOARD_NAME } from 'app/(admin)/utils/constants'
 import { Organization } from './Organization'
 import { FontSelect } from './FontSelect'
 import { Title } from './Title'
+import { WalkingDistance } from './WalkingDistance'
 
 function MetaSettings({
     bid,
@@ -18,9 +18,9 @@ function MetaSettings({
     return (
         <>
             <Title bid={bid} title={meta?.title ?? DEFAULT_BOARD_NAME} />
-            <Address bid={bid} location={meta?.location} />
-            <FontSelect bid={bid} font={meta?.fontSize ?? 'medium'} />
             <Organization bid={bid} organization={organization} />
+            <FontSelect bid={bid} font={meta?.fontSize ?? 'medium'} />
+            <WalkingDistance bid={bid} location={meta?.location} />
         </>
     )
 }

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@entur/button'
 import { FilterChip } from '@entur/chip'
 import { BaseExpand } from '@entur/expand'
-import { Checkbox, Switch } from '@entur/form'
+import { Checkbox } from '@entur/form'
 import {
     CloseIcon,
     DeleteIcon,
@@ -20,13 +20,7 @@ import {
 } from '@entur/icons'
 import { Modal } from '@entur/modal'
 import { Tooltip } from '@entur/tooltip'
-import {
-    Heading3,
-    Heading4,
-    Label,
-    Paragraph,
-    SubParagraph,
-} from '@entur/typography'
+import { Heading3, Heading4, Paragraph, SubParagraph } from '@entur/typography'
 import { ColumnModal } from 'app/(admin)/organizations/components/DefaultColumns/ColumnModal'
 import Goat from 'assets/illustrations/Goat.png'
 import { HiddenInput } from 'components/Form/HiddenInput'
@@ -101,8 +95,6 @@ function TileCard({
         data.delete('columns')
         const count = data.get('count') as number | null
         data.delete('count')
-        const distance = data.get('showDistance') as string
-        data.delete('showDistance')
         const offset = data.get('offset') as number | null
         data.delete('offset')
         const displayName = data.get('displayName') as string
@@ -124,10 +116,11 @@ function TileCard({
             ...tile,
             columns: columns,
             whitelistedLines: lines,
-            walkingDistance: {
-                visible: distance === 'on',
-                distance: tile.walkingDistance?.distance,
-            },
+            ...(address && {
+                walkingDistance: {
+                    distance: tile.walkingDistance?.distance,
+                },
+            }),
             offset: Number(offset) || undefined,
             displayName: displayName.substring(0, 50) || undefined,
         } as TTile
@@ -306,27 +299,6 @@ function TileCard({
                                 {...getFormFeedbackForField('name', state)}
                             />
                         </div>
-                        <Heading4>Gåavstand</Heading4>
-                        <SubParagraph>
-                            Vis gåavstand fra lokasjonen til Tavla til
-                            stoppestedet.
-                        </SubParagraph>
-                        {!address && (
-                            <Label className="!text-error">
-                                {demoBoard
-                                    ? 'Logg inn for å få tilgang til funksjonaliteten.'
-                                    : 'Du må legge til tavlens adresse for å kunne skru på gåavstand.'}
-                            </Label>
-                        )}
-                        <Switch
-                            name="showDistance"
-                            disabled={!address}
-                            defaultChecked={
-                                tile.walkingDistance?.visible ?? false
-                            }
-                        >
-                            Vis gåavstand
-                        </Switch>
 
                         <Heading4>Forskyv avgangstid</Heading4>
                         <div className="flex flex-col gap-2">
@@ -369,7 +341,7 @@ function TileCard({
                                             )
                                         }}
                                     >
-                                        Forskyv basert på gåavstand
+                                        Forskyv basert på gangavstand
                                     </Checkbox>
                                 )}
                         </div>

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -31,8 +31,8 @@ function ExpandableInformation() {
                     </ListItem>
                     <ListItem>Endre fargetema (lys eller mørk modus)</ListItem>
                     <ListItem>
-                        Legge inn adressen som tavlen står på og vise gåavstand
-                        fra tavlen til stoppested(ene)
+                        Legge inn adressen som tavlen står på og vise
+                        gangavstand fra tavlen til stoppested(ene)
                     </ListItem>
                     <ListItem>
                         Opprette så mange tavler du vil og samle disse i ulike

--- a/tavla/src/Board/scenarios/Table/components/WalkingDistance.tsx
+++ b/tavla/src/Board/scenarios/Table/components/WalkingDistance.tsx
@@ -7,7 +7,7 @@ function WalkingDistance({
 }: {
     walkingDistance?: TWalkingDistance
 }) {
-    if (!walkingDistance?.visible) return null
+    if (!walkingDistance || walkingDistance.visible == false) return null
 
     return (
         <div className="flex flex-row items-center whitespace-nowrap">


### PR DESCRIPTION
### Flytt gangavstand til generelle tavleinnstillinger
---
#### Motivasjon
Mange bruker adresse og gangavstand feil, og skjønner ikke at man må inn i TileCard for å skru på gangavstand for hver enkelt tile.

Vi flytter ut, da det ikke er noe poeng i å sette adresse uten å sette gangavstand.

#### Endringer
- Gangavstand erstatter Adresse i MetaSettings.
- Når adresse settes, legges gangavstand til alle tiles automatisk. 
- Trenger ikke lenger visible-felt på walkingDistance-objektet: det opprettes og slettes når adresse settes eller fjernes.
- De som tidligere har satt adresse men ikke gangavstand vil _ikke_ plutselig få opp gangavstand, men om de lagrer TileCard eller oppdaterer adresse vil de det.

<img width="540" alt="Screenshot 2025-01-28 at 14 57 28" src="https://github.com/user-attachments/assets/9bf17ce9-88e2-480b-95d3-e2ea157a3c98" />

#### Sjekkliste for Review
- [ ] Sjekk at det går an å skru på og av gangavstand ved å skrive inn / fjerne adresse
- [ ] Sjekk at tavler som tidligere hadde adresse men ikke gangavstand, ikke plutselig får det
- [ ] Sjekk at ordlyd gir mening
