### PR TITLE
feat(edit): fake door with survey for compress board setting

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
@@ -77,26 +77,23 @@ function CompressSurvey() {
     }
 
     return (
-        <div>
-            <div className="box">
-                <div className="flex flex-row items-center gap-2">
-                    <Heading3 margin="bottom">
-                        Tilpass tavlen til liten skjerm
-                    </Heading3>
-                </div>
+        <>
+            <div className="box flex flex-col">
+                <Heading3 margin="bottom">
+                    Tilpass tavlen til liten skjerm
+                </Heading3>
 
                 <SubParagraph>
                     Fjern klokke, logo og infomelding, slik at avgangene får mer
                     plass på skjermen din.
                 </SubParagraph>
-                <div>
-                    <Switch
-                        checked={switchChecked}
-                        onChange={() => setSwitchChecked(!switchChecked)}
-                    >
-                        Tilpass
-                    </Switch>
-                </div>
+
+                <Switch
+                    checked={switchChecked}
+                    onChange={() => setSwitchChecked(!switchChecked)}
+                >
+                    Tilpass
+                </Switch>
 
                 <div className="flex flex-row mt-8 justify-end">
                     <SubmitButton
@@ -118,76 +115,63 @@ function CompressSurvey() {
                     closeAndReset()
                 }}
             >
-                <div>
-                    <div className="flex flex-col gap-2">
-                        <Heading4>
-                            Vi holder på å utvikle denne funksjonaliteten!
-                        </Heading4>
-                        <Paragraph>
-                            I mellomtiden ønsker vi din tilbakemelding!
-                        </Paragraph>
-                    </div>
-                    <form
-                        action={submitSurvey}
-                        className="flex flex-col justify-between gap-2"
+                <div className="flex flex-col gap-2">
+                    <Heading4>
+                        Vi holder på å utvikle denne funksjonaliteten!
+                    </Heading4>
+                    <Paragraph>
+                        I mellomtiden ønsker vi din tilbakemelding!
+                    </Paragraph>
+                </div>
+                <form
+                    action={submitSurvey}
+                    className="flex flex-col justify-between gap-2"
+                >
+                    <Heading5>Hvorfor trykket du på denne knappen?</Heading5>
+                    <RadioGroup
+                        name="multipleChoice"
+                        value={selectedOption}
+                        onChange={(e) => {
+                            setSelectedOption(e.target.value as string)
+                        }}
                     >
-                        <Heading5>
-                            Hvorfor trykket du på denne knappen?
-                        </Heading5>
-                        <RadioGroup
-                            name="multipleChoice"
-                            value={selectedOption}
-                            onChange={(e) => {
-                                setSelectedOption(e.target.value as string)
+                        <div className="flex flex-col items-start gap-8 sm:gap-2 w-full">
+                            {alternatives.map((option) => (
+                                <Radio key={option} value={option}>
+                                    {option}
+                                </Radio>
+                            ))}
+                        </div>
+                    </RadioGroup>
+
+                    <Heading5>Andre kommentarer</Heading5>
+                    <ClientOnly>
+                        <TextArea
+                            label="Utdyp gjerne!"
+                            name="freeText"
+                            id="freeText"
+                            defaultValue=""
+                        />
+                    </ClientOnly>
+                    <div className="mt-4">
+                        <FormError
+                            {...getFormFeedbackForField('general', formState)}
+                        />
+                    </div>
+                    <ButtonGroup className="flex flex-row mt-8">
+                        <SubmitButton variant="primary">Send</SubmitButton>
+                        <Button
+                            variant="secondary"
+                            onClick={() => {
+                                closeAndReset()
                             }}
                         >
-                            <div className="flex flex-col items-start gap-8 sm:gap-2 w-full">
-                                {alternatives.map((option) => (
-                                    <Radio key={option} value={option}>
-                                        {option}
-                                    </Radio>
-                                ))}
-                            </div>
-                        </RadioGroup>
-
-                        <div className="flex flex-col gap-2">
-                            <Heading5>Andre kommentarer</Heading5>
-                            <ClientOnly>
-                                <TextArea
-                                    label="Utdyp gjerne!"
-                                    name="freeText"
-                                    id="freeText"
-                                    defaultValue=""
-                                />
-                            </ClientOnly>
-                        </div>
-                        <div className="mt-4">
-                            <FormError
-                                {...getFormFeedbackForField(
-                                    'general',
-                                    formState,
-                                )}
-                            />
-                        </div>
-                        <div>
-                            <ButtonGroup className="flex flex-row mt-8">
-                                <SubmitButton variant="primary">
-                                    Send
-                                </SubmitButton>
-                                <Button
-                                    variant="secondary"
-                                    onClick={() => {
-                                        closeAndReset()
-                                    }}
-                                >
-                                    Avbryt
-                                </Button>
-                            </ButtonGroup>
-                        </div>
-                    </form>
-                </div>
+                            Avbryt
+                        </Button>
+                    </ButtonGroup>
+                </form>
             </Modal>
-        </div>
+        </>
     )
 }
 

