### PR TITLE
fix(menu): changed from close to setIsOpen(false)

### DIFF
--- a/tavla/app/(admin)/components/SideNavBar.tsx
+++ b/tavla/app/(admin)/components/SideNavBar.tsx
@@ -35,7 +35,9 @@ function SideNavBar({ loggedIn }: { loggedIn: boolean }) {
             >
                 <IconButton
                     aria-label="Lukk"
-                    onClick={close}
+                    onClick={() => {
+                        setIsOpen(false)
+                    }}
                     className="absolute top-4 right-4"
                 >
                     <CloseIcon />


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Fjerne feilmelding i Sentry som dukker opp når brukere trykker på lukk i mobilmenyen

## ✨ Endringer

- [x] Byttet fra ```close``` til ```() => {setIsOpen(false)}```for å fjerne feilmelding om at close ikke er definert (fordi den ikke var det)

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari
- [ ] UU-sjekk/gjennomgang
- [x] Skrevet eventuell dokumentasjon/tester
- [x] ...
