### PR TITLE
chore(faq): update safari version

### DIFF
--- a/tavla/app/help/components/Questions.tsx
+++ b/tavla/app/help/components/Questions.tsx
@@ -34,7 +34,7 @@ function Questions() {
                 Vi støtter helt ned til disse versjonene og oppover:
                 <ListItem>Chromium 49</ListItem>
                 <ListItem>Firefox 52</ListItem>
-                <ListItem>Safari 8.1</ListItem>
+                <ListItem>Safari 10.1</ListItem>
                 <ListItem>Edge 15</ListItem>
                 <ListItem>Opera 36</ListItem>
                 Det kan hende vi støtter versjoner lengre ned, men Tavla skal


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->

I FAQ-siden oppgir vi at vi støtter nettlesere helt ned til Safari 8.1, dette stemmer ikke.

## ✨ Endringer

Endret fra "Safari 8.1" til "Safari 10.1" 🤓
