### PR TITLE
fix(): fix cleanup commandos

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -17,7 +17,7 @@
         "generate": "graphql-codegen",
         "lint": "next lint --max-warnings 0",
         "prettier": "prettier . --check",
-        "fix": "next lint --fix && prettier .",
+        "fix": "next lint --fix && prettier . --write",
         "build-start": "next build && next start",
         "postinstall": "cd .. && husky install ./.husky"
     },


### PR DESCRIPTION
### Tittel
---
#### Motivasjon

Kommandoen `next lint --fix && prettier .` kjørte hos meg bare i en evig loop med veldig mye overload av feedback i terminalen. Etter å ha konferert litt med stackoverflow og chatteren viser det seg at denne kommandoen bare printer alle endringene. 

#### Endringer

Ved å legge på `--write` på slutten fikser kommandoen at hver fil blir formatert riktig og ferdig før linteren kjører på videre. 

#### Sjekkliste for Review
- [ ] Test at kommandoen fungerer som tenkt
