### PR TITLE
fix(demo): make expandable focusable for a11y

### DIFF
--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -9,7 +9,7 @@ function ExpandableInformation() {
 
     return (
         <div>
-            <div
+            <button
                 className={`flex flex-row justify-between items-center px-6  py-4 bg-blue80 w-full cursor-pointer ${
                     isOpen ? 'rounded-t' : 'rounded'
                 }`}
@@ -19,7 +19,7 @@ function ExpandableInformation() {
                     Hva kan du gjøre med Tavla om du logger inn?
                 </Paragraph>
                 {isOpen ? <UpArrowIcon /> : <DownArrowIcon />}
-            </div>
+            </button>
             <BaseExpand
                 open={isOpen}
                 className="bg-blue90 px-6  py-4 rounded-b"


### PR DESCRIPTION
### Endret interaktivt element i expendable på demo-siden til å være en button
---
#### Motivasjon
Ved å bytte til button fra div så blir den tab-fokuserbar og plukkes også opp som et interaktivt element for skjermleser
(fokus-farge matcher ikke resten av komponentene, men det gjør heller ikke entur-ikonet)

#### Endringer
Byttet til button fra div i expandableinformation

#### Sjekkliste for Review
- [ ] Sjekk at man kan nå elementet ved å tabbe
- [ ] Sjekk at skjermleser leser opp riktig
