### PR TITLE
feat(login): add google SSO

### DIFF
--- a/tavla/app/(admin)/components/Login/Create.tsx
+++ b/tavla/app/(admin)/components/Login/Create.tsx
@@ -23,6 +23,7 @@ import { Button, ButtonGroup } from '@entur/button'
 import Link from 'next/link'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
 import { handleError } from 'app/(admin)/utils/handleError'
+import Google from './Google'
 
 function Create() {
     const submit = async (p: TFormFeedback | undefined, data: FormData) => {
@@ -113,13 +114,15 @@ function Create() {
                         </Button>
                     </div>
                 </ButtonGroup>
-                <Paragraph className="text-center" margin="none">
-                    Har du allerede en bruker?{' '}
-                    <Link className="underline" href="?login=email">
-                        Logg inn
-                    </Link>
-                </Paragraph>
             </form>
+            <Paragraph className="mb-2 mt-6">Eller...</Paragraph>
+            <Google />
+            <Paragraph className="text-center mt-10" margin="none">
+                Har du allerede en bruker?{' '}
+                <Link className="underline" href="?login=email">
+                    Logg inn
+                </Link>
+            </Paragraph>
         </div>
     )
 }

--- a/tavla/app/(admin)/components/Login/Create.tsx
+++ b/tavla/app/(admin)/components/Login/Create.tsx
@@ -115,7 +115,7 @@ function Create() {
                     </div>
                 </ButtonGroup>
             </form>
-            <Paragraph className="mb-2 mt-6">Eller...</Paragraph>
+            <div className="border-2 rounded-sm w-full mb-8 mt-4"></div>
             <Google />
             <Paragraph className="text-center mt-10" margin="none">
                 Har du allerede en bruker?{' '}

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -135,17 +135,15 @@ function Email() {
                         </Button>
                     </div>
                 </ButtonGroup>
-                <Paragraph className="text-center" margin="none">
-                    Har du ikke en bruker?{' '}
-                    <Link
-                        className="underline"
-                        href={getPathWithParams('create')}
-                    >
-                        Opprett bruker
-                    </Link>
-                </Paragraph>
             </form>
+            <Paragraph className="mb-2 mt-6">Eller...</Paragraph>
             <Google />
+            <Paragraph className="text-center mt-10" margin="none">
+                Har du ikke en bruker?{' '}
+                <Link className="underline" href={getPathWithParams('create')}>
+                    Opprett bruker
+                </Link>
+            </Paragraph>
         </div>
     )
 }

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -26,6 +26,7 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
+import Google from './Google'
 
 function Email() {
     const submit = async (
@@ -144,6 +145,7 @@ function Email() {
                     </Link>
                 </Paragraph>
             </form>
+            <Google />
         </div>
     )
 }

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -27,8 +27,10 @@ import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
 import Google from './Google'
+import { usePostHog } from 'posthog-js/react'
 
 function Email() {
+    const posthog = usePostHog()
     const submit = async (
         previousState: TFormFeedback | undefined,
         data: FormData,
@@ -117,6 +119,11 @@ function Email() {
                             variant="primary"
                             width="fluid"
                             aria-label="Logg inn"
+                            onClick={() => {
+                                posthog.capture(
+                                    'LOG_IN_WITH_PASSWORD_BTN_CLICK',
+                                )
+                            }}
                         >
                             Logg inn
                         </SubmitButton>
@@ -136,8 +143,9 @@ function Email() {
                     </div>
                 </ButtonGroup>
             </form>
-            <Paragraph className="mb-2 mt-6">Eller...</Paragraph>
+            <div className="border-2 rounded-sm w-full mb-8 mt-4"></div>
             <Google />
+
             <Paragraph className="text-center mt-10" margin="none">
                 Har du ikke en bruker?{' '}
                 <Link className="underline" href={getPathWithParams('create')}>

--- a/tavla/app/(admin)/components/Login/Google.tsx
+++ b/tavla/app/(admin)/components/Login/Google.tsx
@@ -1,3 +1,4 @@
+'use client'
 import {
     GoogleAuthProvider,
     getAuth,
@@ -8,9 +9,16 @@ import { getClientApp } from 'utils/firebase'
 import { create, login } from './actions'
 import GoogleButton from 'react-google-button'
 import * as Sentry from '@sentry/nextjs'
+import { usePostHog } from 'posthog-js/react'
+import { useState } from 'react'
+import { Paragraph } from '@entur/typography'
+import { FirebaseError } from 'firebase/app'
 
 export default function Google() {
+    const [isLoading, setIsLoading] = useState(false)
+    const posthog = usePostHog()
     const googleAction = async () => {
+        setIsLoading(true)
         const provider = new GoogleAuthProvider()
         const app = await getClientApp()
         const auth = getAuth(app)
@@ -21,24 +29,40 @@ export default function Google() {
                 await create(credential.user.uid)
             }
             await login(userIdToken)
+            setIsLoading(false)
         } catch (error) {
-            Sentry.captureException(error, {
-                extra: {
-                    message:
-                        'Error while creating new user with Google sign in',
-                },
-            })
-            return error
+            if (
+                error instanceof FirebaseError &&
+                (error.code == 'auth/popup-closed-by-user' ||
+                    error.code == 'auth/cancelled-popup-request')
+            ) {
+                setIsLoading(false)
+            } else {
+                Sentry.captureException(error, {
+                    extra: {
+                        message:
+                            'Error while creating new user with Google sign in',
+                    },
+                })
+                throw error
+            }
         }
     }
 
     return (
-        <GoogleButton
-            type="light"
-            label="Logg inn med Google"
-            onClick={() => {
-                googleAction()
-            }}
-        />
+        <div className="w-full [&>div]:!w-full">
+            {isLoading ? (
+                <Paragraph className="text-center">Vent litt....</Paragraph>
+            ) : (
+                <GoogleButton
+                    type="light"
+                    label="Logg inn med Google"
+                    onClick={() => {
+                        posthog.capture('LOG_IN_WITH_GOOGLE_BTN_CLICK')
+                        googleAction()
+                    }}
+                />
+            )}
+        </div>
     )
 }

--- a/tavla/app/(admin)/components/Login/Google.tsx
+++ b/tavla/app/(admin)/components/Login/Google.tsx
@@ -13,12 +13,15 @@ import { usePostHog } from 'posthog-js/react'
 import { useState } from 'react'
 import { Paragraph } from '@entur/typography'
 import { FirebaseError } from 'firebase/app'
+import { BannerAlertBox } from '@entur/alert'
 
 export default function Google() {
     const [isLoading, setIsLoading] = useState(false)
+    const [errorMessage, setErrorMessage] = useState(['', ''])
     const posthog = usePostHog()
     const googleAction = async () => {
         setIsLoading(true)
+        setErrorMessage(['', ''])
         const provider = new GoogleAuthProvider()
         const app = await getClientApp()
         const auth = getAuth(app)
@@ -37,6 +40,15 @@ export default function Google() {
                     error.code == 'auth/cancelled-popup-request')
             ) {
                 setIsLoading(false)
+            } else if (
+                error instanceof FirebaseError &&
+                error.code == 'auth/popup-blocked'
+            ) {
+                setIsLoading(false)
+                setErrorMessage([
+                    'Popup-vinduet ble blokkert.',
+                    'Endre denne innstillingen i nettleseren din for å logge på med Google.',
+                ])
             } else {
                 Sentry.captureException(error, {
                     extra: {
@@ -62,6 +74,16 @@ export default function Google() {
                         googleAction()
                     }}
                 />
+            )}
+
+            {errorMessage[0] && (
+                <BannerAlertBox
+                    className="mt-10"
+                    variant="information"
+                    title={errorMessage[0]}
+                >
+                    {errorMessage[1]}
+                </BannerAlertBox>
             )}
         </div>
     )

--- a/tavla/app/(admin)/components/Login/Google.tsx
+++ b/tavla/app/(admin)/components/Login/Google.tsx
@@ -1,0 +1,41 @@
+import {
+    GoogleAuthProvider,
+    getAdditionalUserInfo,
+    getAuth,
+    signInWithPopup,
+} from 'firebase/auth'
+import { create, login } from './actions'
+import GoogleButton from 'react-google-button'
+import * as Sentry from '@sentry/nextjs'
+
+export default function Google() {
+    const googleAction = async () => {
+        const provider = new GoogleAuthProvider()
+        const auth = getAuth()
+        try {
+            const credential = await signInWithPopup(auth, provider)
+            const userIdToken = await credential.user.getIdToken()
+            if (getAdditionalUserInfo(credential)?.isNewUser) {
+                await create(credential.user.uid)
+            }
+            await login(userIdToken)
+        } catch (error) {
+            Sentry.captureException(error, {
+                extra: {
+                    message:
+                        'Error while creating new user with Google sign in',
+                },
+            })
+        }
+    }
+
+    return (
+        <GoogleButton
+            type="light"
+            label="Logg inn med Google"
+            onClick={() => {
+                googleAction()
+            }}
+        />
+    )
+}

--- a/tavla/app/(admin)/components/Login/Google.tsx
+++ b/tavla/app/(admin)/components/Login/Google.tsx
@@ -1,9 +1,10 @@
 import {
     GoogleAuthProvider,
-    getAdditionalUserInfo,
     getAuth,
     signInWithPopup,
+    getAdditionalUserInfo,
 } from 'firebase/auth'
+import { getClientApp } from 'utils/firebase'
 import { create, login } from './actions'
 import GoogleButton from 'react-google-button'
 import * as Sentry from '@sentry/nextjs'
@@ -11,7 +12,8 @@ import * as Sentry from '@sentry/nextjs'
 export default function Google() {
     const googleAction = async () => {
         const provider = new GoogleAuthProvider()
-        const auth = getAuth()
+        const app = await getClientApp()
+        const auth = getAuth(app)
         try {
             const credential = await signInWithPopup(auth, provider)
             const userIdToken = await credential.user.getIdToken()
@@ -26,6 +28,7 @@ export default function Google() {
                         'Error while creating new user with Google sign in',
                 },
             })
+            return error
         }
     }
 

--- a/tavla/app/help/components/Questions.tsx
+++ b/tavla/app/help/components/Questions.tsx
@@ -19,20 +19,6 @@ function Questions() {
                 Ja, Tavla er helt gratis å bruke uavhengig av hvor mange tavler
                 man har.
             </AccordionItem>
-            <AccordionItem title="Jeg har ikke fått en e-post om verifisering, hva gjør jeg?">
-                Det kan hende det tar litt tid å få en e-post fra oss om
-                verifisering. Dette skal normalt ikke ta mer enn 10 minutter.
-                Hvis du ikke får den innen da, så prøv gjerne igjen. Hvis
-                problemet vedvarer, så send oss en e-post på{' '}
-                <a
-                    href="mailto:tavla@entur.org"
-                    target="_blank"
-                    className="underline"
-                >
-                    tavla@entur.org
-                </a>
-                .
-            </AccordionItem>
             <AccordionItem title="Tavlen min funker ikke på skjermen min eller er blank, hva gjør jeg?">
                 Det er ikke alle skjermer hvor Tavla er støttet. Er skjermen din
                 veldig gammel, så kan det hende at nettleseren ikke klarer å
@@ -65,6 +51,33 @@ function Questions() {
             <AccordionItem title="Lagres tavlene mine?">
                 Når du oppretter en tavle på brukere din, så vil de lagres slik
                 at du kan endre på de senere.
+            </AccordionItem>
+            <AccordionItem title="Jeg har ikke fått en e-post om verifisering, hva gjør jeg?">
+                Det kan hende det tar litt tid å få en e-post fra oss om
+                verifisering. Dette skal normalt ikke ta mer enn 10 minutter.
+                Hvis du ikke får den innen da, så prøv gjerne igjen. Hvis
+                problemet vedvarer, så send oss en e-post på{' '}
+                <a
+                    href="mailto:tavla@entur.org"
+                    target="_blank"
+                    className="underline"
+                >
+                    tavla@entur.org
+                </a>
+                .
+            </AccordionItem>
+            <AccordionItem title="Jeg har opprettet konto med e-post og passord. Kan jeg likevel logge meg inn med Google?">
+                Ja! Om du bruker samme e-post-adresse, vil du kunne logge på med
+                din Google-konto og finne alle tavler og mapper du tidligere har
+                opprettet.
+            </AccordionItem>
+            <AccordionItem title="Jeg har logget på med Google tidligere. Kan jeg likevel logge meg på med e-post og passord?">
+                Ja! Hvis du tidligere kun har logget på med Google, så har du
+                ikke enda satt et passord på din Tavla-konto. Bruk derfor lenken
+                for glemt passord, og du vil motta en lenke på e-post for å
+                sette passordet. Deretter kan du velge hvilken påloggingsmetode
+                du ønsker å bruke - du vil fortsatt ha tilgang til alle dine
+                tavler og mapper med begge metoder.
             </AccordionItem>
             <AccordionItem title="Hvordan setter jeg opp Tavla hos meg?">
                 Se guiden vår{' '}

--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV == 'development') {
 }
 
 const cspHeaderCommon = `
-    default-src 'self' apis.google.com http://127.0.0.1:9099;
+    default-src 'self' apis.google.com http://127.0.0.1:9099 https://ent-tavla-dev.firebaseapp.com/;
     style-src 'self' 'unsafe-inline';
     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com https://apis.google.com;
     object-src 'none';
@@ -88,6 +88,10 @@ const nextConfig = {
                     {
                         key: 'Referrer-Policy',
                         value: 'strict-origin-when-cross-origin',
+                    },
+                    {
+                        key: 'Cross-Origin-Opener-Policy',
+                        value: 'same-origin-allow-popups',
                     },
                 ],
             },

--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV == 'development') {
 }
 
 const cspHeaderCommon = `
-    default-src 'self' apis.google.com http://127.0.0.1:9099 https://ent-tavla-dev.firebaseapp.com/;
+    default-src 'self' apis.google.com http://127.0.0.1:9099 https://ent-tavla-dev.firebaseapp.com/ https://ent-tavla-prd.firebaseapp.com/;
     style-src 'self' 'unsafe-inline';
     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com https://apis.google.com;
     object-src 'none';

--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -15,9 +15,9 @@ if (process.env.NODE_ENV == 'development') {
 }
 
 const cspHeaderCommon = `
-    default-src 'self';
+    default-src 'self' apis.google.com http://127.0.0.1:9099;
     style-src 'self' 'unsafe-inline';
-    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com;
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com https://apis.google.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';

--- a/tavla/package.json
+++ b/tavla/package.json
@@ -55,6 +55,7 @@
         "posthog-js": "1.176.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-google-button": "0.8.0",
         "sharp": "0.33.5",
         "swr": "2.2.5"
     },

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -12626,6 +12626,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-google-button@npm:0.8.0":
+  version: 0.8.0
+  resolution: "react-google-button@npm:0.8.0"
+  dependencies:
+    prop-types: ^15.8.1
+  peerDependencies:
+    react: ">= 16.8.0"
+  checksum: a0a0585349c2ea3687e0d7baa16360c25ca5cc16c42c5ce72e4aceebd3b390eb7d691d03bc3b15a71ddaeb22d7480ba92b02696531c36ec47114b75c95554305
+  languageName: node
+  linkType: hard
+
 "react-is@npm:18.2.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
@@ -14283,6 +14294,7 @@ __metadata:
     prettier: 3.3.3
     react: 18.3.1
     react-dom: 18.3.1
+    react-google-button: 0.8.0
     sharp: 0.33.5
     swr: 2.2.5
     tailwindcss: 3.4.14


### PR DESCRIPTION
### Legg til innlogging via google
---
#### Motivasjon
Vi vil senke terskelen for å opprette bruker på tavla, og innlogging med google gjør at man bypasser problemet med verifiseringsmail som tar lang tid

#### Endringer
Lagt til "Logg inn med google"-knapp på modal for innlogging og ny bruker.
Trykk på knappen gir popup-vindu hvor bruker kan velge google-kontoen sin. De logges så inn, og redirectes til /boards som vanlig.
![Screenshot 2025-02-24 at 13 53 02](https://github.com/user-attachments/assets/80de2792-ebcd-4d92-8048-3ebb53c78a8c)

OBS: firebase tilbyr automatisk lenking mellom kontoer med samme e-post som er logget inn med to forskjellige metoder, så det trenger ikke vi å tenke på.

#### Sjekkliste for Review
- [ ] Sjekk at innlogging / oppretting med google funker, sjekk at brukerne dukker opp som de skal i firebase auth og firestore
- [ ] Sjekk at alle operasjoner rundt bruker fortsatt funker (resette passord, slette bruker, legge til medlemmer osv)
- [ ] Sjekk at lukking av popup eller timeout ikke kræsjer siden eller kaster feil.

Kjent feil:
- vi viser "Vent litt.." imens bruker har popup åpen, denne forsvinner ikke med en gang når bruker lukker popup. Dette er en kjent firebase auth feil.
