### PR TITLE
fix(clock): add timezone and format

### DIFF
--- a/tavla/src/Shared/components/Clock/index.tsx
+++ b/tavla/src/Shared/components/Clock/index.tsx
@@ -1,17 +1,24 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { formatTimeStamp } from 'utils/time'
 
 function Clock() {
     const [currentTime, setCurrentTime] = useState<string>()
 
     useEffect(() => {
-        setCurrentTime(formatTimeStamp(Date.now()))
+        const formatTime = () => {
+            const now = new Date()
+            return new Intl.DateTimeFormat('en-GB', {
+                hour: '2-digit',
+                minute: '2-digit',
+                // second: '2-digit',
+                hour12: false,
+                timeZone: 'Europe/Oslo',
+            }).format(now)
+        }
 
-        const intervalId = setInterval(
-            () => setCurrentTime(formatTimeStamp(Date.now())),
-            1000,
-        )
+        setCurrentTime(formatTime())
+
+        const intervalId = setInterval(() => setCurrentTime(formatTime()), 1000)
         return () => clearInterval(intervalId)
     }, [])
 

--- a/tavla/src/Shared/components/Clock/index.tsx
+++ b/tavla/src/Shared/components/Clock/index.tsx
@@ -10,7 +10,6 @@ function Clock() {
             return new Intl.DateTimeFormat('en-GB', {
                 hour: '2-digit',
                 minute: '2-digit',
-                // second: '2-digit',
                 hour12: false,
                 timeZone: 'Europe/Oslo',
             }).format(now)


### PR DESCRIPTION
## 🥅 Motivasjon

Klokken går feil på noen tavler - brukerinnspill

## ✨ Endringer

- [x] Lagt til format med spesielt tidssoneinformasjon satt til Europa/Oslo
- [x] Teste godt - sliter med å endre tidssone på mac - men NÅ gikk det!

<img width="227" alt="Screenshot 2025-05-25 at 22 24 17" src="https://github.com/user-attachments/assets/17b83eed-b05e-4dca-9fb8-e2da9c04c9d6" /> 
<img width="487" alt="Screenshot 2025-05-25 at 22 23 55" src="https://github.com/user-attachments/assets/4ec669c9-a174-45f9-ae1d-d2066b31e095" />
