### PR TITLE
fix(oversikt): add space between icon and name

### DIFF
--- a/tavla/app/(admin)/boards/components/Column/Name.tsx
+++ b/tavla/app/(admin)/boards/components/Column/Name.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link'
 function BoardName({ board }: { board: TBoard }) {
     return (
         <ColumnWrapper column="name">
-            <p className="flex flex-row gap-1 items-center">
+            <p className="flex flex-row gap-2 items-center">
                 <BoardIcon className="!top-0" aria-label="Tavle-ikon" />
                 <Link href={`/edit/${board.id}`} className="hover:underline">
                     {board.meta.title ?? DEFAULT_BOARD_NAME}
@@ -23,7 +23,7 @@ function BoardName({ board }: { board: TBoard }) {
 function FolderName({ folder }: { folder: TOrganization }) {
     return (
         <ColumnWrapper column="name">
-            <p className="flex flex-row gap-1 items-center">
+            <p className="flex flex-row gap-2 items-center">
                 <FolderIcon className="!top-0" aria-label="Mappe-ikon" />
                 <Link href={`/boards/${folder.id}`} className="hover:underline">
                     {folder.name ?? DEFAULT_FOLDER_NAME}


### PR DESCRIPTION
### Legge til mer luft mellom ikon og navn i tabellene
---
#### Motivasjon
Designet har mer luft mellom ikon og navn på elementet fordi det ser bedre ut. 

#### Endringer
La til 4 px mer luft mellom ikon og navn på element. 

|Før|Etter|
|---|-----|
|![image](https://github.com/user-attachments/assets/006d8e36-9cb5-44d2-aeb3-7d26b8fc6800)|![image](https://github.com/user-attachments/assets/063d74e7-e447-4de2-a061-28429fe5a317)|

#### Sjekkliste for Review
- [x] Se det ser bra ut
