### PR TITLE
chore(migrations): document migration scripts

### DIFF
--- a/tavla/migrations/scripts/001_migrate_footer.py
+++ b/tavla/migrations/scripts/001_migrate_footer.py
@@ -1,3 +1,19 @@
+"""
+Purpose: Migrate footer from organizations to boards
+
+Description:
+    Migrates the footer-value from organization/folder level down to board level as we
+    want to remove the footer-functionality from the organization/folder settings. If
+    a board has setting "override = true" on their footer, then the organization footer
+    value should be migrated to the board footer (and have the existing value overwritten). 
+
+Usage:
+    ./migration run scripts/001_migrate_footer.py
+
+Date: 2025-05-08
+Author: Annika and Silje
+"""
+
 from google.cloud import firestore
 
 import init
@@ -5,7 +21,8 @@ import init
 organizations = "organizations"
 boards = "boards"
 
-# Each migration has to be run through a firestore transaction
+# Each migration should to be run through a firestore transaction to ensure that no
+# migrations are halfway done. Ensures either complete failure or complete success.
 @firestore.transactional
 def update_board_footer(transaction, board_ref, org_footer, log_file):
     snapshot = board_ref.get(transaction=transaction)
@@ -24,7 +41,8 @@ def update_board_footer(transaction, board_ref, org_footer, log_file):
         })
         log_file.write(f"✅ Updating board '{board_ref.id}', board footer: '{footer.get("footer")}' -> organization footer: '{org_footer}'\n")
 
-# Reads through the database 
+# Reads through the database and creates a log-file, runs a transaction if all
+# requirements are met
 def migrate_footer(db: firestore.Client):
     org_collection = db.collection(organizations).stream()
     board_collection = db.collection(boards)
@@ -50,7 +68,7 @@ def migrate_footer(db: firestore.Client):
                 except Exception as e: 
                     log_file.write(f"❌ failed to update board '{board_id}': {e}\n")
 
-# Init the database connection and run the specified migration definition
+# Inits the database connection and runs the migration script
 def migrate():
     db = init.local()
     print(f"db: {db.project}, {db._emulator_host}")

--- a/tavla/migrations/scripts/002_read_tile_column_count.py
+++ b/tavla/migrations/scripts/002_read_tile_column_count.py
@@ -1,9 +1,27 @@
+"""
+Purpose: Count number of tiles in each board
+
+Description:
+    This counts the number of boards with more than one tile, and that does not
+    have identical columns. Used as a measure of how much the customisable 
+    columns functionality is used. 
+
+Usage:
+    ./migration run scripts/002_read_tile_column_count.py
+
+Date: 2025-05-16
+Author: Annika
+"""
+
 from google.cloud import firestore
 
 import init
 
 boards = "boards"
 
+# Reads through the values in the database and increments the correct
+# counts when the correct requirements are met.
+# No transaction needed as we are only reading values from the database.
 def read_columns(db: firestore.Client): 
     board_collection = db.collection(boards).stream()
     total_boards = 0

--- a/tavla/migrations/scripts/init.py
+++ b/tavla/migrations/scripts/init.py
@@ -1,3 +1,20 @@
+"""
+Purpose: Init-functions overview
+
+Description:
+    Gathers all init-functions in a single file, to avoid duplicate code. This provides easy
+    access to all environments through imports. 
+    NB! Needs access to service keys (json format) to be able to connect to the different 
+    databases, see README for further info. 
+
+Usage:
+    import init
+    db = init.dev()
+
+Date: 2025-05-16
+Author: Annika and Silje
+"""
+
 import os
 import firebase_admin
 from firebase_admin import credentials

--- a/tavla/migrations/scripts/test.py
+++ b/tavla/migrations/scripts/test.py
@@ -1,3 +1,16 @@
+"""
+Purpose: Virtual environment running check
+
+Description:
+    Check if the virtual environment is up and able to run scripts. 
+
+Usage:
+    ./migration run scripts/rename_user_field.py
+
+Date: 2025-05-08
+Author: Annika and Silje
+"""
+
 def test():
     print(f"A very simple test is working as intended!! 🎉")
 


### PR DESCRIPTION
## 🥅 Motivasjon
<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->

Vi ønsker å flytte en del av dokumenteringen av migreringsjobbene fra Confluence tettere opp til koden. Det gjør det lettere å forholde seg til det tekniske på ett sted, og det teoretiske på et annet sted. 

## ✨ Endringer

Lagt til docstrings for bedre dokumentering av bakgrunnen for hver migreringsjobb (og script). 
Lagt til flere kommentarer i selve koden. 

## TODO: 

-  [x] Skal vi ha med datoer??
-  [x] Se igjennom kommentarer her: https://enturas.atlassian.net/wiki/spaces/TT1/pages/5358420081/Migrere+databaser