### PR TITLE
fix(): text in tavla is no longer cut

### DIFF
--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -22,15 +22,19 @@ function Destination({ deviations = true }: { deviations?: boolean }) {
         <div className="grow overflow-hidden">
             <TableColumn title="Destinasjon">
                 {destinations.map((destination) => (
-                    <TableRow key={destination.key}>
-                        <div className="truncate">
+                    <TableRow key={destination.key} className="flex flex-row">
+                        <div className="flex-[7] overflow-ellipsis whitespace-nowrap">
                             {destination.via
                                 ? `${destination.destination} via ${destination.via}`
                                 : destination.destination}
                         </div>
 
                         {deviations && (
-                            <Situations situations={destination.situations} />
+                            <div className="flex-[3]">
+                                <Situations
+                                    situations={destination.situations}
+                                />
+                            </div>
                         )}
                     </TableRow>
                 ))}

--- a/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
@@ -17,11 +17,13 @@ function Situation({
     if (!situationText) return null
 
     return (
-        <div className="flex items-center text-[0.65em] text-warning">
+        <div className="mt-[0.1em] flex items-center text-[0.65em] text-warning">
             <div className="mr-[0.1em] flex items-center fill-warning text-[1.8em]">
                 <ValidationExclamation />
             </div>
-            <div className="truncate">{situationText}</div>
+            <div className="overflow-ellipsis whitespace-nowrap">
+                {situationText}
+            </div>
         </div>
     )
 }

--- a/tavla/src/Board/scenarios/Table/components/TableRow/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableRow/index.tsx
@@ -1,6 +1,14 @@
-function TableRow({ children }: { children: React.ReactNode }) {
+function TableRow({
+    className,
+    children,
+}: {
+    className?: string
+    children: React.ReactNode
+}) {
     return (
-        <div className="flex h-em-3 items-center border-t border-solid border-t-secondary">
+        <div
+            className={`flex h-em-3 w-full items-center border-t border-solid border-t-secondary ${className || ''}`}
+        >
             <div className="mx-em-0.25 w-full">{children}</div>
         </div>
     )


### PR DESCRIPTION
## 🥅 Motivasjon

Destinasjon i Tavla kuttes horisontalt på topp og bunn

## ✨ Endringer

- [x] Fjernet "truncate" og byttet det ut med whitespace-nowrap overflow-ellipsis som en midlertidig fix
<img width="229" alt="Screenshot 2025-05-26 at 09 59 41" src="https://github.com/user-attachments/assets/d6042782-77c0-4861-8388-e98aedd9b11f" />

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1371" alt="Screenshot 2025-05-26 at 10 01 40" src="https://github.com/user-attachments/assets/2b133967-6378-4292-8d96-7ce638fa8154" /> | <img width="1364" alt="Screenshot 2025-05-26 at 10 00 22" src="https://github.com/user-attachments/assets/3e3be3c9-673b-4da0-a20c-1a5b8ea8c807" /> |

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari - ser likt ut i de andre, men gjerne test dere også!
- [ ] Teste på ulike skjermer i BrowserStack 
