### PR TITLE
fix(delete): delete board removes board from org

### DIFF
--- a/tavla/src/Board/scenarios/Board/firebase.ts
+++ b/tavla/src/Board/scenarios/Board/firebase.ts
@@ -54,53 +54,13 @@ export async function getOrganizationWithBoard(bid: TBoardID) {
             .collection('organizations')
             .where('boards', 'array-contains', bid)
             .get()
-        return ref.docs.map((doc) => doc.data() as TOrganization)[0] ?? null
+        const org = ref.docs.map(
+            (doc) => ({ id: doc.id, ...doc.data() }) as TOrganization,
+        )
+        return org[0]
     } catch (error) {
         Sentry.captureMessage('Failed to fetch organization with board ' + bid)
         throw error
-    }
-}
-
-export async function getOrganizationLogoWithBoard(bid: TBoardID) {
-    try {
-        const ref = await firestore()
-            .collection('organizations')
-            .where('boards', 'array-contains', bid)
-            .get()
-        const organization = ref.docs.map(
-            (doc) => doc.data() as TOrganization,
-        )[0]
-        return organization?.logo ?? null
-    } catch (error) {
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while fetching logo of organization of board',
-                boardID: bid,
-            },
-        })
-        return null
-    }
-}
-
-export async function getOrganizationFooterWithBoard(bid: TBoardID) {
-    try {
-        const ref = await firestore()
-            .collection('organizations')
-            .where('boards', 'array-contains', bid)
-            .get()
-        const organization = ref.docs.map(
-            (doc) => doc.data() as TOrganization,
-        )[0]
-        return organization?.footer ?? null
-    } catch (error) {
-        Sentry.captureException(error, {
-            extra: {
-                message:
-                    'Error while fetching organization footer for board from firestore',
-                boardID: bid,
-            },
-        })
-        return null
     }
 }
 


### PR DESCRIPTION
### Fiks feil som gjorde at sletting av tavle ikke sletta id fra org-board-list
---
#### Motivasjon
For orgs laget etter at denne endringen går inn vil aktive tavler telles riktig.

#### Endringer
- Når vi henter organization for et gitt board må id-en manuelt legges på objektet, det holder ikke å bare returnere doc.data() as TOrganization

#### Sjekkliste for Review
- [ ] Sjekk at sletting av board også medfører sletting av board id i org
