### PR TITLE
chore(): disable tracking while waiting for cookies

### DIFF
--- a/tavla/app/providers.tsx
+++ b/tavla/app/providers.tsx
@@ -9,6 +9,7 @@ if (typeof window !== 'undefined') {
         api_host: 'https://eu.posthog.com',
         capture_pageview: false, // This will be done manually
         autocapture: false, // We will capture manually
+        opt_out_capturing_by_default: true,
     })
 }
 

--- a/tavla/sentry.client.config.ts
+++ b/tavla/sentry.client.config.ts
@@ -9,5 +9,5 @@ Sentry.init({
 
     tracesSampleRate: 1,
 
-    enabled: process.env.NODE_ENV !== 'development',
+    enabled: false, //process.env.NODE_ENV !== 'development',
 })


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->

Vi vil ikke samle inn data fra brukeren mens vi venter på å få implementert cookie-consent, så vi disabler sentry og posthog. 

## ✨ Endringer

- [x] Disabler sentry
- [x] Disabler posthog

## ✅ Sjekkliste

- [ ] Skru det på igjen når vi har implementert cookiebanner
