### PR TITLE
fix(alphabetic-sort): changed the sort of boards from update to alphabetic

### DIFF
--- a/tavla/app/(admin)/utils/constants.ts
+++ b/tavla/app/(admin)/utils/constants.ts
@@ -3,8 +3,8 @@ import { TTableColumn, TSort } from './types'
 export const DEFAULT_BOARD_NAME = 'Tavle uten navn'
 export const DEFAULT_FOLDER_NAME = 'Mappe uten navn'
 
-export const DEFAULT_SORT_COLUMN: TTableColumn = 'lastModified'
-export const DEFAULT_SORT_TYPE: TSort = 'descending'
+export const DEFAULT_SORT_COLUMN: TTableColumn = 'name'
+export const DEFAULT_SORT_TYPE: TSort = 'ascending'
 
 export const FIREBASE_DEV_CONFIG = {
     apiKey: 'AIzaSyCjyL7k4AehY4M95cxBVaW4LJTy6JNdTjo',


### PR DESCRIPTION
### Byttet til alfabetisk sortering på tavler og mapper
---
#### Motivasjon
Gir mer mening å ha alfabetisk sortering

#### Endringer
Endret DEFAULT_SORT_COLUMN og DEFAULT_SORT_TYPE til å være "name" og "ascending" fra "lastModified" og "descending", respektivt. 

Det ble også endret for mapper på oversiktssiden i tillegg til kun i mapper, men tenker det er greit? 

|Før|Etter|
|---|-----|
|![image](https://github.com/user-attachments/assets/bf3dfc12-1293-4eaa-8be3-878dbe254e99)|![image](https://github.com/user-attachments/assets/87b1fdb5-dee7-476b-b2a4-2642d7291e60)|
|![image](https://github.com/user-attachments/assets/cfb80376-2596-4650-b0cf-6b5c1ca2778b)|![image](https://github.com/user-attachments/assets/90f8f129-8044-407e-af56-0fc08ca81abf)|

#### Sjekkliste for Review
- [ ] Sjekk at det ser greit ut ved opprettelse av nye tavler
