### PR TITLE
feat(edit): submit empty platform select to show all platforms

### DIFF
--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -92,7 +92,6 @@ function TileSelector({
                 <Dropdown
                     items={quays}
                     label="Plattform/retning"
-                    clearable
                     prepend={<SearchIcon aria-hidden />}
                     selectedItem={
                         selectedQuay ??

--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -17,7 +17,6 @@ import {
     getFormFeedbackForField,
 } from 'app/(admin)/utils'
 import { useState } from 'react'
-import { Label } from '@entur/typography'
 import { SubmitButton } from 'components/Form/SubmitButton'
 import { usePostHog } from 'posthog-js/react'
 
@@ -63,7 +62,6 @@ function TileSelector({
             }}
         >
             <div className="w-full">
-                <Label>Velg fylke</Label>
                 <MultiSelect
                     label="Fylker (valgfritt)"
                     items={counties}
@@ -75,7 +73,6 @@ function TileSelector({
                 />
             </div>
             <div className="w-full">
-                <Label>Søk etter stoppested</Label>
                 <SearchableDropdown
                     items={stopPlaceItems}
                     label="Stoppested"
@@ -88,7 +85,6 @@ function TileSelector({
                 />
             </div>
             <div className="w-full">
-                <Label>Velg stoppestedets retning</Label>
                 <Dropdown
                     items={quays}
                     label="Plattform/retning"

--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -1,5 +1,10 @@
 'use client'
-import { Dropdown, MultiSelect, SearchableDropdown } from '@entur/dropdown'
+import {
+    Dropdown,
+    MultiSelect,
+    NormalizedDropdownItemType,
+    SearchableDropdown,
+} from '@entur/dropdown'
 import { SearchIcon } from '@entur/icons'
 import { useCountiesSearch } from 'app/(admin)/hooks/useCountiesSearch'
 import { useStopPlaceSearch } from 'app/(admin)/hooks/useStopPlaceSearch'
@@ -19,13 +24,9 @@ import { usePostHog } from 'posthog-js/react'
 function TileSelector({
     action,
     oid,
-    showLabel,
-    col = true,
 }: {
     action: (data: FormData) => void
     oid?: TOrganizationID
-    showLabel?: boolean
-    col?: boolean
 }) {
     const { counties, selectedCounties, setSelectedCounties } =
         useCountiesSearch(oid)
@@ -39,12 +40,10 @@ function TileSelector({
 
     const posthog = usePostHog()
 
-    const classname = col ? '' : 'lg:flex-row'
-
     const [state, setFormError] = useState<TFormFeedback | undefined>()
     return (
         <form
-            className={`flex flex-col ${classname} gap-4 mr-6 w-full`}
+            className="flex flex-col lg:flex-row gap-4 mr-6 w-full"
             action={action}
             onSubmit={(event) => {
                 if (!selectedStopPlace) {
@@ -64,7 +63,7 @@ function TileSelector({
             }}
         >
             <div className="w-full">
-                {showLabel && <Label>Velg fylke</Label>}
+                <Label>Velg fylke</Label>
                 <MultiSelect
                     label="Fylker (valgfritt)"
                     items={counties}
@@ -76,7 +75,7 @@ function TileSelector({
                 />
             </div>
             <div className="w-full">
-                {showLabel && <Label>Søk etter stoppested</Label>}
+                <Label>Søk etter stoppested</Label>
                 <SearchableDropdown
                     items={stopPlaceItems}
                     label="Stoppested"
@@ -89,13 +88,19 @@ function TileSelector({
                 />
             </div>
             <div className="w-full">
-                {showLabel && <Label>Velg stoppestedets retning</Label>}
+                <Label>Velg stoppestedets retning</Label>
                 <Dropdown
                     items={quays}
                     label="Plattform/retning"
                     clearable
                     prepend={<SearchIcon aria-hidden />}
-                    selectedItem={selectedQuay}
+                    selectedItem={
+                        selectedQuay ??
+                        ({
+                            value: selectedStopPlace?.value,
+                            label: 'Vis alle',
+                        } as NormalizedDropdownItemType)
+                    }
                     onChange={setSelectedQuay}
                     disabled={!selectedStopPlace}
                     {...getFormFeedbackForField('quay', state)}

--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -47,7 +47,7 @@ function TileSelector({
             className={`flex flex-col ${classname} gap-4 mr-6 w-full`}
             action={action}
             onSubmit={(event) => {
-                if (!selectedStopPlace || !selectedQuay) {
+                if (!selectedStopPlace) {
                     event.preventDefault()
                     return setFormError(
                         getFormFeedbackForError(

--- a/tavla/app/(admin)/components/TileSelector/utils.ts
+++ b/tavla/app/(admin)/components/TileSelector/utils.ts
@@ -21,7 +21,9 @@ export function formDataToTile(data: FormData, organization?: TOrganization) {
     return {
         type: placeId !== stopPlaceId ? 'quay' : 'stop_place',
         name: `${stopPlaceName[0]}${
-            quayName === 'Vis alle' ? '' : ' ' + quayName.trim()
+            quayName === 'Vis alle' || quayName === ''
+                ? ''
+                : ' ' + quayName.trim()
         }, ${stopPlaceName[1]}`,
         uuid: nanoid(),
         placeId,

--- a/tavla/app/(admin)/edit/[id]/page.tsx
+++ b/tavla/app/(admin)/edit/[id]/page.tsx
@@ -79,7 +79,6 @@ export default async function EditPage(props: TProps) {
                 <div className="bg-background rounded-md py-8 px-6 flex flex-col gap-4">
                     <Heading2>Stoppesteder</Heading2>
                     <TileSelector
-                        col={false}
                         oid={organization?.id}
                         action={async (data: FormData) => {
                             'use server'

--- a/tavla/app/demo/components/DemoBoard.tsx
+++ b/tavla/app/demo/components/DemoBoard.tsx
@@ -31,7 +31,6 @@ function DemoBoard() {
                         setBoard({ ...board, tiles: [...board.tiles, tile] })
                         posthog.capture('ADD_STOP_PLACE_DEMO_PAGE')
                     }}
-                    col={false}
                 />
                 <TileList board={board} setDemoBoard={setBoard} bid="demo" />
             </div>


### PR DESCRIPTION
### Tom plattform-select tilsvarer "vis alle"
---
#### Motivasjon
Redusere antall klikk med 2 for folk som skal lage tavle for et stoppested.

#### Endringer
- når platform-select er tom tilsvarer dette "vis alle"

#### Sjekkliste for Review
- [ ] Sjekk at det fortsatt går an å legge til, endre og slette både stop-places og quays som vanlig

obs: annen mulig løsning er å sette dropdownen til "vis alle"-verdien med en gang, men det viste seg å være vanskelig (kan ikke sette default-valg enkelt i dropdown-komponenten)

obsobs: hele tileselector-komponenten er jo HELT krise, alt av form handling skjer på en annen måte enn det vi gjør ellers