--- a/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
@@ -117,10 +117,11 @@ function CompressSurvey() {
             >
                 <div className="flex flex-col gap-2">
                     <Heading4>
-                        Vi holder på å utvikle denne funksjonaliteten!
+                        Vi holder på å sjekke ut interessen for denne
+                        funksjonaliteten!
                     </Heading4>
                     <Paragraph>
-                        I mellomtiden ønsker vi din tilbakemelding!
+                        I mellomtiden ønsker vi din tilbakemelding.
                     </Paragraph>
                 </div>
                 <form

--- a/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+import { Modal } from '@entur/modal'
+import {
+    Heading3,
+    Heading4,
+    Heading5,
+    Paragraph,
+    SubParagraph,
+} from '@entur/typography'
+import { Button, ButtonGroup } from '@entur/button'
+import { SubmitButton } from 'components/Form/SubmitButton'
+import { Radio, RadioGroup, Switch, TextArea } from '@entur/form'
+import {
+    getFormFeedbackForError,
+    getFormFeedbackForField,
+    TFormFeedback,
+} from 'app/(admin)/utils'
+import { useToast } from '@entur/alert'
+import { FormError } from 'app/(admin)/components/FormError'
+import { usePostHog } from 'posthog-js/react'
+import ClientOnly from 'app/components/NoSSR/ClientOnly'
+import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
+
+const alternatives = [
+    'Jeg var nysgjerrig på funksjonaliteten',
+    'Jeg har behov for komprimert visning av tavlen min på grunn av liten skjerm',
+    'Jeg ønsker ikke logo, klokke eller infomelding på tavlen min',
+    'Annet',
+]
+
+function CompressSurvey() {
+    const [isOpen, setIsOpen] = useState<boolean>(false)
+    const [selectedOption, setSelectedOption] = useState<string>('')
+    const { addToast } = useToast()
+    const [formState, setFormError] = useState<TFormFeedback | undefined>(
+        undefined,
+    )
+    const posthog = usePostHog()
+
+    const submitSurvey = async (data: FormData) => {
+        const freeText = data.get('freeText') as string
+        const selectedChoice = data.get('multipleChoice') as string
+
+        if (selectedChoice || !isEmptyOrSpaces(freeText)) {
+            posthog.capture('survey sent', {
+                $survey_id: process.env.COMPRESS_SURVEY_ID,
+                $survey_response: selectedChoice,
+                $survey_response_1: freeText ?? null,
+            })
+            setIsOpen(false)
+            addToast('Tusen takk for din tilbakemelding!')
+        } else {
+            return setFormError(
+                getFormFeedbackForError('survey/content-missing'),
+            )
+        }
+    }
+
+    const closeAndReset = () => {
+        setIsOpen(false)
+        setFormError(undefined)
+        setSelectedOption('')
+    }
+
+    return (
+        <div>
+            <div className="box">
+                <div className="flex flex-row items-center gap-2">
+                    <Heading3 margin="bottom">Komprimer Tavle</Heading3>
+                </div>
+
+                <SubParagraph>
+                    Fjern klokke, logo og infomelding, slik at avgangene får mer
+                    plass på skjermen din
+                </SubParagraph>
+                <div>
+                    <Switch>Komprimer</Switch>
+                </div>
+
+                <div className="flex flex-row mt-8 justify-end">
+                    <SubmitButton
+                        variant="secondary"
+                        className="max-sm:w-full"
+                        onClick={() => {
+                            setIsOpen(true)
+                        }}
+                    >
+                        Lagre valg
+                    </SubmitButton>
+                </div>
+            </div>
+            <Modal
+                size="medium"
+                open={isOpen}
+                onDismiss={() => {
+                    closeAndReset()
+                }}
+            >
+                <div>
+                    <div className="flex flex-col gap-2">
+                        <Heading4>
+                            Vi holder på å utvikle denne funksjonaliteten!
+                        </Heading4>
+                        <Paragraph>
+                            I mellomtiden ønsker vi din tilbakemelding!
+                        </Paragraph>
+                    </div>
+                    <form
+                        action={submitSurvey}
+                        className="flex flex-col justify-between gap-2"
+                    >
+                        <Heading5>
+                            Hvorfor trykket du på denne knappen?
+                        </Heading5>
+                        <div className="flex flex-col">
+                            <RadioGroup
+                                name="multipleChoice"
+                                value={selectedOption}
+                                onChange={(e) => {
+                                    setSelectedOption(e.target.value as string)
+                                }}
+                            >
+                                <div className="flex flex-col items-start gap-2">
+                                    {alternatives.map((option) => (
+                                        <Radio key={option} value={option}>
+                                            {option}
+                                        </Radio>
+                                    ))}
+                                </div>
+                            </RadioGroup>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <Heading5>Andre kommentarer</Heading5>
+                            <ClientOnly>
+                                <TextArea
+                                    label="Utdyp gjerne!"
+                                    name="freeText"
+                                    id="freeText"
+                                    defaultValue=""
+                                />
+                            </ClientOnly>
+                        </div>
+                        <div className="mt-4">
+                            <FormError
+                                {...getFormFeedbackForField(
+                                    'general',
+                                    formState,
+                                )}
+                            />
+                        </div>
+                        <div>
+                            <ButtonGroup className="flex flex-row mt-8">
+                                <SubmitButton variant="primary">
+                                    Send
+                                </SubmitButton>
+                                <Button
+                                    variant="secondary"
+                                    onClick={() => {
+                                        closeAndReset()
+                                    }}
+                                >
+                                    Avbryt
+                                </Button>
+                            </ButtonGroup>
+                        </div>
+                    </form>
+                </div>
+            </Modal>
+        </div>
+    )
+}
+
+export { CompressSurvey }

--- a/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/CompressSurvey/index.tsx
@@ -25,7 +25,7 @@ import { isEmptyOrSpaces } from 'app/(admin)/edit/utils'
 
 const alternatives = [
     'Jeg var nysgjerrig på funksjonaliteten',
-    'Jeg har behov for komprimert visning av tavlen min på grunn av liten skjerm',
+    'Jeg har behov for tilpasset visning av tavlen min på grunn av liten skjerm',
     'Jeg ønsker ikke logo, klokke eller infomelding på tavlen min',
     'Annet',
 ]
@@ -80,19 +80,21 @@ function CompressSurvey() {
         <div>
             <div className="box">
                 <div className="flex flex-row items-center gap-2">
-                    <Heading3 margin="bottom">Komprimer Tavle</Heading3>
+                    <Heading3 margin="bottom">
+                        Tilpass tavlen til liten skjerm
+                    </Heading3>
                 </div>
 
                 <SubParagraph>
                     Fjern klokke, logo og infomelding, slik at avgangene får mer
-                    plass på skjermen din
+                    plass på skjermen din.
                 </SubParagraph>
                 <div>
                     <Switch
                         checked={switchChecked}
                         onChange={() => setSwitchChecked(!switchChecked)}
                     >
-                        Komprimer
+                        Tilpass
                     </Switch>
                 </div>
 

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -23,7 +23,6 @@ import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 import { CompressSurvey } from './components/CompressSurvey'
 import { Delete } from 'app/(admin)/boards/components/Column/Delete'
 
-
 export type TProps = {
     params: Promise<{ id: TBoardID }>
 }

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -20,6 +20,7 @@ import { ThemeSelect } from './components/ThemeSelect'
 import { TileList } from './components/TileList'
 import { getBoard } from 'Board/scenarios/Board/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
+import { CompressSurvey } from './components/CompressSurvey'
 
 export type TProps = {
     params: Promise<{ id: TBoardID }>
@@ -107,6 +108,7 @@ export default async function EditPage(props: TProps) {
                             organizationBoard={organization !== undefined}
                         />
                         <ThemeSelect board={board} />
+                        <CompressSurvey />
                     </div>
                 </div>
             </div>

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -256,6 +256,14 @@ export function getFormFeedbackForError(
                 variant: 'negative',
             }
         }
+        case 'survey/content-missing': {
+            return {
+                form_type: 'general',
+                feedback:
+                    'Vennligst velg et alternativ eller skriv en kommentar',
+                variant: 'negative',
+            }
+        }
     }
 
     return {

--- a/tavla/helm/tavla/values.yaml
+++ b/tavla/helm/tavla/values.yaml
@@ -15,6 +15,8 @@ common:
         sentry:
             - SENTRY_AUTH_TOKEN
             - NEXT_PUBLIC_SENTRY_DSN_URL
+        posthog:
+            - COMPRESS_SURVEY_ID
     container:
         image: <+artifacts.primary.image>
         cpu: 0.3

--- a/tavla/helm/tavla/values.yaml
+++ b/tavla/helm/tavla/values.yaml
@@ -15,8 +15,6 @@ common:
         sentry:
             - SENTRY_AUTH_TOKEN
             - NEXT_PUBLIC_SENTRY_DSN_URL
-        posthog:
-            - COMPRESS_SURVEY_ID
     container:
         image: <+artifacts.primary.image>
         cpu: 0.3

--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -1,21 +1,23 @@
 const { PHASE_DEVELOPMENT_SERVER } = require('next/constants')
-const { withSentryConfig } = require("@sentry/nextjs");
+const { withSentryConfig } = require('@sentry/nextjs')
 
 const commonConnectSrc = [
     "'self'",
-    "https://api.entur.io",
-    "https://tavla-api.entur.no",
-    "https://tavla-api.dev.entur.no"
+    'https://api.entur.io',
+    'https://tavla-api.entur.no',
+    'https://tavla-api.dev.entur.no',
 ]
 
 if (process.env.NODE_ENV == 'development') {
-    commonConnectSrc.push("http://*.identitytoolkit.googleapis.com http://127.0.0.1:9099 ws://localhost:3000 http://127.0.0.1:3001")
+    commonConnectSrc.push(
+        'http://*.identitytoolkit.googleapis.com http://127.0.0.1:9099 ws://localhost:3000 http://127.0.0.1:3001',
+    )
 }
 
 const cspHeaderCommon = `
     default-src 'self';
     style-src 'self' 'unsafe-inline';
-    script-src 'self' 'unsafe-inline' 'unsafe-eval';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';
@@ -35,7 +37,17 @@ const cspHeaderTavlevisning = `
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
-    transpilePackages: ['swr', 'tailwindcss', 'next', '@sentry/nextjs', '@sentry/browser', '@sentry/react', '@sentry/core', '@sentry/utils', '@sentry-internal'],
+    transpilePackages: [
+        'swr',
+        'tailwindcss',
+        'next',
+        '@sentry/nextjs',
+        '@sentry/browser',
+        '@sentry/react',
+        '@sentry/core',
+        '@sentry/utils',
+        '@sentry-internal',
+    ],
     i18n: {
         locales: ['nb'],
         defaultLocale: 'nb',
@@ -53,37 +65,38 @@ const nextConfig = {
         ],
         dangerouslyAllowSVG: true,
         contentDispositionType: 'attachment',
-        contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+        contentSecurityPolicy:
+            "default-src 'self'; script-src 'none'; sandbox;",
     },
     async headers() {
         return [
-            {         
+            {
                 source: '/(.*)?',
                 headers: [
                     {
                         key: 'Strict-Transport-Security',
-                        value: 'max-age=63072000; includeSubDomains; preload'
+                        value: 'max-age=63072000; includeSubDomains; preload',
                     },
                     {
                         key: 'Content-Security-Policy',
-                        value: cspHeader.replace(/\n/g, '')
+                        value: cspHeader.replace(/\n/g, ''),
                     },
                     {
                         key: 'X-Content-Type-Options',
-                        value: 'nosniff'
+                        value: 'nosniff',
                     },
                     {
                         key: 'Referrer-Policy',
-                        value: 'strict-origin-when-cross-origin'
+                        value: 'strict-origin-when-cross-origin',
                     },
-                ]
+                ],
             },
-            {         
+            {
                 source: '/:id(\\w{20})',
                 headers: [
                     {
                         key: 'Strict-Transport-Security',
-                        value: 'max-age=63072000; includeSubDomains; preload'
+                        value: 'max-age=63072000; includeSubDomains; preload',
                     },
                     {
                         key: 'Content-Security-Policy',
@@ -91,19 +104,17 @@ const nextConfig = {
                     },
                     {
                         key: 'X-Content-Type-Options',
-                        value: 'nosniff'
+                        value: 'nosniff',
                     },
                     {
                         key: 'Referrer-Policy',
-                        value: 'strict-origin-when-cross-origin'
+                        value: 'strict-origin-when-cross-origin',
                     },
-                ]
+                ],
             },
         ]
-    }
+    },
 }
-
-
 
 module.exports = async (phase, { defaultConfig }) => {
     if (phase === PHASE_DEVELOPMENT_SERVER) {
@@ -124,14 +135,13 @@ module.exports = withSentryConfig(nextConfig, {
     // For all available options, see:
     // https://github.com/getsentry/sentry-webpack-plugin#options
 
-    org: "entur",
-    project: "tavla",
+    org: 'entur',
+    project: 'tavla',
     authToken: process.env.SENTRY_AUTH_TOKEN,
     silent: !process.env.CI,
 
     // For all available options, see:
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
     hideSourceMaps: true,
-    disableLogger: true, 
-  }
-);
+    disableLogger: true,
+})


### PR DESCRIPTION
### Legg til fake door bak "Komprimer Tavle"-innstilling
---
#### Motivasjon
Vi vil undersøke om folk ønsker muligheten til å komprimere innholdet før vi faktisk utvikler funksjonaliteten.

#### Endringer
- Legger til "Komprimer Tavle" som en ekstra innstilling:
<img width="568" alt="Screenshot 2025-01-31 at 08 45 21" src="https://github.com/user-attachments/assets/48216cba-27c7-4ddb-ac62-f97a21e91e83" />

- Klikk på lagre-knapp åpner følgende modal, lenket til en posthog survey:
<img width="827" alt="Screenshot 2025-01-31 at 08 45 57" src="https://github.com/user-attachments/assets/bcdd2311-03b3-4a1e-a283-1b563f22e45a" />

- Resultatene av undersøkelsen finnes under "Surveys" i Posthog dashboard

#### Sjekkliste for Review
- [ ] Sjekk ordlyd og innhold i skjema. Spør vi om alt vi ønsker å spørre om?
- [ ] Sjekk at klikk på lagreknappen åpner skjema
- [ ] Sjekk at innsending av skjema krever minst ett felt, og at svaret dukker opp i posthog

Denne PR-en er knyttet til en hypotese, når den er prodsatt starter vi måling. Vi må huske å sette et vindu for hvor lenge vi vil måle
