### PR TITLE
fix(rediger): remove written input when select element is selected

### DIFF
--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -39,6 +39,13 @@ function TileSelector({
     const posthog = usePostHog()
 
     const [state, setFormError] = useState<TFormFeedback | undefined>()
+
+    const handleCountyChange = (
+        newSelectedCounties: typeof selectedCounties,
+    ) => {
+        setSelectedCounties(newSelectedCounties)
+    }
+
     return (
         <form
             className="flex flex-col lg:flex-row gap-4 mr-6 w-full"
@@ -65,7 +72,8 @@ function TileSelector({
                     label="Fylker (valgfritt)"
                     items={counties}
                     selectedItems={selectedCounties}
-                    onChange={setSelectedCounties}
+                    onChange={handleCountyChange}
+                    clearInputOnSelect={true}
                     prepend={<SearchIcon aria-hidden />}
                     maxChips={2}
                     hideSelectAll


### PR DESCRIPTION
## 🥅 Motivasjon

Forbedre brukeropplevelsen til brukeren 

## ✨ Endringer

- [x] Fjerne skrevet input når et element i select-listen er valgt, men behold cursor/fokus

## 📸 Screenshots

#### Før
https://github.com/user-attachments/assets/0059f500-8364-4656-92be-148828d13219

#### Etter
https://github.com/user-attachments/assets/3851df13-ba4a-40dd-a486-a1c436eca471