### PR TITLE
feat(tabell): move board

### DIFF
--- a/tavla/app/(admin)/oversikt/components/Column/Actions.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Actions.tsx
@@ -5,6 +5,7 @@ import { Open } from 'app/(admin)/tavler/[id]/rediger/components/Buttons/Open'
 import { Copy } from 'app/(admin)/tavler/[id]/rediger/components/Buttons/Copy'
 import { DeleteOrganization } from 'app/(admin)/components/DeleteOrganization'
 import { EditBoard, EditFolder } from './Edit'
+import { Move } from './Move'
 
 function BoardActions({ board }: { board: TBoard }) {
     return (
@@ -13,6 +14,7 @@ function BoardActions({ board }: { board: TBoard }) {
                 <EditBoard bid={board.id} />
                 <Copy bid={board.id} />
                 <Open bid={board.id} />
+                <Move board={board} />
                 <Delete board={board} />
             </div>
         </ColumnWrapper>

--- a/tavla/app/(admin)/oversikt/components/Column/Delete.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Delete.tsx
@@ -13,7 +13,6 @@ import { getFormFeedbackForField } from 'app/(admin)/utils'
 import sheep from 'assets/illustrations/Sheep.png'
 import Image from 'next/image'
 import { SubmitButton } from 'components/Form/SubmitButton'
-import { OverflowMenuItem } from '@entur/menu'
 import { useToast } from '@entur/alert'
 import { deleteBoardAction } from '../../utils/actions'
 
@@ -106,15 +105,6 @@ function DeleteButton({
             </Button>
         )
     }
-    if (type === 'action')
-        return (
-            <OverflowMenuItem onSelect={onClick}>
-                <div className="flex flex-row">
-                    <DeleteIcon aria-label="Slette-ikon" />
-                    Slett tavle
-                </div>
-            </OverflowMenuItem>
-        )
     return (
         <Tooltip
             content="Slett tavle"

--- a/tavla/app/(admin)/oversikt/components/Column/Delete.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Delete.tsx
@@ -36,13 +36,7 @@ function Delete({
 
     return (
         <>
-            <Tooltip
-                content="Slett tavle"
-                placement="bottom"
-                id="tooltip-delete-board"
-            >
-                <DeleteButton type={type} onClick={open} />
-            </Tooltip>
+            <DeleteButton type={type} onClick={open} />
 
             <Modal
                 open={isOpen}

--- a/tavla/app/(admin)/oversikt/components/Column/Move.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Move.tsx
@@ -1,0 +1,101 @@
+'use client'
+import { useToast } from '@entur/alert'
+import { IconButton } from '@entur/button'
+import { ForwardIcon } from '@entur/icons'
+import { Modal } from '@entur/modal'
+import { Tooltip } from '@entur/tooltip'
+import { Heading3, Paragraph } from '@entur/typography'
+import { HiddenInput } from 'components/Form/HiddenInput'
+import { SubmitButton } from 'components/Form/SubmitButton'
+import { TBoard } from 'types/settings'
+import { useModalWithValue } from '../../hooks/useModalWithValue'
+import { Dropdown } from '@entur/dropdown'
+import { useOrganizations } from 'app/(admin)/hooks/useOrganizations'
+import { moveBoardAction } from '../../utils/actions'
+import { FormError } from 'app/(admin)/components/FormError'
+import { getFormFeedbackForField, TFormFeedback } from 'app/(admin)/utils'
+import { useState } from 'react'
+
+function Move({ board }: { board: TBoard }) {
+    const { addToast } = useToast()
+
+    const { isOpen, open, close } = useModalWithValue('flytt', board.id ?? '')
+    const [error, setError] = useState<TFormFeedback | undefined>(undefined)
+
+    const submit = async (data: FormData) => {
+        const resultingError = await moveBoardAction(data)
+        if (resultingError) {
+            setError(resultingError)
+        } else {
+            const toastText = selectedOrganization?.value.id
+                ? `Tavlen er flyttet til "${selectedOrganization?.value.name}"!`
+                : 'Tavlen er ikke lengre i en mappe!'
+            addToast(toastText)
+            setError(undefined)
+            close()
+        }
+    }
+
+    const { organizations, selectedOrganization, setSelectedOrganization } =
+        useOrganizations()
+
+    return (
+        <>
+            <Tooltip
+                content="Flytt til en annen mappe"
+                placement="bottom"
+                id="tooltip-move-board"
+            >
+                <IconButton
+                    aria-label="Flytt til en annen mappe"
+                    onClick={open}
+                >
+                    <ForwardIcon aria-label="Pil-ikon" />
+                </IconButton>
+            </Tooltip>
+            <Modal
+                open={isOpen}
+                size="medium"
+                onDismiss={() => {
+                    setError(undefined)
+                    close()
+                }}
+                closeLabel="Avbryt sletting"
+            >
+                <Heading3 margin="bottom" as="h1">
+                    Flytt tavlen &quot;{board.meta.title}&quot;
+                </Heading3>
+                <Paragraph className="mb-8">
+                    Velg hvilken mappe tavlen skal ligge i.
+                </Paragraph>
+                <form action={submit} className="w-full">
+                    <Dropdown
+                        items={organizations}
+                        label="Dine mapper"
+                        selectedItem={selectedOrganization}
+                        onChange={setSelectedOrganization}
+                        aria-required="true"
+                        className="mb-4 z-1000"
+                    />
+                    <HiddenInput id="bid" value={board.id} />
+                    <HiddenInput
+                        id="newOid"
+                        value={selectedOrganization?.value.id}
+                    />
+                    <FormError {...getFormFeedbackForField('general', error)} />
+
+                    <div className="flex flex-row mt-8 justify-start">
+                        <SubmitButton
+                            variant="primary"
+                            className="max-sm:w-full"
+                        >
+                            Flytt tavlen
+                        </SubmitButton>
+                    </div>
+                </form>
+            </Modal>
+        </>
+    )
+}
+
+export { Move }

--- a/tavla/app/(admin)/oversikt/utils/actions.ts
+++ b/tavla/app/(admin)/oversikt/utils/actions.ts
@@ -4,9 +4,15 @@ import { revalidatePath } from 'next/cache'
 import { deleteBoard, initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { redirect } from 'next/navigation'
 import { handleError } from 'app/(admin)/utils/handleError'
-import { TBoard, TBoardID, TOrganization } from 'types/settings'
+import {
+    TBoard,
+    TBoardID,
+    TOrganization,
+    TOrganizationID,
+} from 'types/settings'
 import { getBoardsForOrganization } from 'app/(admin)/actions'
 import { getOrganizationForBoard } from 'Board/scenarios/Board/firebase'
+import { moveBoard } from 'app/(admin)/tavler/[id]/rediger/components/Settings/actions'
 
 initializeAdminApp()
 
@@ -47,4 +53,16 @@ export async function countAllBoards(
     let count = boards.length
     folderCounts.map((folderCount) => (count += folderCount))
     return count
+}
+
+export async function moveBoardAction(data: FormData) {
+    const bid = data.get('bid') as TBoardID
+    const newOrganizationID = data.get('newOid') as TOrganizationID | undefined
+    const oldOrganization = await getOrganizationForBoard(bid)
+    try {
+        await moveBoard(bid, newOrganizationID, oldOrganization?.id)
+        revalidatePath('/')
+    } catch (e) {
+        return handleError(e)
+    }
 }

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -252,7 +252,7 @@ async function getTilesWithDistance(board: TBoard, location?: TLocation) {
     )
 }
 
-async function moveBoard(
+export async function moveBoard(
     bid: TBoardID,
     toOrganization?: TOrganizationID,
     fromOrganization?: TOrganizationID,
@@ -294,8 +294,6 @@ async function moveBoard(
                 .collection('users')
                 .doc(user.uid)
                 .update({ owner: firestore.FieldValue.arrayUnion(bid) })
-
-        revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         Sentry.captureException(error, {
             extra: {
@@ -305,6 +303,6 @@ async function moveBoard(
                 oldOrg: fromOrganization,
             },
         })
-        return handleError(error)
+        throw error
     }
 }

--- a/tavla/package.json
+++ b/tavla/package.json
@@ -32,7 +32,7 @@
         "@entur/layout": "2.3.18",
         "@entur/loader": "0.5.12",
         "@entur/menu": "5.1.3",
-        "@entur/modal": "1.7.55",
+        "@entur/modal": "1.7.64",
         "@entur/tokens": "3.17.2",
         "@entur/tooltip": "5.1.1",
         "@entur/typography": "1.8.47",

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -758,7 +758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@entur/a11y@npm:^0.2.92, @entur/a11y@npm:^0.2.94":
+"@entur/a11y@npm:^0.2.94":
   version: 0.2.95
   resolution: "@entur/a11y@npm:0.2.95"
   dependencies:
@@ -781,6 +781,19 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 84960d7de513904915568abd11b1c5866f8a2d4940b6765f0c20495e6c67997fc418840bcdb0e2eb39793189ad88c3bd7babee7859fdb60752aa4aef398dbb37
+  languageName: node
+  linkType: hard
+
+"@entur/a11y@npm:^0.2.98":
+  version: 0.2.98
+  resolution: "@entur/a11y@npm:0.2.98"
+  dependencies:
+    "@entur/tokens": ^3.19.0
+    "@entur/utils": ^0.12.3
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 4b7553e4cdb5e9745b58a50fcad7a87152afe4c69104048b7fa08353de2237da689588c0cdcd32bda10f43054f253868bf739a704fbd9639a89036f676221118
   languageName: node
   linkType: hard
 
@@ -1181,24 +1194,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@entur/modal@npm:1.7.55":
-  version: 1.7.55
-  resolution: "@entur/modal@npm:1.7.55"
+"@entur/modal@npm:1.7.64":
+  version: 1.7.64
+  resolution: "@entur/modal@npm:1.7.64"
   dependencies:
-    "@entur/a11y": ^0.2.92
-    "@entur/button": ^3.2.34
-    "@entur/icons": ^7.4.2
-    "@entur/layout": ^2.3.18
-    "@entur/tokens": ^3.17.2
-    "@entur/typography": ^1.8.47
-    "@entur/utils": ^0.12.0
+    "@entur/a11y": ^0.2.98
+    "@entur/button": ^3.3.4
+    "@entur/icons": ^7.8.0
+    "@entur/layout": ^3.1.0
+    "@entur/tokens": ^3.19.0
+    "@entur/typography": ^1.9.4
+    "@entur/utils": ^0.12.3
     "@reach/dialog": ^0.16.0
     classnames: ^2.3.1
     react-focus-lock: ^2.9.1
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 344900e9ac0cebc675ba51812123c30eb5409215549d377ebf1ee8e6a79c94ec5cbbfed74370320d33b11a76dabcb993f2acfa18d50b6093b91aeaf9ff746509
+  checksum: 4450c9f921fc174a5f204dad706e077df0c1e0161272c5e151208b5e6ed26844529d2cdade03f2a929a8a22e882ca379cb03a242835201cd7429a7a8b597e19d
   languageName: node
   linkType: hard
 
@@ -14494,7 +14507,7 @@ __metadata:
     "@entur/layout": 2.3.18
     "@entur/loader": 0.5.12
     "@entur/menu": 5.1.3
-    "@entur/modal": 1.7.55
+    "@entur/modal": 1.7.64
     "@entur/tokens": 3.17.2
     "@entur/tooltip": 5.1.1
     "@entur/typography": 1.8.47


### PR DESCRIPTION
### Funksjonalitet for å flytte en tavle til en mappe i tabellen
---
#### Motivasjon
Gjøre det enkelt for folk å flytte tavler.

#### Endringer
- Mulighet for å flytte en tavle direkte i tabellen.
- Laget en modal med "flytt" som parameter -> her kan man bla seg gjennom mappene man har
- Oppdaterte entur-pakke i samme slengen

| Før   | Etter |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/a31f1738-d147-4612-9216-acd429a162af) | ![image](https://github.com/user-attachments/assets/64b1c618-65a3-4124-a9c9-5a3a4a7b874c) |

#### Sjekkliste for Review
- [x] Tavle flyttes til mappe man har valgt
- [x] Sjekk at ting blir riktig i DB
- [x] Man skal ikke redirectes når man flytter en tavle
