### PR TITLE
chore(oversikt): add redirect

### DIFF
--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -118,6 +118,15 @@ const nextConfig = {
             },
         ]
     },
+    async redirects() {
+        return [
+            {
+                source: '/boards',
+                destination: '/oversikt',
+                permanent: true,
+            },
+        ]
+    },
 }
 
 module.exports = async (phase, { defaultConfig }) => {


### PR DESCRIPTION
### La til redirects for oversiktssiden
---
#### Motivasjon
Vi vil at brukere som har bokmerket oversiktssiden fremdeles skal sendes til oversikten selv etter endring av slug-navn. 

#### Endringer
La til en permanent redirect i next.config.js 

#### Sjekkliste for Review
- [x] Etter #1854 er inne, sjekk at man sendes til /oversikt om man går på /boards og at man kommer til beveren dersom man skriver inn /boards/[mappe-id]
