### PR TITLE
fix(landing): input email stays in case of error

### DIFF
--- a/tavla/app/(admin)/components/Login/Create.tsx
+++ b/tavla/app/(admin)/components/Login/Create.tsx
@@ -7,7 +7,7 @@ import {
     sendEmailVerification,
 } from 'firebase/auth'
 import Image from 'next/image'
-import { useActionState } from 'react'
+import { useActionState, useState } from 'react'
 import { create } from './actions'
 
 import { Button, ButtonGroup } from '@entur/button'
@@ -26,7 +26,11 @@ import { FormError } from '../FormError'
 import Google from './Google'
 
 function Create() {
-    const submit = async (p: TFormFeedback | undefined, data: FormData) => {
+    const [email, setEmail] = useState('')
+    const submit = async (
+        previousState: TFormFeedback | undefined,
+        data: FormData,
+    ) => {
         const email = data.get('email') as string
         const password = data.get('password') as string
         const repeat = data.get('repeat_password') as string
@@ -69,6 +73,8 @@ function Create() {
                         name="email"
                         label="E-post"
                         type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
                         {...getFormFeedbackForField('email', state)}
                     />
                 </div>

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -6,7 +6,7 @@ import {
     sendEmailVerification,
     signInWithEmailAndPassword,
 } from 'firebase/auth'
-import { useActionState } from 'react'
+import { useActionState, useState } from 'react'
 import { getClientApp } from 'utils/firebase'
 import { login } from './actions'
 
@@ -30,6 +30,7 @@ import { TLoginPage } from './types'
 
 function Email() {
     const posthog = usePostHog()
+    const [email, setEmail] = useState('')
     const submit = async (
         previousState: TFormFeedback | undefined,
         data: FormData,
@@ -91,6 +92,8 @@ function Email() {
                         name="email"
                         label="E-post"
                         type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
                         {...getFormFeedbackForField('email', state)}
                     />
                 </div>

--- a/tavla/app/(admin)/utils/index.ts
+++ b/tavla/app/(admin)/utils/index.ts
@@ -72,8 +72,14 @@ export function getFormFeedbackForError(
         case 'auth/weak-password':
             return {
                 form_type: 'password',
-                feedback: 'Passordet er for svakt.',
+                feedback: 'Passordet er for kort – det må være minst 6 tegn.',
                 variant: 'warning',
+            }
+        case 'auth/missing-password':
+            return {
+                form_type: 'password',
+                feedback: 'Du må skrive inn et passord.',
+                variant: 'negative',
             }
         case 'auth/unverified':
             return {


### PR DESCRIPTION
### Legger til at epost er i en useState dersom det feiler slik at verdien beholdes
---
#### Motivasjon
Det er irriterende for brukeren å fylle inn alt på nytt dersom de skriver inn en liten ting feil, dette skal hjelpe. 

#### Endringer
Lagt inn state som passer på epost dersom aktiviteten (innlogging eller opprettelse av ny konto) feiler.

|Før|Etter|
|-----|------|
|<img width="460" height="763" alt="image" src="https://github.com/user-attachments/assets/d68775ce-9584-4006-9531-4ec190d54721" />|<img width="460" height="763" alt="image" src="https://github.com/user-attachments/assets/9c1ebfb4-3690-480e-93f7-f36cefdde07a" />|
|<img width="460" height="763" alt="image" src="https://github.com/user-attachments/assets/c7128155-f0c2-467d-99b1-aa6b8bf1348b" />|<img width="460" height="763" alt="image" src="https://github.com/user-attachments/assets/b2975eb9-2c13-4ada-ba40-0e2cd8653dbb" />|
|<img width="460" height="833" alt="image" src="https://github.com/user-attachments/assets/929c192e-2a7b-4464-9e9f-fca1ccf7c6dd" />|<img width="460" height="833" alt="image" src="https://github.com/user-attachments/assets/666ddedd-c992-4f36-ac48-58d9bf7744d9" />|

#### Sjekkliste for Review
- [ ] Sjekk at dersom du skriver inn feil passord så beholdes eposten ved innlogging
- [ ] Sjekk at dersom du skriver inn to ulike passord så beholdes eposten ved opprettelse av ny konto
