### PR TITLE
feat(board): support for combining tiles

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -380,7 +380,7 @@ function TileCard({
                         {isCombined && (
                             <SubParagraph className="!text-error mb-2">
                                 Har du samlet stoppestedene i én liste vil du
-                                ikke ha mulighet til å sette kolonner.
+                                ikke ha mulighet til å velge kolonner.
                             </SubParagraph>
                         )}
                         <ColumnModal

--- a/tavla/app/(admin)/edit/[id]/components/TileList/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileList/index.tsx
@@ -57,6 +57,7 @@ function TileList({
                     index={index}
                     totalTiles={board.tiles.length}
                     setDemoBoard={setDemoBoard}
+                    isCombined={board.combinedTiles ? true : false}
                 />
             ))}
         </div>

--- a/tavla/app/(admin)/edit/[id]/components/ViewType/actions.ts
+++ b/tavla/app/(admin)/edit/[id]/components/ViewType/actions.ts
@@ -1,0 +1,49 @@
+'use server'
+import {
+    initializeAdminApp,
+    userCanEditBoard,
+} from 'app/(admin)/utils/firebase'
+import { handleError } from 'app/(admin)/utils/handleError'
+import { firestore } from 'firebase-admin'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { TBoard } from 'types/settings'
+
+initializeAdminApp()
+
+export async function setViewType(board: TBoard, viewType: string) {
+    const access = await userCanEditBoard(board.id)
+    if (!access) return redirect('/')
+
+    if (viewType == 'combined') {
+        try {
+            await firestore()
+                .collection('boards')
+                .doc(board.id ?? '')
+                .update({
+                    combinedTiles: [
+                        { ids: board.tiles.map((tile) => tile.uuid) },
+                    ],
+                    'meta.dateModified': Date.now(),
+                })
+
+            revalidatePath(`/edit/${board.id}`)
+        } catch (e) {
+            handleError(e)
+        }
+    } else {
+        try {
+            await firestore()
+                .collection('boards')
+                .doc(board.id ?? '')
+                .update({
+                    combinedTiles: firestore.FieldValue.delete(),
+                    'meta.dateModified': Date.now(),
+                })
+
+            revalidatePath(`/edit/${board.id}`)
+        } catch (e) {
+            handleError(e)
+        }
+    }
+}

--- a/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
@@ -7,12 +7,14 @@ import { useState } from 'react'
 import { TBoard } from 'types/settings'
 import { setViewType as setViewTypeAction } from './actions'
 import { useToast } from '@entur/alert'
+import { usePostHog } from 'posthog-js/react'
 
 function ViewTypeSetting({ board }: { board: TBoard }) {
     const [value, setValue] = useState(
         board.combinedTiles ? 'combined' : 'separate',
     )
     const { addToast } = useToast()
+    const posthog = usePostHog()
 
     const setViewType = async () => {
         const formFeedback = await setViewTypeAction(board, value)
@@ -44,6 +46,7 @@ function ViewTypeSetting({ board }: { board: TBoard }) {
                     variant="secondary"
                     aria-label="Lagre visningstype"
                     className="max-sm:w-full"
+                    onClick={() => posthog.capture('SAVE_VIEW_TYPE_BTN')}
                 >
                     Lagre visningstype
                 </SubmitButton>

--- a/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { RadioGroup, Radio } from '@entur/form'
+import { Heading3, Paragraph } from '@entur/typography'
+import { SubmitButton } from 'components/Form/SubmitButton'
+import { useState } from 'react'
+import { TBoard } from 'types/settings'
+import { setViewType as setViewTypeAction } from './actions'
+import { useToast } from '@entur/alert'
+
+function ViewTypeSetting({ board }: { board: TBoard }) {
+    const [value, setValue] = useState(
+        board.combinedTiles ? 'combined' : 'separate',
+    )
+    const { addToast } = useToast()
+
+    const setViewType = async () => {
+        const formFeedback = await setViewTypeAction(board, value)
+        if (!formFeedback) {
+            addToast('Visningstype lagret!')
+        }
+    }
+    return (
+        <form action={setViewType} className="box flex flex-col">
+            <Heading3 margin="bottom">Visningstype</Heading3>
+            <Paragraph>
+                Velg om alle stoppestedene skal vises i hver sin tabell eller
+                kombinert i samme tabell.
+            </Paragraph>
+
+            <div className="h-full">
+                <RadioGroup
+                    name="viewType"
+                    label="Visningstype"
+                    onChange={(e) => setValue(e.target.value)}
+                    value={value}
+                >
+                    <Radio value="separate">Én liste per stoppested</Radio>
+                    <Radio value="combined">Alle stoppesteder i én liste</Radio>
+                </RadioGroup>
+            </div>
+            <div className="flex flex-row mt-8 justify-end">
+                <SubmitButton
+                    variant="secondary"
+                    aria-label="Lagre visningstype"
+                    className="max-sm:w-full"
+                >
+                    Lagre visningstype
+                </SubmitButton>
+            </div>
+        </form>
+    )
+}
+export { ViewTypeSetting }

--- a/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
@@ -10,14 +10,14 @@ import { useToast } from '@entur/alert'
 import { usePostHog } from 'posthog-js/react'
 
 function ViewTypeSetting({ board }: { board: TBoard }) {
-    const [value, setValue] = useState(
+    const [viewTypeValue, setViewTypeValue] = useState(
         board.combinedTiles ? 'combined' : 'separate',
     )
     const { addToast } = useToast()
     const posthog = usePostHog()
 
     const setViewType = async () => {
-        const formFeedback = await setViewTypeAction(board, value)
+        const formFeedback = await setViewTypeAction(board, viewTypeValue)
         if (!formFeedback) {
             addToast('Visningstype lagret!')
         }
@@ -34,8 +34,8 @@ function ViewTypeSetting({ board }: { board: TBoard }) {
                 <RadioGroup
                     name="viewType"
                     label="Visningstype"
-                    onChange={(e) => setValue(e.target.value)}
-                    value={value}
+                    onChange={(e) => setViewTypeValue(e.target.value)}
+                    value={viewTypeValue}
                 >
                     <Radio value="separate">Én liste per stoppested</Radio>
                     <Radio value="combined">Alle stoppesteder i én liste</Radio>
@@ -46,7 +46,11 @@ function ViewTypeSetting({ board }: { board: TBoard }) {
                     variant="secondary"
                     aria-label="Lagre visningstype"
                     className="max-sm:w-full"
-                    onClick={() => posthog.capture('SAVE_VIEW_TYPE_BTN')}
+                    onClick={() =>
+                        posthog.capture('SAVE_VIEW_TYPE_BTN', {
+                            value: viewTypeValue,
+                        })
+                    }
                 >
                     Lagre visningstype
                 </SubmitButton>

--- a/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/ViewType/index.tsx
@@ -26,8 +26,8 @@ function ViewTypeSetting({ board }: { board: TBoard }) {
         <form action={setViewType} className="box flex flex-col">
             <Heading3 margin="bottom">Visningstype</Heading3>
             <Paragraph>
-                Velg om alle stoppestedene skal vises i hver sin tabell eller
-                kombinert i samme tabell.
+                Velg om alle stoppestedene skal vises i hver sin liste eller
+                kombinert i samme liste.
             </Paragraph>
 
             <div className="h-full">

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -1,6 +1,10 @@
 import { notFound, redirect } from 'next/navigation'
 import { TBoardID } from 'types/settings'
-import { addTile, getWalkingDistanceTile } from './actions'
+import {
+    addTile,
+    addTileToCombinedList,
+    getWalkingDistanceTile,
+} from './actions'
 import { Heading1, Heading2 } from '@entur/typography'
 import { MetaSettings } from './components/MetaSettings'
 import { TileSelector } from 'app/(admin)/components/TileSelector'
@@ -22,6 +26,7 @@ import { getBoard } from 'Board/scenarios/Board/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 import { CompressSurvey } from './components/CompressSurvey'
 import { Delete } from 'app/(admin)/boards/components/Column/Delete'
+import { ViewTypeSetting } from './components/ViewType'
 
 export type TProps = {
     params: Promise<{ id: TBoardID }>
@@ -52,6 +57,7 @@ export default async function EditPage(props: TProps) {
 
     const access = await userCanEditBoard(params.id)
     if (!access) return redirect('/')
+
     return (
         <div className="bg-gray-50">
             <div className="flex flex-col gap-6 pt-16 container pb-20">
@@ -84,6 +90,8 @@ export default async function EditPage(props: TProps) {
                             )
                             if (!tile.placeId) return
                             await addTile(params.id, tile)
+                            if (board.combinedTiles)
+                                await addTileToCombinedList(board, tile.uuid)
                             revalidatePath(`/edit/${params.id}`)
                         }}
                     />
@@ -106,6 +114,7 @@ export default async function EditPage(props: TProps) {
                             meta={board.meta}
                             organization={organization}
                         />
+                        <ViewTypeSetting board={board} />
                         <Footer
                             bid={params.id}
                             footer={board.footer}

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -25,21 +25,23 @@ function ExpandableInformation() {
                 className="bg-blue90 px-6  py-4 rounded-b"
             >
                 <UnorderedList className="space-y-3 gap-1 pl-6">
-                    <ListItem>Endre tekststørrelse</ListItem>
+                    <ListItem>
+                        Vise stoppestedene hver for seg eller samlet i én liste
+                    </ListItem>
+                    <ListItem>
+                        Vise gangavstand fra tavlen til stoppested(ene)
+                    </ListItem>
                     <ListItem>
                         Legge til en infomelding nederst i tavlen
                     </ListItem>
                     <ListItem>Endre fargetema (lys eller mørk modus)</ListItem>
+                    <ListItem>Endre tekststørrelse</ListItem>
                     <ListItem>
-                        Legge inn adressen som tavlen står på og vise
-                        gangavstand fra tavlen til stoppested(ene)
+                        Gi andre tilgang til å administrere tavlen
                     </ListItem>
                     <ListItem>
                         Opprette så mange tavler du vil og samle disse i ulike
                         organisasjoner (mapper)
-                    </ListItem>
-                    <ListItem>
-                        Gi andre tilgang til å administrere tavlen
                     </ListItem>
                 </UnorderedList>
             </BaseExpand>

--- a/tavla/app/demo/page.tsx
+++ b/tavla/app/demo/page.tsx
@@ -11,7 +11,7 @@ async function Demo() {
         <main className="container pt-8 pb-20 flex flex-col gap-10">
             <div>
                 <Heading1>Test ut Tavla!</Heading1>
-                <LeadParagraph margin="none" className="lg:w-4/5">
+                <LeadParagraph margin="none">
                     Dette er en demo-løsning hvor du kan prøve å opprette din
                     egen tavle. Du må logge inn for å lagre tavlen og få tilgang
                     til all funksjonalitet. Tavlen du lager her blir ikke

--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -50,11 +50,7 @@ function getCombinedTiles(board: TBoard) {
 
     const combinedTiles =
         combinedTileIds?.map((tileIds) =>
-            tileIds.map(
-                (tileId) =>
-                    board.tiles.find((tile) => tile.uuid === tileId) ||
-                    ({} as TTile),
-            ),
+            board.tiles.filter((tile) => tileIds.includes(tile.uuid)),
         ) || []
 
     return combinedTiles

--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -12,8 +12,6 @@ function BoardTile({ tileSpec }: { tileSpec: TTile }) {
             return <StopPlaceTile {...tileSpec} />
         case 'quay':
             return <QuayTile {...tileSpec} />
-        case 'combined':
-            return <CombinedTile {...tileSpec} />
     }
 }
 
@@ -25,17 +23,50 @@ function Board({ board }: { board: TBoard }) {
             </Tile>
         )
 
+    const combinedTiles = getCombinedTiles(board)
+    const separateTiles = getSeparateTiles(board)
+
     return (
         <div
             className={`max-sm:overflow-y-scroll grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
                 board.meta?.fontSize || defaultFontSize(board),
             )} `}
         >
-            {board.tiles.map((tile, index) => {
+            {separateTiles.map((tile, index) => {
                 return <BoardTile key={index} tileSpec={tile} />
+            })}
+            {combinedTiles.map((combinedTile, index) => {
+                return <CombinedTile key={index} combinedTile={combinedTile} />
             })}
         </div>
     )
 }
 
 export { Board }
+
+function getCombinedTiles(board: TBoard) {
+    const combinedTileIds =
+        board.combinedTiles?.map((combineTile) => combineTile.ids) ?? []
+
+    const combinedTiles =
+        combinedTileIds?.map((tileIds) =>
+            tileIds.map(
+                (tileId) =>
+                    board.tiles.find((tile) => tile.uuid === tileId) ||
+                    ({} as TTile),
+            ),
+        ) || []
+
+    return combinedTiles
+}
+
+function getSeparateTiles(board: TBoard) {
+    const combinedTileIds =
+        board.combinedTiles?.map((combineTile) => combineTile.ids) ?? []
+
+    const separateTiles = board.tiles.filter(
+        (tile) => !combinedTileIds?.flat().includes(tile.uuid),
+    )
+
+    return separateTiles
+}

--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -4,6 +4,7 @@ import { StopPlaceTile } from '../StopPlaceTile'
 import { QuayTile } from '../QuayTile'
 import { Tile } from 'components/Tile'
 import { defaultFontSize, getFontScale } from 'Board/scenarios/Board/utils'
+import { CombinedTile } from '../CombinedTile'
 
 function BoardTile({ tileSpec }: { tileSpec: TTile }) {
     switch (tileSpec.type) {
@@ -11,6 +12,8 @@ function BoardTile({ tileSpec }: { tileSpec: TTile }) {
             return <StopPlaceTile {...tileSpec} />
         case 'quay':
             return <QuayTile {...tileSpec} />
+        case 'combined':
+            return <CombinedTile {...tileSpec} />
     }
 }
 

--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { TCombinedTile } from 'types/tile'
+import { GetQuayQuery, StopPlaceQuery, TSituationFragment } from 'graphql/index'
+import { Tile } from 'components/Tile'
+import { TableHeader } from '../Table/components/TableHeader'
+import { TileLoader } from 'Board/components/TileLoader'
+import {
+    DataFetchingFailed,
+    FetchErrorTypes,
+} from 'Board/components/DataFetchingFailed'
+import { Table } from '../Table'
+import { useQueries } from 'hooks/useQuery'
+
+export function CombinedTile({
+    placeId,
+    whitelistedLines,
+    whitelistedTransportModes,
+    columns,
+    walkingDistance,
+    offset,
+    displayName,
+}: TCombinedTile) {
+    const quayQueries = placeId
+        .filter(({ type }) => type === 'quay')
+        .map(({ id }) => ({
+            query: GetQuayQuery,
+            variables: {
+                quayId: id,
+                whitelistedTransportModes,
+                whitelistedLines,
+            },
+            options: { offset, poll: true },
+        }))
+
+    const stopPlaceQueries = placeId
+        .filter(({ type }) => type === 'stop_place')
+        .map(({ id }) => ({
+            query: StopPlaceQuery,
+            variables: {
+                stopPlaceId: id,
+                whitelistedTransportModes,
+                whitelistedLines,
+            },
+            options: { offset, poll: true },
+        }))
+
+    const {
+        data: quayData,
+        error: quayError,
+        isLoading: quayLoading,
+    } = useQueries(quayQueries)
+    const {
+        data: stopPlaceData,
+        error: stopPlaceError,
+        isLoading: stopPlaceLoading,
+    } = useQueries(stopPlaceQueries)
+
+    const loading = quayLoading || stopPlaceLoading
+    const errors = quayError || stopPlaceError
+
+    if (loading) {
+        return (
+            <Tile>
+                <TileLoader />
+            </Tile>
+        )
+    }
+    if (errors) {
+        return (
+            <Tile>
+                <DataFetchingFailed
+                    timeout={errors?.message === FetchErrorTypes.TIMEOUT}
+                />
+            </Tile>
+        )
+    }
+
+    const estimatedCalls = [
+        ...(quayData?.flatMap((data) => data?.quay?.estimatedCalls ?? []) ??
+            []),
+        ...(stopPlaceData?.flatMap(
+            (data) => data?.stopPlace?.estimatedCalls ?? [],
+        ) ?? []),
+    ]
+    const situations: TSituationFragment[] = [
+        ...(quayData?.flatMap((data) => data?.quay?.situations ?? []) ?? []),
+        ...(stopPlaceData?.flatMap(
+            (data) => data?.stopPlace?.situations ?? [],
+        ) ?? []),
+    ]
+    const sortedEstimatedCalls = estimatedCalls.sort((a, b) => {
+        const timeA = new Date(a.expectedDepartureTime).getTime()
+        const timeB = new Date(b.expectedDepartureTime).getTime()
+
+        if (isNaN(timeA)) return 1
+        if (isNaN(timeB)) return -1
+
+        return timeA - timeB
+    })
+
+    return (
+        <Tile className="flex flex-col max-sm:min-h-[30vh]">
+            <TableHeader
+                heading={displayName ?? 'Kombinerte stoppesteder'}
+                walkingDistance={walkingDistance}
+            />
+            <Table
+                departures={sortedEstimatedCalls}
+                situations={situations}
+                columns={columns}
+            />
+        </Tile>
+    )
+}

--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -74,12 +74,20 @@ export function CombinedTile({
             </Tile>
         )
     }
-
     const estimatedCalls = [
-        ...(quayData?.flatMap((data) => data?.quay?.estimatedCalls ?? []) ??
-            []),
+        ...(quayData?.flatMap(
+            (data) =>
+                data?.quay?.estimatedCalls.map((call) => ({
+                    ...call,
+                    name: data.quay?.name,
+                })) ?? [],
+        ) ?? []),
         ...(stopPlaceData?.flatMap(
-            (data) => data?.stopPlace?.estimatedCalls ?? [],
+            (data) =>
+                data?.stopPlace?.estimatedCalls.map((call) => ({
+                    ...call,
+                    name: data.stopPlace?.name,
+                })) ?? [],
         ) ?? []),
     ]
     const situations: TSituationFragment[] = [

--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -71,19 +71,9 @@ export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
     }
 
     const estimatedCalls = [
-        ...(quayData?.flatMap(
-            (data) =>
-                data?.quay?.estimatedCalls.map((call) => ({
-                    ...call,
-                    name: data.quay?.name,
-                })) ?? [],
-        ) ?? []),
+        ...(quayData?.flatMap((data) => data.quay?.estimatedCalls ?? []) ?? []),
         ...(stopPlaceData?.flatMap(
-            (data) =>
-                data?.stopPlace?.estimatedCalls.map((call) => ({
-                    ...call,
-                    name: data.stopPlace?.name,
-                })) ?? [],
+            (data) => data.stopPlace?.estimatedCalls ?? [],
         ) ?? []),
     ]
 

--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -5,7 +5,6 @@ import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
 import { isNotNullOrUndefined } from 'utils/typeguards'
 import { TDepartureFragment } from 'graphql/index'
-import { nanoid } from 'nanoid'
 
 function Destination({ deviations = true }: { deviations?: boolean }) {
     const departures = useNonNullContext(DeparturesContext)
@@ -47,12 +46,11 @@ function Name() {
         text: departure?.name,
         key: departure.serviceJourney.id,
     }))
-    const id = nanoid(7)
     return (
         <div className="grow overflow-hidden">
             <TableColumn title="Stoppested">
-                {names.map((name) => (
-                    <TableRow key={id}>
+                {names.map((name, index) => (
+                    <TableRow key={index}>
                         <div className="justify-items-end">{name.text}</div>
                     </TableRow>
                 ))}

--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -4,7 +4,7 @@ import { Situations } from './Situations'
 import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
 import { isNotNullOrUndefined } from 'utils/typeguards'
-import { TDepartureFragment } from 'graphql/index'
+import { nanoid } from 'nanoid'
 
 function Destination({ deviations = true }: { deviations?: boolean }) {
     const departures = useNonNullContext(DeparturesContext)
@@ -16,7 +16,7 @@ function Destination({ deviations = true }: { deviations?: boolean }) {
             departure.destinationDisplay?.via
                 ?.filter(isNotNullOrUndefined)
                 .join(', ') ?? '',
-        key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
+        key: nanoid(),
     }))
     return (
         <div className="grow overflow-hidden">
@@ -38,20 +38,18 @@ function Destination({ deviations = true }: { deviations?: boolean }) {
         </div>
     )
 }
-type TDepartureWithName = TDepartureFragment & { name: string }
 
 function Name() {
     const departures = useNonNullContext(DeparturesContext)
-    const names = (departures as TDepartureWithName[]).map((departure) => ({
-        text: departure?.name,
-        key: departure.serviceJourney.id,
-    }))
+
     return (
         <div className="grow overflow-hidden">
             <TableColumn title="Stoppested">
-                {names.map((name, index) => (
-                    <TableRow key={index}>
-                        <div className="justify-items-end">{name.text}</div>
+                {departures.map((departure) => (
+                    <TableRow key={nanoid()}>
+                        <div className="justify-items-end">
+                            {departure.quay.name}
+                        </div>
                     </TableRow>
                 ))}
             </TableColumn>

--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -4,6 +4,8 @@ import { Situations } from './Situations'
 import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
 import { isNotNullOrUndefined } from 'utils/typeguards'
+import { TDepartureFragment } from 'graphql/index'
+import { nanoid } from 'nanoid'
 
 function Destination({ deviations = true }: { deviations?: boolean }) {
     const departures = useNonNullContext(DeparturesContext)
@@ -37,5 +39,26 @@ function Destination({ deviations = true }: { deviations?: boolean }) {
         </div>
     )
 }
+type TDepartureWithName = TDepartureFragment & { name: string }
 
-export { Destination }
+function Name() {
+    const departures = useNonNullContext(DeparturesContext)
+    const names = (departures as TDepartureWithName[]).map((departure) => ({
+        text: departure?.name,
+        key: departure.serviceJourney.id,
+    }))
+    const id = nanoid(7)
+    return (
+        <div className="grow overflow-hidden">
+            <TableColumn title="Stoppested">
+                {names.map((name) => (
+                    <TableRow key={id}>
+                        <div className="justify-items-end">{name.text}</div>
+                    </TableRow>
+                ))}
+            </TableColumn>
+        </div>
+    )
+}
+
+export { Destination, Name }

--- a/tavla/src/Board/scenarios/Table/components/Line/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Line/index.tsx
@@ -4,6 +4,7 @@ import { TableColumn } from '../TableColumn'
 import { TableRow } from '../TableRow'
 import { TravelTag } from 'components/TravelTag'
 import { getAirPublicCode } from 'utils/publicCode'
+import { nanoid } from 'nanoid'
 
 function Line() {
     const departures = useNonNullContext(DeparturesContext)
@@ -13,7 +14,7 @@ function Line() {
         transportSubmode:
             departure.serviceJourney.transportSubmode ?? undefined,
         publicCode: departure.serviceJourney.line.publicCode ?? '',
-        key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
+        key: nanoid(),
         id: departure.serviceJourney.id ?? '',
     }))
 

--- a/tavla/src/Board/scenarios/Table/components/Platform.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Platform.tsx
@@ -2,13 +2,14 @@ import { useNonNullContext } from 'hooks/useNonNullContext'
 import { DeparturesContext } from '../contexts'
 import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
+import { nanoid } from 'nanoid'
 
 function Platform() {
     const departures = useNonNullContext(DeparturesContext)
 
     const platforms = departures.map((departure) => ({
         publicCode: departure.quay.publicCode,
-        key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
+        key: nanoid(),
     }))
 
     return (

--- a/tavla/src/Board/scenarios/Table/components/RealTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/RealTime.tsx
@@ -3,15 +3,14 @@ import { DeparturesContext } from '../contexts'
 import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
 import { Pulse } from 'components/Pulse'
+import { nanoid } from 'nanoid'
 
 function RealTime() {
     const departures = useNonNullContext(DeparturesContext)
 
     const realtimes = departures.map((departure) => ({
         realtime: departure.realtime,
-        key: `${departure.serviceJourney.id}_${
-            departure.aimedDepartureTime
-        }_${Date.now()}`,
+        key: nanoid(),
     }))
 
     return (

--- a/tavla/src/Board/scenarios/Table/components/Time/AimedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/AimedTime.tsx
@@ -3,13 +3,14 @@ import { DeparturesContext } from 'Board/scenarios/Table/contexts'
 import { TableColumn } from '../TableColumn'
 import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
+import { nanoid } from 'nanoid'
 
 function AimedTime() {
     const departures = useNonNullContext(DeparturesContext)
 
     const time = departures.map((departure) => ({
         aimedDepartureTime: departure.aimedDepartureTime,
-        key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
+        key: nanoid(),
     }))
 
     return (

--- a/tavla/src/Board/scenarios/Table/components/Time/ArrivalTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ArrivalTime.tsx
@@ -3,13 +3,14 @@ import { useNonNullContext } from 'hooks/useNonNullContext'
 import { TableColumn } from '../TableColumn'
 import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
+import { nanoid } from 'nanoid'
 
 function ArrivalTime() {
     const departures = useNonNullContext(DeparturesContext)
 
     const time = departures.map((departure) => ({
         expectedArrivalTime: departure.expectedArrivalTime,
-        key: `${departure.serviceJourney.id}_${departure.expectedArrivalTime}`,
+        key: nanoid(),
     }))
 
     return (

--- a/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
@@ -4,6 +4,7 @@ import { DeparturesContext } from 'Board/scenarios/Table/contexts'
 import { TableColumn } from '../TableColumn'
 import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
+import { nanoid } from 'nanoid'
 
 function ExpectedTime() {
     const departures = useNonNullContext(DeparturesContext)
@@ -12,7 +13,7 @@ function ExpectedTime() {
         aimedDepartureTime: departure.aimedDepartureTime,
         expectedDepartureTime: departure.expectedDepartureTime,
         cancelled: departure.cancellation,
-        key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
+        key: nanoid(),
     }))
 
     return (

--- a/tavla/src/Board/scenarios/Table/index.tsx
+++ b/tavla/src/Board/scenarios/Table/index.tsx
@@ -61,7 +61,6 @@ function Table({
                         <Destination deviations />
                     )}
                     {columns.includes('name') && <Name />}
-
                     {columns.includes('platform') && <Platform />}
                     {columns.includes('time') && <ExpectedTime />}
                     {columns.includes('realtime') && <RealTime />}

--- a/tavla/src/Board/scenarios/Table/index.tsx
+++ b/tavla/src/Board/scenarios/Table/index.tsx
@@ -1,6 +1,6 @@
 import { TDepartureFragment, TSituationFragment } from 'graphql/index'
 import React from 'react'
-import { Destination } from './components/Destination'
+import { Destination, Name } from './components/Destination'
 import { DeparturesContext } from './contexts'
 import { TColumn } from 'types/column'
 import { isArray } from 'lodash'
@@ -49,7 +49,6 @@ function Table({
                 </Paragraph>
             </div>
         )
-
     return (
         <div className="flex flex-col">
             <StopPlaceDeviation situations={situations} />
@@ -61,6 +60,8 @@ function Table({
                     {columns.includes('destination') && (
                         <Destination deviations />
                     )}
+                    {columns.includes('name') && <Name />}
+
                     {columns.includes('platform') && <Platform />}
                     {columns.includes('time') && <ExpectedTime />}
                     {columns.includes('realtime') && <RealTime />}

--- a/tavla/src/Shared/graphql/fragments/departure.graphql
+++ b/tavla/src/Shared/graphql/fragments/departure.graphql
@@ -1,6 +1,7 @@
 fragment departure on EstimatedCall {
     quay {
         publicCode
+        name
     }
     destinationDisplay {
         frontText

--- a/tavla/src/Shared/graphql/index.ts
+++ b/tavla/src/Shared/graphql/index.ts
@@ -9,7 +9,7 @@ export type TDepartureFragment = {
     expectedArrivalTime: DateTime
     cancellation: boolean
     realtime: boolean
-    quay: { __typename?: 'Quay'; publicCode: string | null }
+    quay: { __typename?: 'Quay'; publicCode: string | null; name: string }
     destinationDisplay: {
         __typename?: 'DestinationDisplay'
         frontText: string | null
@@ -100,7 +100,11 @@ export type TGetQuayQuery = {
             expectedArrivalTime: DateTime
             cancellation: boolean
             realtime: boolean
-            quay: { __typename?: 'Quay'; publicCode: string | null }
+            quay: {
+                __typename?: 'Quay'
+                publicCode: string | null
+                name: string
+            }
             destinationDisplay: {
                 __typename?: 'DestinationDisplay'
                 frontText: string | null
@@ -262,7 +266,11 @@ export type TStopPlaceQuery = {
             expectedArrivalTime: DateTime
             cancellation: boolean
             realtime: boolean
-            quay: { __typename?: 'Quay'; publicCode: string | null }
+            quay: {
+                __typename?: 'Quay'
+                publicCode: string | null
+                name: string
+            }
             destinationDisplay: {
                 __typename?: 'DestinationDisplay'
                 frontText: string | null
@@ -428,6 +436,7 @@ export const DepartureFragment = new TypedDocumentString(
     fragment departure on EstimatedCall {
   quay {
     publicCode
+    name
   }
   destinationDisplay {
     frontText
@@ -505,6 +514,7 @@ export const GetQuayQuery = new TypedDocumentString(`
     fragment departure on EstimatedCall {
   quay {
     publicCode
+    name
   }
   destinationDisplay {
     frontText
@@ -637,6 +647,7 @@ export const StopPlaceQuery = new TypedDocumentString(`
     fragment departure on EstimatedCall {
   quay {
     publicCode
+    name
   }
   destinationDisplay {
     frontText

--- a/tavla/src/Shared/types/column.ts
+++ b/tavla/src/Shared/types/column.ts
@@ -4,6 +4,7 @@ export const Columns = {
     line: 'Linje',
     destination: 'Destinasjon og avvik',
     platform: 'Plattform',
+    name: 'Stoppested',
     time: 'Forventet',
     realtime: 'Sanntidsindikator',
 } as const

--- a/tavla/src/Shared/types/column.ts
+++ b/tavla/src/Shared/types/column.ts
@@ -17,3 +17,12 @@ export const DEFAULT_ORGANIZATION_COLUMNS = [
     'time',
     'realtime',
 ] as TColumn[]
+
+export const DEFAULT_COMBINED_COLUMNS = [
+    'line',
+    'destination',
+    'name',
+    'platform',
+    'time',
+    'realtime',
+] as TColumn[]

--- a/tavla/src/Shared/types/settings.ts
+++ b/tavla/src/Shared/types/settings.ts
@@ -5,10 +5,13 @@ import { TTile } from './tile'
 
 export type TTheme = 'entur' | 'dark' | 'light'
 
+export type TCombinedTiles = { ids: string[] }
+
 export type TBoard = {
     id?: TBoardID
     meta: TMeta
     tiles: TTile[]
+    combinedTiles?: TCombinedTiles[]
     theme?: TTheme
     footer?: TFooter
 }

--- a/tavla/src/Shared/types/settings.ts
+++ b/tavla/src/Shared/types/settings.ts
@@ -5,7 +5,7 @@ import { TTile } from './tile'
 
 export type TTheme = 'entur' | 'dark' | 'light'
 
-export type TCombinedTiles = { ids: string[] }
+export type TCombinedTiles = { ids: TBoardID[] }
 
 export type TBoard = {
     id?: TBoardID

--- a/tavla/src/Shared/types/tile.ts
+++ b/tavla/src/Shared/types/tile.ts
@@ -30,14 +30,5 @@ export type TWalkingDistance = {
     distance?: number
     visible?: boolean
 }
-export type TPlaceId = {
-    id: string
-    type: 'stop_place' | 'quay'
-}
-export type TCombinedTile = {
-    type: 'combined'
-    placeId: TPlaceId[]
-} & TSharedTile &
-    TColumnTile
 
-export type TTile = TStopPlaceTile | TQuayTile | TCombinedTile
+export type TTile = TStopPlaceTile | TQuayTile

--- a/tavla/src/Shared/types/tile.ts
+++ b/tavla/src/Shared/types/tile.ts
@@ -30,5 +30,14 @@ export type TWalkingDistance = {
     distance?: number
     visible?: boolean
 }
+export type TPlaceId = {
+    id: string
+    type: 'stop_place' | 'quay'
+}
+export type TCombinedTile = {
+    type: 'combined'
+    placeId: TPlaceId[]
+} & TSharedTile &
+    TColumnTile
 
-export type TTile = TStopPlaceTile | TQuayTile
+export type TTile = TStopPlaceTile | TQuayTile | TCombinedTile


### PR DESCRIPTION
### Mulighet for å kombinere stoppesteder til én
---
#### Motivasjon
Vi har fått flere henvendelser som handler om det er mulig å slå sammen stoppesteder til ett stoppested. Det er flere plasser hvor det ligger stoppesteder ganske nærme hverandre, og man ønsker å kunne slå disse sammen i stedet for å ha to separate tiles. I tillegg er det flere som har uttrykt at de ønsker å kunne se alt som går i en spesifikk retning, så vi har en hypotese om at ved å klare å kombinere flere plattformer så vil dette problemet også blir løst i større grad. 

OBS: i første omgang er det kun mulig å enten kombinere alle stoppestedene i tavla, eller ingen, men det er lagt opp i databasen at man kan ha flere kombinerte tiles. 

#### Endringer
- Det skal nå være mulig å velge visningstype i innstillinger. 
- Databasen har fått et nytt felt: `combinedTiles: [{ids: }]` hvor man legger inn `uuid` for de tilene som skal kombineres. Velger man separat visning, så slettes dette feltet. 
- Det er ikke mulig å velge hvilke kolonner som skal vises i tavlevisningen om man har kombinert visning. Dette kan endres på senere, men er første iterasjon. 
- Lagt til måling på selve knappen. Vi skal også opprette en måling i Grafana. 
- Det er mulig å legge til gåavstand, men dette vil bare vises om visningen er separat. 

![image](https://github.com/user-attachments/assets/ef283cd7-3beb-47d2-ad43-09b84e780e08)

![image](https://github.com/user-attachments/assets/897d3365-3ee9-4a4c-9d74-124afa59d888)

![image](https://github.com/user-attachments/assets/c1fa7407-fdde-46ac-999c-1cc4889f7383)


#### Sjekkliste for Review
- [x] Sjekk at man får trykket på kombinert visning
- [x] Sjekk at man får trykket på separat visning
- [x] Sjekk at feltene i databasen oppdaterer seg deretter
- [x] Sjekk at det funker på gammel chrome
- [x] Sjekk at alle innstillinger fortsatt funker for hele tavla
