### PR TITLE
fix(time): show adjusted time to avoid optimistic times

### DIFF
--- a/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
@@ -6,6 +6,8 @@ import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
 import { nanoid } from 'nanoid'
 
+const TWO_MINUTES = 120
+
 function ExpectedTime() {
     const departures = useNonNullContext(DeparturesContext)
 
@@ -52,12 +54,12 @@ function Time({
             </>
         )
 
-    const timeDeviation = Math.abs(
+    const timeDeviationInSeconds = Math.abs(
         (Date.parse(aimedDepartureTime) - Date.parse(expectedDepartureTime)) /
             1000,
     )
 
-    if (timeDeviation > 120) {
+    if (timeDeviationInSeconds > TWO_MINUTES) {
         return (
             <>
                 <div className="text-right font-semibold text-estimated-time">

--- a/tavla/src/Shared/utils/time.ts
+++ b/tavla/src/Shared/utils/time.ts
@@ -1,8 +1,15 @@
-export function getRelativeTimeString(dateString: string) {
-    const timeDiff = Date.parse(dateString) - Date.now()
+const ONE_MINUTE = 60
+const TEN_MINUTES = 600
 
-    if (timeDiff < 60_000) return 'Nå'
-    else if (timeDiff < 600_000) return Math.floor(timeDiff / 60_000) + ' min'
+export function getRelativeTimeString(dateString: string) {
+    const timeDiffInSeconds = (Date.parse(dateString) - Date.now()) / 1000
+
+    // Compensate to avoid optimistic time since fetch of departures happens every 30 seconds
+    const adjustedTimeDiffInSeconds = timeDiffInSeconds - 30
+
+    if (adjustedTimeDiffInSeconds < ONE_MINUTE) return 'Nå'
+    else if (adjustedTimeDiffInSeconds < TEN_MINUTES)
+        return Math.floor(adjustedTimeDiffInSeconds / ONE_MINUTE) + ' min'
     return formatDateString(dateString)
 }
 
@@ -17,19 +24,6 @@ export function formatTimeStamp(timestamp: number) {
         minute: '2-digit',
         timeZone: 'Europe/Oslo',
     }).format(timestamp)
-}
-
-export function formatDate(date: Date) {
-    return date
-        .toLocaleDateString('no-NB', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-            timeZone: 'Europe/Oslo',
-        })
-        .replace(',', '')
 }
 
 export function formatDateToISO(date: Date) {
@@ -48,12 +42,6 @@ export function getDate(dateString: string) {
         day: '2-digit',
         timeZone: 'Europe/Oslo',
     }).format(Date.parse(dateString))
-}
-
-export function isTimestampToday(timestamp: number) {
-    const today = new Date().setHours(0, 0, 0, 0)
-    const timestampDay = new Date(timestamp).setHours(0, 0, 0, 0)
-    return today === timestampDay
 }
 
 export function isDateStringToday(dateString: string) {

--- a/tavla/src/Shared/utils/time.ts
+++ b/tavla/src/Shared/utils/time.ts
@@ -5,7 +5,7 @@ export function getRelativeTimeString(dateString: string) {
     const timeDiffInSeconds = (Date.parse(dateString) - Date.now()) / 1000
 
     // Compensate to avoid optimistic time since fetch of departures happens every 30 seconds
-    const adjustedTimeDiffInSeconds = timeDiffInSeconds - 30
+    const adjustedTimeDiffInSeconds = timeDiffInSeconds - 15
 
     if (adjustedTimeDiffInSeconds < ONE_MINUTE) return 'Nå'
     else if (adjustedTimeDiffInSeconds < TEN_MINUTES)


### PR DESCRIPTION
### Justere tiden for når avgangene kommer
---
#### Motivasjon
På møtet med Fram i sted fikk vi innspill på at tidene noen ganger er litt "optimistiske" (som de hadde fått fra sine brukere). F. eks at når det sto at det var 3 minutter til den gikk, så var det faktisk 2 minutter og noen sekunder. 

Dette er forståelig at skjer siden vi kun henter avganger hvert 30 sekund - dette er ikke noe vi tar høyde for i koden i dag. 
F. eks la oss si at det er 2 minutter og 1 sekund (02:01) til avgangen går. Som koden er i dag, så vil man da runde nedover til 2 minutter. Men dette vil være misvisende om man ser på skjermen rett før det er en ny fetch av avganger, da vil pr def være 01:31 minutter til avgangen går, og ikke 2 minutter - dermed vil man ikke rekke avgangen om man tenker man har 2 minutter på seg, men egentlig så er den 30 sekunder mindre. Det er bedre at vi er på den sikre siden da, og heller viser 1 minutt, og ikke 2 minutter.

#### Endringer
Nå har jeg bare fjernet 30 sekunder direkte fra differansen, slik at tiden alltid vil være 30 sek mindre enn det den _egentlig_ er. Dette kan diskuteres! Her er hvordan forskjellen vil bli (venstre er som det blir, høyre er som det er nå):

![image](https://github.com/user-attachments/assets/669676c4-eb4e-4199-8470-f2764d614ab4)

Her ble alle avgangene forskjøvet med 1 minutt, men det er ikke alltid casen. Om det er mindre enn 30 sek til neste "hele" minutt, så vises det neste hele minuttet. Altså: 02.29 og 02:01 -> viser 1 minutt. 02:31 og 02:59-> viser 2 minutter.

#### Sjekkliste for Review
- [ ] (Hva skal reviewers sjekke før denne PR-en godkjennes?)
