### PR TITLE
chore(): remove folder footer

### DIFF
--- a/tavla/app/(admin)/mapper/[id]/rediger/page.tsx
+++ b/tavla/app/(admin)/mapper/[id]/rediger/page.tsx
@@ -8,7 +8,6 @@ import { initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 import { auth } from 'firebase-admin'
 import { UidIdentifier } from 'firebase-admin/lib/auth/identifier'
-import { Footer } from '../../components/Footer'
 
 initializeAdminApp()
 
@@ -65,10 +64,6 @@ async function EditOrganizationPage(props: TProps) {
                         members={usersReq.users}
                         uid={user.uid}
                         oid={organization.id}
-                    />
-                    <Footer
-                        oid={organization.id}
-                        footer={organization.footer}
                     />
                     <UploadLogo organization={organization} />
                 </div>

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/Footer.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/Footer.tsx
@@ -4,18 +4,8 @@ import { Heading4 } from '@entur/typography'
 import { TFooter } from 'types/settings'
 import { Tooltip } from '@entur/tooltip'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
-import { Switch } from '@entur/form'
-import { useState } from 'react'
 
-function Footer({
-    footer,
-    isInOrganization,
-}: {
-    footer?: TFooter
-    isInOrganization: boolean
-}) {
-    const [override, setOverride] = useState(footer?.override ?? false)
-
+function Footer({ footer }: { footer?: TFooter }) {
     return (
         <div className="flex flex-col">
             <div className="flex flex-col items-start sm:flex-row justify-between sm:items-center gap-2">
@@ -33,22 +23,12 @@ function Footer({
                         />
                     </Tooltip>
                 </div>
-                {isInOrganization && (
-                    <Switch
-                        checked={override}
-                        onChange={() => setOverride(!override)}
-                        name="override"
-                    >
-                        Vis infomelding fra mappen
-                    </Switch>
-                )}
             </div>
             <ClientOnlyTextField
                 label="Infomelding"
                 name="footer"
                 defaultValue={footer?.footer ?? ''}
                 className="w-full"
-                readOnly={override && isInOrganization}
             />
         </div>
     )

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
@@ -80,10 +80,7 @@ function Settings({
                         <ThemeSelect theme={board.theme} />
                         <FontSelect font={board.meta.fontSize} />
                         <WalkingDistance location={board.meta.location} />
-                        <Footer
-                            footer={board.footer}
-                            isInOrganization={organization ? true : false}
-                        />
+                        <Footer footer={board.footer} />
                         <HiddenInput id="bid" value={board.id} />
                     </div>
                 </div>


### PR DESCRIPTION
### Tittel
---
#### Motivasjon

Vi vil på sikt fjerne alle infomeldinger på mappenivå. På tavlenivå har vi lagret infomeldinger som kan ha en `override` skrudd på, slik at man bruker mappens infomelding. Vi vil fjerne muligheten til å sette en infomelding på mappenivå, samtidig som vi beholder `override`-logikken før vi migrerer over feltene i databasen. Dette for å forhindre at migreringen potensielt blir ufullstendig. 

#### Endringer

Fjernet `footer`-funksjonalitet på mappenivå, og fjernet muligheten til å toggle hvilken infomelding som skal vises i tavleredigeringen. 

| Før   | Etter |
| ----- | ----- |
| bilde | bilde |

#### Sjekkliste for Review
- [ ] Sjekk at footer-funksjonalitet er fjernet på mapperedigeringen
- [ ] Sjekk at override-logikk på tavlen fungerer som tenkt (gjerne på allerede eksisterende tavler)
