### PR TITLE
feat(banner): add banner to promote new functionality for combined tiles

### DIFF
--- a/tavla/app/components/Banner.tsx
+++ b/tavla/app/components/Banner.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import { BannerAlertBox } from '@entur/alert'
 import { useLocalStorage } from 'app/(admin)/hooks/useLocalStorage'
 import ClientOnly from './NoSSR/ClientOnly'
@@ -23,8 +22,8 @@ function Banner() {
                 }}
                 title="Nyhet! Nå kan du kombinere flere stoppesteder i en liste."
             >
-                Du finner det under "Innstillinger" nederst på siden hvor du
-                redigerer tavlen din.
+                Du finner det under &quot;Innstillinger&quot; nederst på siden
+                hvor du redigerer tavlen din.
             </BannerAlertBox>
         </ClientOnly>
     )

--- a/tavla/app/components/Banner.tsx
+++ b/tavla/app/components/Banner.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { BannerAlertBox } from '@entur/alert'
+import { useLocalStorage } from 'app/(admin)/hooks/useLocalStorage'
+import ClientOnly from './NoSSR/ClientOnly'
+import { usePostHog } from 'posthog-js/react'
+
+function Banner() {
+    const [showBanner, setShowBanner] = useLocalStorage('show_banner', true)
+
+    const posthog = usePostHog()
+
+    if (!showBanner) return null
+
+    return (
+        <ClientOnly>
+            <BannerAlertBox
+                variant="information"
+                closable
+                onClose={() => {
+                    setShowBanner(false)
+                    posthog.capture('DISMISS_NEW_FUNCTIONALITY_BANNER')
+                }}
+                title="Nyhet! Nå kan du kombinere flere stoppesteder i en liste."
+            >
+                Du finner det under "Innstillinger" nederst på siden hvor du
+                redigerer tavlen din.
+            </BannerAlertBox>
+        </ClientOnly>
+    )
+}
+
+export { Banner }

--- a/tavla/app/layout.tsx
+++ b/tavla/app/layout.tsx
@@ -2,7 +2,6 @@ import 'styles/imports.css'
 import 'styles/fonts.css'
 import 'styles/reset.css'
 import './globals.css'
-
 import { ReactNode, Suspense } from 'react'
 import { Metadata } from 'next'
 import { EnturToastProvider, PHProvider } from './providers'
@@ -11,6 +10,7 @@ import { TopNavigation } from './(admin)/components/TopNavigation'
 import { ContactForm } from './components/ContactForm'
 import PostHogPageView from './components/PostHogPageView'
 import { getUserFromSessionCookie } from './(admin)/utils/server'
+import { Banner } from './components/Banner'
 
 export const metadata: Metadata = {
     title: 'Entur Tavla',
@@ -43,6 +43,8 @@ async function RootLayout({ children }: { children: ReactNode }) {
             <PHProvider>
                 <body>
                     <EnturToastProvider>
+                        {loggedIn && <Banner />}
+
                         <TopNavigation loggedIn={loggedIn} />
                         <Suspense>
                             <PostHogPageView />


### PR DESCRIPTION
### Legge til banner for å promotere ny funksjonalitet 
---
#### Motivasjon
Ny funksjonalitet om kombinerte stoppesteder ligger litt gjømt nede i innstillinger på rediger tavle. Dette er et forsøk på å promotere det i større grad.

#### Endringer
- Lagt til banner-komponenten fra design-systemet. Vi er blitt enige om at denne skal ligge på alle sider så lenge man er innlogget. 
- Lagrer i localstorage om man har dismissa banneren eller ikke
- Må ha en `<ClientOnly>` wrappa rundt fordi banneren bruker en tooltip som gir duf hydration error

![image](https://github.com/user-attachments/assets/36e5fb7c-276e-4df7-a682-1210e44ca483)

#### Sjekkliste for Review
- [x] Sjekk at du får opp banneren når du logger inn (du skal ikke få den opp når du er logget ut)
- [x] Sjekk at verdien blir satt i local storage når du krysser den bort, og at den ikke dukker opp på refresh. 
