### PR TITLE
feat(board): remove heading on combined board

### DIFF
--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -299,6 +299,13 @@ function TileCard({
                                     Det originale navnet til stoppestedet:{' '}
                                     {tile.name.split(',')[0]}
                                 </SubParagraph>
+                                {isCombined && (
+                                    <SubParagraph className="!text-error">
+                                        Har du samlet stoppestedene i én liste
+                                        vil du ikke ha mulighet til å sette navn
+                                        på stoppested.
+                                    </SubParagraph>
+                                )}
                             </div>
                             <ClientOnlyTextField
                                 label="Navn på stoppested"

--- a/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/edit/[id]/components/TileCard/index.tsx
@@ -312,6 +312,7 @@ function TileCard({
                                 className="!w-full md:!w-1/2 lg:!w-1/4"
                                 name="displayName"
                                 defaultValue={tile.displayName}
+                                disabled={isCombined}
                                 maxLength={50}
                                 {...getFormFeedbackForField('name', state)}
                             />

--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { TTile } from 'types/tile'
 import { GetQuayQuery, StopPlaceQuery, TSituationFragment } from 'graphql/index'
 import { Tile } from 'components/Tile'
-import { TableHeader } from '../Table/components/TableHeader'
 import { TileLoader } from 'Board/components/TileLoader'
 import {
     DataFetchingFailed,
@@ -89,13 +88,8 @@ export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
         return isNaN(time) ? Infinity : time
     })
 
-    const heading = combinedTile
-        .map((tile) => tile.displayName || tile.name?.split(',')[0])
-        .join(', ')
-
     return (
         <Tile className="flex flex-col max-sm:min-h-[30vh]">
-            <TableHeader heading={heading} />
             <Table
                 departures={sortedEstimatedCalls}
                 situations={situations}


### PR DESCRIPTION
### Fjerne headingen på tavlen hvis det er kombinert visning
---
#### Motivasjon
Vi tror at siden stoppestedsnavnet ligger i selve tabellen, så trengs det ikke å vises på toppen heller.

#### Endringer
![image](https://github.com/user-attachments/assets/fb007053-c824-4a09-a7f0-f0e96c3d32f5)
![image](https://github.com/user-attachments/assets/f7d5bd12-2556-4b0a-86e2-d2a240162522)

#### Sjekkliste for Review
- [ ] Feltet blir disablet om man har kombinerte tiles
