### PR TITLE
fix(login): fix login buttons overflowing on mobile

### DIFF
--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -113,8 +113,8 @@ function Email() {
                         Glemt passord?
                     </Link>
                 </p>
-                <ButtonGroup className="flex flex-row gap-4 pb-4">
-                    <div className="w-1/2">
+                <ButtonGroup className="flex sm:flex-row flex-col gap-4 pb-4">
+                    <div className="sm:w-1/2 w-full order-1">
                         <SubmitButton
                             variant="primary"
                             width="fluid"
@@ -129,7 +129,7 @@ function Email() {
                         </SubmitButton>
                     </div>
 
-                    <div className="w-1/2">
+                    <div className="sm:w-1/2 w-full order-2">
                         <Button
                             type="button"
                             as={Link}

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -145,7 +145,6 @@ function Email() {
             </form>
             <div className="border-2 rounded-sm w-full mb-8 mt-4"></div>
             <Google />
-
             <Paragraph className="text-center mt-10" margin="none">
                 Har du ikke en bruker?{' '}
                 <Link className="underline" href={getPathWithParams('create')}>

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -114,7 +114,7 @@ function Email() {
                     </Link>
                 </p>
                 <ButtonGroup className="flex sm:flex-row flex-col gap-4 pb-4">
-                    <div className="sm:w-1/2 w-full order-1">
+                    <div className="sm:w-1/2 w-full">
                         <SubmitButton
                             variant="primary"
                             width="fluid"
@@ -129,7 +129,7 @@ function Email() {
                         </SubmitButton>
                     </div>
 
-                    <div className="sm:w-1/2 w-full order-2">
+                    <div className="sm:w-1/2 w-full">
                         <Button
                             type="button"
                             as={Link}


### PR DESCRIPTION
### Fikse at innloggingsknappene overflower på mobil
---
#### Motivasjon
Vi ønsker at nettsiden skal se fin og funksjonell ut, også på mobil. Ved å fikse at knappene ikke overflower og overlapper bidrar vi til det.

#### Endringer
- La til kolonne-sortering på knappene på små skjermer

##### Bilder
|Før|Etter|
|-----|-----|
|![image](https://github.com/user-attachments/assets/9c941ec5-5b64-4640-aa1d-0bb8eed7ede8)|![image](https://github.com/user-attachments/assets/e62efdac-e98b-46b1-890f-3ec5b5bf9460)|

#### Sjekkliste for Review
- [x] Annika sjekker med Hannah at det ser greit ut
- [ ] Sjekk at det ser greit ut på mobil
