### PR TITLE
chore(): gratis in bold on landing page

### DIFF
--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -30,10 +30,11 @@ async function Landing() {
                         <Heading1>Lag en avgangstavle for</Heading1>
                         <WordCarousel />
                         <LeadParagraph margin="bottom">
-                            Tavla er en gratis tjeneste som gjør det enkelt å
-                            sette opp avgangstavler for offentlig transport i
-                            hele Norge! Vis kollektivtilbudet i nærheten og
-                            hjelp folk til å planlegge sin neste kollektivreise.
+                            Tavla er en <b>gratis</b> tjeneste som gjør det
+                            enkelt å sette opp avgangstavler for offentlig
+                            transport i hele Norge! Vis kollektivtilbudet i
+                            nærheten og hjelp folk til å planlegge sin neste
+                            kollektivreise.
                         </LeadParagraph>
                         <div className="flex md:flex-row flex-col w-full gap-4 mt-5">
                             {!loggedIn && <CreateUserButtonLanding />}


### PR DESCRIPTION
## 🥅 Motivasjon

Tydeliggjøre at Tavla er gratis å bruke

## ✨ Endringer

- [x] "Gratis" i bold på landingssiden

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="800" alt="Screenshot 2025-05-14 at 14 13 35" src="https://github.com/user-attachments/assets/ec4c2fef-6973-45aa-8f67-b05f50c5f259" /> | <img width="835" alt="Screenshot 2025-05-14 at 14 13 47" src="https://github.com/user-attachments/assets/f27a22ff-8ce9-453c-93ec-b575351e5706" /> |
