### PR TITLE
chore(tilecard): fix overly permissiv regex range

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/utils.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/utils.ts
@@ -4,7 +4,7 @@ import { TLineFragment } from './types'
 export function sortLineByPublicCode(a: TLineFragment, b: TLineFragment) {
     if (!a || !a.publicCode || !b || !b.publicCode) return 1
 
-    const containsLetters = /[a-åA-Å]/
+    const containsLetters = /[a-zæøåA-ZÆØÅ]/
     const aContainsLetters = containsLetters.test(a.publicCode)
     const bContainsLetters = containsLetters.test(b.publicCode)
 


### PR DESCRIPTION
Potential fix for [https://github.com/entur/tavla/security/code-scanning/1](https://github.com/entur/tavla/security/code-scanning/1)

To fix the issue, we need to rewrite the regular expression to avoid overlapping ranges and explicitly define the intended character set. Instead of using `a-å` and `A-Å`, we can explicitly list all the characters in the Norwegian alphabet, including both uppercase and lowercase letters. This ensures that the regular expression is unambiguous and matches only the intended characters.

The updated regular expression will explicitly list the characters: `a-zæøåA-ZÆØÅ`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
