### PR TITLE
feat(edit): add posthog survey after created board

### DIFF
--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -14,6 +14,7 @@ import {
 import { useState } from 'react'
 import { Label } from '@entur/typography'
 import { SubmitButton } from 'components/Form/SubmitButton'
+import { usePostHog } from 'posthog-js/react'
 
 function TileSelector({
     action,
@@ -36,6 +37,8 @@ function TileSelector({
         selectedStopPlace?.value ?? '',
     )
 
+    const posthog = usePostHog()
+
     const classname = col ? '' : 'lg:flex-row'
 
     const [state, setFormError] = useState<TFormFeedback | undefined>()
@@ -54,6 +57,7 @@ function TileSelector({
                         ),
                     )
                 }
+                posthog.capture('ADD_TILE_TO_BOARD')
                 setFormError(undefined)
                 setSelectedQuay(null)
                 setSelectedStopPlace(null)

--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -1,21 +1,23 @@
 const { PHASE_DEVELOPMENT_SERVER } = require('next/constants')
-const { withSentryConfig } = require("@sentry/nextjs");
+const { withSentryConfig } = require('@sentry/nextjs')
 
 const commonConnectSrc = [
     "'self'",
-    "https://api.entur.io",
-    "https://tavla-api.entur.no",
-    "https://tavla-api.dev.entur.no"
+    'https://api.entur.io',
+    'https://tavla-api.entur.no',
+    'https://tavla-api.dev.entur.no',
 ]
 
 if (process.env.NODE_ENV == 'development') {
-    commonConnectSrc.push("http://*.identitytoolkit.googleapis.com http://127.0.0.1:9099 ws://localhost:3000 http://127.0.0.1:3001")
+    commonConnectSrc.push(
+        'http://*.identitytoolkit.googleapis.com http://127.0.0.1:9099 ws://localhost:3000 http://127.0.0.1:3001',
+    )
 }
 
 const cspHeaderCommon = `
     default-src 'self';
     style-src 'self' 'unsafe-inline';
-    script-src 'self' 'unsafe-inline' 'unsafe-eval';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';
@@ -35,7 +37,17 @@ const cspHeaderTavlevisning = `
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
-    transpilePackages: ['swr', 'tailwindcss', 'next', '@sentry/nextjs', '@sentry/browser', '@sentry/react', '@sentry/core', '@sentry/utils', '@sentry-internal'],
+    transpilePackages: [
+        'swr',
+        'tailwindcss',
+        'next',
+        '@sentry/nextjs',
+        '@sentry/browser',
+        '@sentry/react',
+        '@sentry/core',
+        '@sentry/utils',
+        '@sentry-internal',
+    ],
     i18n: {
         locales: ['nb'],
         defaultLocale: 'nb',
@@ -53,37 +65,38 @@ const nextConfig = {
         ],
         dangerouslyAllowSVG: true,
         contentDispositionType: 'attachment',
-        contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+        contentSecurityPolicy:
+            "default-src 'self'; script-src 'none'; sandbox;",
     },
     async headers() {
         return [
-            {         
+            {
                 source: '/(.*)?',
                 headers: [
                     {
                         key: 'Strict-Transport-Security',
-                        value: 'max-age=63072000; includeSubDomains; preload'
+                        value: 'max-age=63072000; includeSubDomains; preload',
                     },
                     {
                         key: 'Content-Security-Policy',
-                        value: cspHeader.replace(/\n/g, '')
+                        value: cspHeader.replace(/\n/g, ''),
                     },
                     {
                         key: 'X-Content-Type-Options',
-                        value: 'nosniff'
+                        value: 'nosniff',
                     },
                     {
                         key: 'Referrer-Policy',
-                        value: 'strict-origin-when-cross-origin'
+                        value: 'strict-origin-when-cross-origin',
                     },
-                ]
+                ],
             },
-            {         
+            {
                 source: '/:id(\\w{20})',
                 headers: [
                     {
                         key: 'Strict-Transport-Security',
-                        value: 'max-age=63072000; includeSubDomains; preload'
+                        value: 'max-age=63072000; includeSubDomains; preload',
                     },
                     {
                         key: 'Content-Security-Policy',
@@ -91,19 +104,17 @@ const nextConfig = {
                     },
                     {
                         key: 'X-Content-Type-Options',
-                        value: 'nosniff'
+                        value: 'nosniff',
                     },
                     {
                         key: 'Referrer-Policy',
-                        value: 'strict-origin-when-cross-origin'
+                        value: 'strict-origin-when-cross-origin',
                     },
-                ]
+                ],
             },
         ]
-    }
+    },
 }
-
-
 
 module.exports = async (phase, { defaultConfig }) => {
     if (phase === PHASE_DEVELOPMENT_SERVER) {
@@ -124,14 +135,13 @@ module.exports = withSentryConfig(nextConfig, {
     // For all available options, see:
     // https://github.com/getsentry/sentry-webpack-plugin#options
 
-    org: "entur",
-    project: "tavla",
+    org: 'entur',
+    project: 'tavla',
     authToken: process.env.SENTRY_AUTH_TOKEN,
     silent: !process.env.CI,
 
     // For all available options, see:
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
     hideSourceMaps: true,
-    disableLogger: true, 
-  }
-);
+    disableLogger: true,
+})


### PR DESCRIPTION
### Legg til posthog-capture for å kunne legge til survey
---
#### Motivasjon
Vi vil få feedback på hvordan folk synes det er å opprette tavler.

#### Endringer
- legger til posthog event for når tile er lagt til. I posthog vises da en survey til bruker første gang de gjør denne handlingen (så lenge de er på edit-siden, ikke demo, forhåpentligvis).
- Skjema i posthog:
![Screenshot 2025-02-05 at 11 43 24](https://github.com/user-attachments/assets/a63e77f0-0bb9-4dc5-8e7d-98807ff62cea)

Går videre til fritekstfelt med forklaring

OBS: inntil videre er den bare i localhost, dev og prod har csp som blokkerer
#### Sjekkliste for Review
- [ ] Sjekk at survey dukker opp når du legger til stoppested for første gang
- [ ] Sjekk at survey responsen din legges inn i posthog
- [ ] Sjekk at survey ikke popper opp andre ganger du legger til stoppested
