### PR TITLE
style(modal): show long dropdown

### DIFF
--- a/tavla/app/(admin)/oversikt/components/Column/Move.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Move.tsx
@@ -75,7 +75,7 @@ function Move({ board }: { board: TBoard }) {
                         selectedItem={selectedOrganization}
                         onChange={setSelectedOrganization}
                         aria-required="true"
-                        className="mb-4 z-1000"
+                        className="mb-4"
                     />
                     <HiddenInput id="bid" value={board.id} />
                     <HiddenInput

--- a/tavla/src/Shared/styles/reset.css
+++ b/tavla/src/Shared/styles/reset.css
@@ -63,6 +63,10 @@ a.eds-button > .eds-icon,
     padding: 0;
 }
 
+.eds-dropdown__list__floating-container {
+    transform: translate(-2px, 50px) !important;
+}
+
 .eds-contrast .eds-expandable-panel__trigger {
     background: var(--secondary-background-color);
 }


### PR DESCRIPTION
### Vise dropdown i modaler om listen er lang
---
#### Motivasjon
Når listen av mapper ble lang, så vistes de ikke i modalen. Det gikk heller ikke an å scrolle i listen.

#### Endringer
- La til en generell styling i `reset.css` på dropdown-containeren. Denne sørger for at dropdownenlisten alltid vil ligge _under_ selve dropdownen, som igjen fører til at det er mulig å scrolle i dropdownen og i modalen.

| Før   | Etter |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/6508e73b-6c5e-49bc-b357-05868bf0e285) | ![image](https://github.com/user-attachments/assets/d2a6f5c4-011b-4448-8500-71929cf3f939) |

#### Sjekkliste for Review
- [ ] Sjekk at du kan scrolle i dropdownen for å velge hvilken som helst mappe hvis du har mange mapper
