### PR TITLE
chore(posthog): delete events

### DIFF
--- a/tavla/app/(admin)/components/Footer/index.tsx
+++ b/tavla/app/(admin)/components/Footer/index.tsx
@@ -39,11 +39,6 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                             <EnturLink
                                 href="mailto:tavla@entur.org"
                                 target="_blank"
-                                onClick={() =>
-                                    posthog.capture('SUPPORT_EMAIL', {
-                                        type: 'footer',
-                                    })
-                                }
                             >
                                 Kontakt Tavla
                             </EnturLink>

--- a/tavla/app/(admin)/components/Footer/index.tsx
+++ b/tavla/app/(admin)/components/Footer/index.tsx
@@ -57,9 +57,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                 href="/demo"
                                 as={Link}
                                 onClick={() =>
-                                    posthog.capture('DEMO_FROM_FOOTER', {
-                                        type: 'footer',
-                                    })
+                                    posthog.capture('DEMO_FROM_FOOTER')
                                 }
                             >
                                 Prøv Tavla

--- a/tavla/app/(admin)/components/Login/index.tsx
+++ b/tavla/app/(admin)/components/Login/index.tsx
@@ -8,14 +8,12 @@ import { logout } from './actions'
 import { Create } from './Create'
 import { usePageParam } from 'app/(admin)/hooks/usePageParam'
 import { Reset } from './Reset'
-import { usePostHog } from 'posthog-js/react'
 import { TLoginPage } from './types'
 import { Email } from './Email'
 
 function Login({ loggedIn }: { loggedIn: boolean }) {
     const router = useRouter()
     const pathname = usePathname()
-    const posthog = usePostHog()
 
     const { open, hasPage, pageParam } = usePageParam('login')
 
@@ -39,9 +37,6 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 href="?login"
                 scroll={false}
                 className="gap-4 p-4"
-                onClick={() => {
-                    posthog.capture('LOGIN_BTN_NAV_BAR')
-                }}
             >
                 <UserIcon />
                 Logg inn


### PR DESCRIPTION
### Fjerne unødvendige posthog events
---

#### Endringer
- Fjernet tracking på mailen vår i footeren. Hvorfor? Gir ingen verdi i å tracke denne, en slik mail må vi uansett ha i footeren.
- Fjernet type på tracking av lenke til demo-side i footer. Hvorfor? Vi trenger ikke å sende med en type siden den har et egetdefinert navn. 
- Fjernet tracking på logg inn-knappen i navbaren. Hvorfor? For meg så jeg ikke helt en grunn til å ha det på en logg-inn knapp som vi uansett må ha der? 

Kan godt ta tilbake noe tracking hvis dere tenker det er hensiktsmessig! 😄 
