### PR TITLE
fix(edit): delete board 

### DIFF
--- a/tavla/app/(admin)/boards/components/Column/Delete.tsx
+++ b/tavla/app/(admin)/boards/components/Column/Delete.tsx
@@ -2,7 +2,7 @@
 import { useActionState } from 'react'
 import { Button, ButtonGroup, IconButton } from '@entur/button'
 import { DeleteIcon } from '@entur/icons'
-import { TBoard, TOrganizationID } from 'types/settings'
+import { TBoard } from 'types/settings'
 import { Tooltip } from '@entur/tooltip'
 import { useModalWithValue } from '../../hooks/useModalWithValue'
 import { Modal } from '@entur/modal'
@@ -16,7 +16,6 @@ import { SubmitButton } from 'components/Form/SubmitButton'
 import { OverflowMenuItem } from '@entur/menu'
 import { useToast } from '@entur/alert'
 import { deleteBoardAction } from '../../utils/actions'
-import { useParams } from 'next/navigation'
 
 function Delete({
     board,
@@ -29,9 +28,6 @@ function Delete({
 
     const [state, deleteBoard] = useActionState(deleteBoardAction, undefined)
     const { isOpen, open, close } = useModalWithValue('delete', board.id ?? '')
-
-    const params = useParams()
-    const oid = params?.id as TOrganizationID
 
     const submit = async (data: FormData) => {
         deleteBoard(data)
@@ -69,7 +65,6 @@ function Delete({
 
                 <form action={submit} onSubmit={close} className="w-full">
                     <HiddenInput id="bid" value={board.id} />
-                    <HiddenInput id="oid" value={oid ?? undefined} />
                     <FormError {...getFormFeedbackForField('general', state)} />
                     <ButtonGroup className="flex flex-row">
                         <SubmitButton

--- a/tavla/app/(admin)/boards/utils/actions.ts
+++ b/tavla/app/(admin)/boards/utils/actions.ts
@@ -5,7 +5,7 @@ import { deleteBoard, initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
 import { handleError } from 'app/(admin)/utils/handleError'
 import { TBoardID } from 'types/settings'
-import { getOrganizationWithBoard } from 'Board/scenarios/Board/firebase'
+import { getOrganizationForBoard } from 'Board/scenarios/Board/firebase'
 
 initializeAdminApp()
 
@@ -14,7 +14,7 @@ export async function deleteBoardAction(
     data: FormData,
 ) {
     const bid = data.get('bid') as TBoardID
-    const organization = await getOrganizationWithBoard(bid)
+    const organization = await getOrganizationForBoard(bid)
 
     try {
         await deleteBoard(bid)

--- a/tavla/app/(admin)/boards/utils/actions.ts
+++ b/tavla/app/(admin)/boards/utils/actions.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from 'next/cache'
 import { deleteBoard, initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
 import { handleError } from 'app/(admin)/utils/handleError'
-import { TBoardID, TOrganizationID } from 'types/settings'
+import { TBoardID } from 'types/settings'
+import { getOrganizationWithBoard } from 'Board/scenarios/Board/firebase'
 
 initializeAdminApp()
 
@@ -13,13 +14,14 @@ export async function deleteBoardAction(
     data: FormData,
 ) {
     const bid = data.get('bid') as TBoardID
-    const oid = data.get('oid') as TOrganizationID
+    const organization = await getOrganizationWithBoard(bid)
+
     try {
         await deleteBoard(bid)
         revalidatePath('/')
     } catch (e) {
         return handleError(e)
     }
-    if (oid) redirect(`/boards/${oid}`)
+    if (organization) redirect(`/boards/${organization?.id}`)
     redirect('/boards')
 }

--- a/tavla/app/(admin)/utils/firebase.ts
+++ b/tavla/app/(admin)/utils/firebase.ts
@@ -7,7 +7,7 @@ import {
     getOrganizationIfUserHasAccess,
 } from '../actions'
 import * as Sentry from '@sentry/nextjs'
-import { getOrganizationWithBoard } from 'Board/scenarios/Board/firebase'
+import { getOrganizationForBoard } from 'Board/scenarios/Board/firebase'
 
 initializeAdminApp()
 
@@ -60,7 +60,7 @@ export async function userCanEditBoard(bid?: TBoardID) {
     const userEditorAccess = user && user.owner?.includes(bid)
 
     if (user?.uid && !userEditorAccess) {
-        const organization = await getOrganizationWithBoard(bid)
+        const organization = await getOrganizationForBoard(bid)
         return organization && organization.owners?.includes(user.uid)
     }
     return userEditorAccess
@@ -72,7 +72,7 @@ export async function deleteBoard(bid: TBoardID) {
 
     if (!user || !access) throw 'auth/operation-not-allowed'
 
-    const organization = await getOrganizationWithBoard(bid)
+    const organization = await getOrganizationForBoard(bid)
 
     try {
         await firestore().collection('boards').doc(bid).delete()

--- a/tavla/pages/[id].tsx
+++ b/tavla/pages/[id].tsx
@@ -3,7 +3,7 @@ import { TBoard, TOrganization } from 'types/settings'
 import { Board } from 'Board/scenarios/Board'
 import {
     getBoard,
-    getOrganizationWithBoard,
+    getOrganizationForBoard,
 } from 'Board/scenarios/Board/firebase'
 import { Footer } from 'components/Footer'
 import { useRefresh } from 'hooks/useRefresh'
@@ -26,7 +26,7 @@ export async function getServerSideProps({
         }
     }
 
-    const organization = await getOrganizationWithBoard(id)
+    const organization = await getOrganizationForBoard(id)
 
     return {
         props: {

--- a/tavla/src/Board/scenarios/Board/firebase.ts
+++ b/tavla/src/Board/scenarios/Board/firebase.ts
@@ -48,7 +48,7 @@ export async function getOrganization(oid: TOrganizationID) {
     }
 }
 
-export async function getOrganizationWithBoard(bid: TBoardID) {
+export async function getOrganizationForBoard(bid: TBoardID) {
     try {
         const ref = await firestore()
             .collection('organizations')


### PR DESCRIPTION
### Slette tavle fra /edit-siden
---
#### Motivasjon
Var ikke mulig å slette en tavle fra rediger-siden. Grunnen til dette var at den trodde `bid` var en `oid`, så det ble feil. Nå henter jeg organisasjonen basert på `bid` i stedet for å hente det fra slugs i URLen. 

#### Endringer
- Henter organisasjonen/mappen basert på board-id som kommer inn, og ikke basert på URLen.
- Renamet en funksjon

#### Sjekkliste for Review
- [ ] (Hva skal reviewers sjekke før denne PR-en godkjennes?)
