### PR TITLE
fix(boards): redirect to specific folder on create or delete

### DIFF
--- a/tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -2,7 +2,7 @@
 import { useActionState } from 'react'
 import { Button, ButtonGroup, IconButton } from '@entur/button'
 import { DeleteIcon } from '@entur/icons'
-import { TBoard } from 'types/settings'
+import { TBoard, TOrganizationID } from 'types/settings'
 import { Tooltip } from '@entur/tooltip'
 import { useModalWithValue } from '../../hooks/useModalWithValue'
 import { Modal } from '@entur/modal'
@@ -16,6 +16,7 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { OverflowMenuItem } from '@entur/menu'
 import { useToast } from '@entur/alert'
 import { deleteBoardAction } from '../../utils/actions'
+import { useParams } from 'next/navigation'
 
 function Delete({
     board,
@@ -28,6 +29,9 @@ function Delete({
 
     const [state, deleteBoard] = useActionState(deleteBoardAction, undefined)
     const { isOpen, open, close } = useModalWithValue('delete', board.id ?? '')
+
+    const params = useParams()
+    const oid = params?.id as TOrganizationID
 
     const submit = async (data: FormData) => {
         deleteBoard(data)
@@ -65,6 +69,7 @@ function Delete({
 
                 <form action={submit} onSubmit={close} className="w-full">
                     <HiddenInput id="bid" value={board.id} />
+                    <HiddenInput id="oid" value={oid ?? undefined} />
                     <FormError {...getFormFeedbackForField('general', state)} />
                     <ButtonGroup className="flex flex-row">
                         <SubmitButton

--- a/tavla/app/(admin)/boards/utils/actions.ts
+++ b/tavla/app/(admin)/boards/utils/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { deleteBoard, initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
 import { handleError } from 'app/(admin)/utils/handleError'
+import { TBoardID, TOrganizationID } from 'types/settings'
 
 initializeAdminApp()
 
@@ -11,13 +12,14 @@ export async function deleteBoardAction(
     prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    const bid = data.get('bid') as TBoardID
+    const oid = data.get('oid') as TOrganizationID
     try {
-        const bid = data.get('bid') as string
-
         await deleteBoard(bid)
         revalidatePath('/')
     } catch (e) {
         return handleError(e)
     }
+    if (oid) redirect(`/boards/${oid}`)
     redirect('/boards')
 }

--- a/tavla/app/(admin)/components/CreateOrganization/actions.ts
+++ b/tavla/app/(admin)/components/CreateOrganization/actions.ts
@@ -46,5 +46,5 @@ export async function createOrganization(
         })
         return handleError(error)
     }
-    redirect(`/folders/${organization.id}`)
+    redirect(`/boards/${organization.id}`)
 }


### PR DESCRIPTION
### Redirect riktig etter man har slettet en tavle
---
#### Motivasjon
Det er ikke intuitivt at man redirectes til /boards om man står i en spesifikk mappe og sletter en tavle.

#### Endringer
Når man nå sletter en tavle i en mappe, så redirectes man til denne mappen, og ikke til oversikten over alle tavler og mapper.
