### PR TITLE
fix(opprett tavle): remove autocomple on tavle-name

### DIFF
--- a/tavla/app/(admin)/components/CreateBoard/NameAndOrganizationSelector.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/NameAndOrganizationSelector.tsx
@@ -32,6 +32,7 @@ function NameAndOrganizationSelector({ folder }: { folder?: TOrganization }) {
                 name="name"
                 maxLength={50}
                 required
+                autoComplete="off"
                 {...getFormFeedbackForField('name', state)}
             />
 


### PR DESCRIPTION
## 🥅 Motivasjon

Fjern autocomplete der det er unødvendig slik at ikke brukeren tenker informasjonen lagres/hentes fra andre steder

## ✨ Endringer

- [x] Fjern autocomplete på "Opprett tavle" - "Navn"