### PR TITLE
feat(oversikt): add a count of all boards belonging to user

### DIFF
--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -12,6 +12,7 @@ import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 import { Heading1 } from '@entur/typography'
 import { CreateOrganization } from '../components/CreateOrganization'
 import { CreateBoard } from '../components/CreateBoard'
+import { getNumberOfBoards } from './utils'
 
 initializeAdminApp()
 
@@ -35,10 +36,14 @@ async function FoldersAndBoardsPage() {
                     <CreateOrganization />
                 </div>
             </div>
-            <div className="flex flex-col sm:flex-row md:items-center gap-3">
-                <Search />
+            <Search />
+            <div>
+                <p className="pb-[16px] text-[0.9rem] text-gray-500">
+                    Totalt antall tavler:{' '}
+                    {getNumberOfBoards(folders, privateBoards)}
+                </p>
+                <BoardTable folders={folders} boards={privateBoards} />
             </div>
-            <BoardTable folders={folders} boards={privateBoards} />
         </div>
     )
 }

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -9,10 +9,10 @@ import {
 } from 'app/(admin)/actions'
 import { initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
-import { Heading1 } from '@entur/typography'
+import { Heading1, Label } from '@entur/typography'
 import { CreateOrganization } from '../components/CreateOrganization'
 import { CreateBoard } from '../components/CreateBoard'
-import { getNumberOfBoards } from './utils'
+import { countAllBoards } from './utils/actions'
 
 initializeAdminApp()
 
@@ -26,6 +26,7 @@ async function FoldersAndBoardsPage() {
 
     const folders = await getOrganizationsForUser()
     const privateBoards = await getPrivateBoardsForUser()
+    const count = await countAllBoards(folders, privateBoards)
 
     return (
         <div className="flex flex-col gap-8 container pb-20">
@@ -37,11 +38,8 @@ async function FoldersAndBoardsPage() {
                 </div>
             </div>
             <Search />
-            <div>
-                <p className="pb-[16px] text-[0.9rem] text-gray-500">
-                    Totalt antall tavler:{' '}
-                    {getNumberOfBoards(folders, privateBoards)}
-                </p>
+            <div className="gap-4">
+                <Label>Totalt antall tavler: {count}</Label>
                 <BoardTable folders={folders} boards={privateBoards} />
             </div>
         </div>

--- a/tavla/app/(admin)/oversikt/utils/actions.ts
+++ b/tavla/app/(admin)/oversikt/utils/actions.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from 'next/cache'
 import { deleteBoard, initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
 import { handleError } from 'app/(admin)/utils/handleError'
-import { TBoardID } from 'types/settings'
+import { TBoard, TBoardID, TOrganization } from 'types/settings'
+import { getBoardsForOrganization } from 'app/(admin)/actions'
 import { getOrganizationForBoard } from 'Board/scenarios/Board/firebase'
 
 initializeAdminApp()
@@ -24,4 +25,26 @@ export async function deleteBoardAction(
     }
     if (organization) redirect(`/mapper/${organization?.id}`)
     redirect('/oversikt')
+}
+
+export async function getNumberOfBoardsInFolder(folderId?: string) {
+    if (!folderId) return 0
+
+    const boardsInFolder = await getBoardsForOrganization(folderId)
+    return boardsInFolder.length
+}
+
+export async function countAllBoards(
+    folders: TOrganization[],
+    boards: TBoard[],
+) {
+    const folderCounts = await Promise.all(
+        folders.map(
+            async (folder) => await getNumberOfBoardsInFolder(folder.id),
+        ),
+    )
+
+    let count = boards.length
+    folderCounts.map((folderCount) => (count += folderCount))
+    return count
 }

--- a/tavla/app/(admin)/oversikt/utils/index.ts
+++ b/tavla/app/(admin)/oversikt/utils/index.ts
@@ -1,3 +1,5 @@
+import { TBoard, TOrganization } from 'types/settings'
+
 function hash(seq: string) {
     let hash = 0
     for (let i = 0; i < seq.length; i++) {
@@ -22,4 +24,12 @@ const colorValues = Object.values(dataColors)
 export function colorsFromHash(name: string) {
     const index = Math.abs(hash(name)) % colorValues.length
     return colorValues[index]
+}
+
+export function getNumberOfBoards(folders: TOrganization[], boards: TBoard[]) {
+    let number = 0
+    folders.map(
+        (folder) => folder.boards?.length && (number += folder.boards.length),
+    )
+    return number + boards.length
 }

--- a/tavla/app/(admin)/oversikt/utils/index.ts
+++ b/tavla/app/(admin)/oversikt/utils/index.ts
@@ -1,5 +1,3 @@
-import { TBoard, TOrganization } from 'types/settings'
-
 function hash(seq: string) {
     let hash = 0
     for (let i = 0; i < seq.length; i++) {
@@ -24,12 +22,4 @@ const colorValues = Object.values(dataColors)
 export function colorsFromHash(name: string) {
     const index = Math.abs(hash(name)) % colorValues.length
     return colorValues[index]
-}
-
-export function getNumberOfBoards(folders: TOrganization[], boards: TBoard[]) {
-    let number = 0
-    folders.map(
-        (folder) => folder.boards?.length && (number += folder.boards.length),
-    )
-    return number + boards.length
 }


### PR DESCRIPTION
### La til antall tavler en bruker har på oversiktssiden
---
#### Motivasjon
Fint å se hvor mange tavler man har

#### Endringer
Lagde en funksjon som teller antall tavler i mapper og legger det sammen med private tavler.
|Før|Etter|
|---|-----|
|![image](https://github.com/user-attachments/assets/236fc28a-186e-4c5f-b253-b56d9346daca)|![image](https://github.com/user-attachments/assets/4f58b8db-3242-48e6-9278-04eebd2ebde2)|

#### Sjekkliste for Review
- [ ] Sjekk at det ved opprettelse av ny privat tavle og tavle i mappe at antallet oppdaterer seg riktig