### PR TITLE
chore(oversikt/mapper): add empty table state

### DIFF
--- a/tavla/app/(admin)/components/CreateBoard/index.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Modal } from '@entur/modal'
 import { NameAndOrganizationSelector } from './NameAndOrganizationSelector'
-import { SecondaryButton } from '@entur/button'
+import { PrimaryButton } from '@entur/button'
 import { BoardIcon } from '@entur/icons'
 import { TOrganization } from 'types/settings'
 import { useModalWithValues } from 'app/(admin)/oversikt/hooks/useModalWithValue'
@@ -14,10 +14,10 @@ function CreateBoard({ folder }: { folder?: TOrganization }) {
 
     return (
         <>
-            <SecondaryButton onClick={open}>
+            <PrimaryButton onClick={open}>
                 Opprett tavle
                 <BoardIcon aria-label="Tavle-ikon" />
-            </SecondaryButton>
+            </PrimaryButton>
             <Modal
                 open={isOpen}
                 size="medium"

--- a/tavla/app/(admin)/mapper/[id]/page.tsx
+++ b/tavla/app/(admin)/mapper/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Heading1, Paragraph } from '@entur/typography'
+import { Heading1, Label, Paragraph } from '@entur/typography'
 import { getBoardsForOrganization } from 'app/(admin)/actions'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
 import { getOrganization } from 'Board/scenarios/Board/firebase'
@@ -15,6 +15,7 @@ import { UploadLogo } from '../components/UploadLogo'
 import { MemberAdministration } from '../components/MemberAdministration'
 import { auth } from 'firebase-admin'
 import { UidIdentifier } from 'firebase-admin/lib/auth/identifier'
+import EmptyOverview from 'app/(admin)/oversikt/components/EmptyOverview'
 
 export type TProps = {
     params: Promise<{ id: TOrganizationID }>
@@ -39,6 +40,7 @@ async function FolderPage(props: TProps) {
 
     const params = await props.params
     const folder = await getOrganization(params.id)
+    const boardCount = folder?.boards?.length
 
     if (!folder || !folder.id) {
         return notFound()
@@ -89,7 +91,16 @@ async function FolderPage(props: TProps) {
                 sammen med deg. Du kan også laste opp en logo, som vil vises i
                 alle tavlene.
             </Paragraph>
-            <BoardTable boards={boardsInFolder} />
+            <div className="gap-4">
+                {boardCount === 0 ? (
+                    <EmptyOverview text="Her var det tomt gitt! Start med å opprette en tavle" />
+                ) : (
+                    <div className="flex flex-col mt-8">
+                        <Label>Totalt antall tavler: {boardCount}</Label>
+                        <BoardTable boards={boardsInFolder} />
+                    </div>
+                )}
+            </div>
         </div>
     )
 }

--- a/tavla/app/(admin)/mapper/[id]/page.tsx
+++ b/tavla/app/(admin)/mapper/[id]/page.tsx
@@ -95,7 +95,7 @@ async function FolderPage(props: TProps) {
                 {boardCount === 0 ? (
                     <EmptyOverview text="Her var det tomt gitt! Start med å opprette en tavle" />
                 ) : (
-                    <div className="flex flex-col mt-8">
+                    <div className="flex flex-col">
                         <Label>Totalt antall tavler: {boardCount}</Label>
                         <BoardTable boards={boardsInFolder} />
                     </div>

--- a/tavla/app/(admin)/oversikt/components/EmptyOverview.tsx
+++ b/tavla/app/(admin)/oversikt/components/EmptyOverview.tsx
@@ -1,0 +1,18 @@
+import leafs from 'assets/illustrations/leafs.svg'
+import Image from 'next/image'
+import { Heading4 } from '@entur/typography'
+
+interface EmptyOverviewProps {
+    text?: string
+}
+
+const EmptyOverview: React.FC<EmptyOverviewProps> = ({ text }) => {
+    return (
+        <div className="flex flex-col gap-4 items-center justify-center h-full">
+            <Image src={leafs} alt="" className="h-1/4 w-1/4 mx-auto" />
+            <Heading4 className="text-center">{text}</Heading4>
+        </div>
+    )
+}
+
+export default EmptyOverview

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -50,8 +50,8 @@ async function FoldersAndBoardsPage() {
                             className="h-1/4 w-1/4 mx-auto"
                         />
                         <Heading4 className="text-center">
-                            Oisann, her var det tomt! Start med å lage en mappe
-                            eller en tavle!
+                            Her var det tomt gitt! Start med å opprette en mappe
+                            eller en tavle
                         </Heading4>
                     </>
                 ) : (

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -35,8 +35,8 @@ async function FoldersAndBoardsPage() {
             <div className="flex max-sm:flex-col flex-row justify-between">
                 <Heading1>Mapper og tavler</Heading1>
                 <div className="flex flex-row gap-4">
-                    <CreateBoard />
                     <CreateFolder />
+                    <CreateBoard />
                 </div>
             </div>
 

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -9,7 +9,7 @@ import {
 } from 'app/(admin)/actions'
 import { initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
-import { Heading1, Label } from '@entur/typography'
+import { Heading1, Heading4, Label } from '@entur/typography'
 import { CreateFolder } from '../components/CreateFolder'
 import { CreateBoard } from '../components/CreateBoard'
 import { countAllBoards } from './utils/actions'
@@ -37,10 +37,25 @@ async function FoldersAndBoardsPage() {
                     <CreateFolder />
                 </div>
             </div>
-            <Search />
+
             <div className="gap-4">
-                <Label>Totalt antall tavler: {count}</Label>
-                <BoardTable folders={folders} boards={privateBoards} />
+                {count === 0 ? (
+                    <Heading4 className="text-center">
+                        Oisann, her var det tomt! Start med å lage en mappe
+                        eller en tavle!
+                    </Heading4>
+                ) : (
+                    <>
+                        <Search />
+                        <div className="flex flex-col mt-8">
+                            <Label>Totalt antall tavler: {count}</Label>
+                            <BoardTable
+                                folders={folders}
+                                boards={privateBoards}
+                            />
+                        </div>
+                    </>
+                )}
             </div>
         </div>
     )

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -9,12 +9,11 @@ import {
 } from 'app/(admin)/actions'
 import { initializeAdminApp } from 'app/(admin)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(admin)/utils/server'
-import { Heading1, Heading4, Label } from '@entur/typography'
+import { Heading1, Label } from '@entur/typography'
 import { CreateFolder } from '../components/CreateFolder'
 import { CreateBoard } from '../components/CreateBoard'
 import { countAllBoards } from './utils/actions'
-import leafs from 'assets/illustrations/leafs.svg'
-import Image from 'next/image'
+import EmptyOverview from './components/EmptyOverview'
 
 initializeAdminApp()
 
@@ -43,17 +42,7 @@ async function FoldersAndBoardsPage() {
 
             <div className="gap-4">
                 {elementsListCount === 0 ? (
-                    <>
-                        <Image
-                            src={leafs}
-                            alt=""
-                            className="h-1/4 w-1/4 mx-auto"
-                        />
-                        <Heading4 className="text-center">
-                            Her var det tomt gitt! Start med å opprette en mappe
-                            eller en tavle
-                        </Heading4>
-                    </>
+                    <EmptyOverview text="Her var det tomt gitt! Start med å opprette en mappe eller en tavle" />
                 ) : (
                     <>
                         <Search />

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -13,6 +13,8 @@ import { Heading1, Heading4, Label } from '@entur/typography'
 import { CreateFolder } from '../components/CreateFolder'
 import { CreateBoard } from '../components/CreateBoard'
 import { countAllBoards } from './utils/actions'
+import leafs from 'assets/illustrations/leafs.svg'
+import Image from 'next/image'
 
 initializeAdminApp()
 
@@ -27,6 +29,7 @@ async function FoldersAndBoardsPage() {
     const folders = await getOrganizationsForUser()
     const privateBoards = await getPrivateBoardsForUser()
     const count = await countAllBoards(folders, privateBoards)
+    const elementsListCount = privateBoards.length + folders.length
 
     return (
         <div className="flex flex-col gap-8 container pb-20">
@@ -39,11 +42,18 @@ async function FoldersAndBoardsPage() {
             </div>
 
             <div className="gap-4">
-                {count === 0 ? (
-                    <Heading4 className="text-center">
-                        Oisann, her var det tomt! Start med å lage en mappe
-                        eller en tavle!
-                    </Heading4>
+                {elementsListCount === 0 ? (
+                    <>
+                        <Image
+                            src={leafs}
+                            alt=""
+                            className="h-1/4 w-1/4 mx-auto"
+                        />
+                        <Heading4 className="text-center">
+                            Oisann, her var det tomt! Start med å lage en mappe
+                            eller en tavle!
+                        </Heading4>
+                    </>
                 ) : (
                     <>
                         <Search />

--- a/tavla/app/help/components/Questions.tsx
+++ b/tavla/app/help/components/Questions.tsx
@@ -79,16 +79,6 @@ function Questions() {
                 du ønsker å bruke - du vil fortsatt ha tilgang til alle dine
                 tavler og mapper med begge metoder.
             </AccordionItem>
-            <AccordionItem title="Hvordan setter jeg opp Tavla hos meg?">
-                Se guiden vår{' '}
-                <Link
-                    href="https://www.kakadu.no/entur/slik-oppretter-du-en-tavle"
-                    className="underline"
-                >
-                    her
-                </Link>{' '}
-                på hvordan du lager en avgangstavle.
-            </AccordionItem>
         </Accordion>
     )
 }


### PR DESCRIPTION
## 🥅 Motivasjon

Bedre brukeropplevelse - det skal ikke være mulig å søke eller se tabellen når listen er tom. Hvis listen er tom så viser vi en infomelding som sier at det er tomt her. 

## ✨ Endringer

- [x] "Opprett tavle" som primary-knapp
- [x] Legg til empty overview på både "oversikt" og "mapper"
  - [x] Sjekk på om listen er tom - om den er det, vis en infomelding
  - [x] Slengt på et kos bilde - feks. av disse bladene
<img width="208" alt="Screenshot 2025-05-14 at 15 56 57" src="https://github.com/user-attachments/assets/e43b2451-c9bf-4d47-9863-ac9ff0231bbf" />

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1727" alt="Screenshot 2025-05-14 at 14 47 39" src="https://github.com/user-attachments/assets/227b5499-f6c5-4ee7-9796-4fb4f3c25849" /> | <img width="1728" alt="Screenshot 2025-05-20 at 08 57 55" src="https://github.com/user-attachments/assets/e9546f32-0feb-44d7-bf1c-1cb02ee534de" /> |
| <img width="1728" alt="Screenshot 2025-05-15 at 13 09 23" src="https://github.com/user-attachments/assets/005dbd9a-3ce1-429a-92b0-c3ee2cb5a825" /> | <img width="1728" alt="Screenshot 2025-05-20 at 08 58 16" src="https://github.com/user-attachments/assets/08a6fd30-dd53-4615-b0e8-4ba1ca321fd5" /> |
