### PR TITLE
fix(board): remove redirect on unsupported browser

### DIFF
--- a/tavla/pages/[id].tsx
+++ b/tavla/pages/[id].tsx
@@ -11,21 +11,10 @@ import { getBackendUrl } from 'utils/index'
 import Head from 'next/head'
 import { useEffect } from 'react'
 import { GetServerSideProps } from 'next'
-import { isUnsupportedBrowser } from 'utils/browserDetection'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-    const { params, req } = context
+    const { params } = context
     const { id } = params as { id: string }
-
-    const ua = req.headers['user-agent'] || ''
-    if (isUnsupportedBrowser(ua)) {
-        return {
-            redirect: {
-                destination: '/unsupported-browser',
-                permanent: false,
-            },
-        }
-    }
 
     const board: TBoard | undefined = await getBoard(id)
 


### PR DESCRIPTION
### Fjern redirect til unsupported
---
#### Motivasjon
FRAM sier flere av deres tavler kræsjer, vi har hatt en brå økning i antall 307 (redirect) requests siden prodsettingen i går
<img width="662" alt="Screenshot 2025-02-20 at 16 35 23" src="https://github.com/user-attachments/assets/61a1ae11-00ce-4d37-9a0d-9eb79270afad" />

