### PR TITLE
chore(tags): add tags to board table

### DIFF
--- a/tavla/app/(admin)/boards/components/Column/Tags.tsx
+++ b/tavla/app/(admin)/boards/components/Column/Tags.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { Badge } from '@entur/layout'
+import { TTag } from 'types/meta'
+import { colorsFromHash } from '../../utils'
+import { ColumnWrapper } from './ColumnWrapper'
+
+function Tags({ tags }: { tags: TTag[] }) {
+    return (
+        <ColumnWrapper column="tags">
+            <ul className="flex flex-row flex-wrap gap-1 items-center">
+                {tags.map((tag) => {
+                    const color = colorsFromHash(tag)
+                    return (
+                        <li key={tag}>
+                            <Badge
+                                variant="primary"
+                                type="status"
+                                style={{
+                                    backgroundColor: color,
+                                    borderColor: color,
+                                }}
+                            >
+                                <span className="visuallyHidden">
+                                    Merkelapp:
+                                </span>
+                                {tag}
+                            </Badge>
+                        </li>
+                    )
+                })}
+            </ul>
+        </ColumnWrapper>
+    )
+}
+
+export { Tags }

--- a/tavla/app/(admin)/boards/components/Column/index.tsx
+++ b/tavla/app/(admin)/boards/components/Column/index.tsx
@@ -3,6 +3,7 @@ import { LastModified } from './LastModified'
 import { TTableColumn } from 'app/(admin)/utils/types'
 import { BoardName, FolderName } from './Name'
 import { BoardActions, FolderActions } from './Actions'
+import { Tags } from './Tags'
 
 function Column({
     board,
@@ -17,6 +18,8 @@ function Column({
         switch (column) {
             case 'name':
                 return <BoardName board={board} />
+            case 'tags':
+                return <Tags tags={board.meta.tags ?? []} />
             case 'actions':
                 return <BoardActions board={board} />
             case 'lastModified':
@@ -26,6 +29,8 @@ function Column({
         switch (column) {
             case 'name':
                 return <FolderName folder={folder} />
+            case 'tags':
+                return <Tags tags={[]} />
             case 'actions':
                 return <FolderActions folder={folder} />
             case 'lastModified':

--- a/tavla/app/(admin)/boards/utils/index.ts
+++ b/tavla/app/(admin)/boards/utils/index.ts
@@ -1,3 +1,12 @@
+function hash(seq: string) {
+    let hash = 0
+    for (let i = 0; i < seq.length; i++) {
+        const char = seq.charCodeAt(i)
+        hash = (hash << 5) - hash + char
+    }
+    return hash
+}
+
 export const dataColors = {
     azure: 'var(--data-visualization-azure)',
     blue: 'var(--data-visualization-blue)',
@@ -6,4 +15,11 @@ export const dataColors = {
     lavender: 'var(--data-visualization-lavender)',
     lilac: 'var(--data-visualization-lilac)',
     spring: 'var(--data-visualization-spring)',
+}
+
+const colorValues = Object.values(dataColors)
+
+export function colorsFromHash(name: string) {
+    const index = Math.abs(hash(name)) % colorValues.length
+    return colorValues[index]
 }

--- a/tavla/app/(admin)/utils/types.ts
+++ b/tavla/app/(admin)/utils/types.ts
@@ -2,6 +2,7 @@ export type TSort = 'none' | 'ascending' | 'descending'
 
 export const TableColumns = {
     name: 'Navn',
+    tags: 'Merkelapper',
     lastModified: 'Sist oppdatert',
     actions: 'Handlinger',
 } as const

--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -265,9 +265,10 @@
     }
 
     .table-custom-nth-child {
-        &:nth-child(6n + 1),
-        &:nth-child(6n + 2),
-        &:nth-child(6n + 3) {
+        &:nth-child(8n + 1),
+        &:nth-child(8n + 2),
+        &:nth-child(8n + 3),
+        &:nth-child(8n + 4) {
             @apply bg-grey80;
         }
     }

--- a/tavla/src/Shared/types/meta.ts
+++ b/tavla/src/Shared/types/meta.ts
@@ -5,9 +5,11 @@ export type TMeta = {
     dateModified?: number
     version?: number
     fontSize?: TFontSize
+    tags?: TTag[]
     location?: TLocation
 }
 
+export type TTag = string
 export type TFontSize = 'small' | 'medium' | 'large'
 export type TCoordinate = { lat: number; lng: number }
 export type TLocation = {


### PR DESCRIPTION
### Legge til merkelapper (igjen)
---
#### Motivasjon
Grunnen til at vi gjør det er at vi ønsker å prodsette, men AtB vil gjerne ha tid til å omorganisere tavlene sine i mapper basert på de tagsa de har. Derfor gjeninnfører vi tags, men det er ikke mulig å fjerne eller legge til noen tags. Denne PRen skal bli revertet på mandag igjen når de har fått plasser tavlene sine i riktige mapper, og vi ikke lengre trenger denne funksjonaliteten. 

#### Endringer
Lagt ved merkelapper som en kolonne i tabellen.

#### Sjekkliste for Review
- [ ] (Hva skal reviewers sjekke før denne PR-en godkjennes?)
