### PR TITLE
chore(): add tailwind prettier

### DIFF
--- a/tavla/.prettierrc.js
+++ b/tavla/.prettierrc.js
@@ -1,6 +1,15 @@
-module.exports = {
+// prettier.config.js, .prettierrc.js, prettier.config.cjs, or .prettierrc.cjs
+
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
+const config = {
     trailingComma: 'all',
     tabWidth: 4,
     semi: false,
     singleQuote: true,
+    plugins: ['prettier-plugin-tailwindcss'],
 }
+
+module.exports = config

--- a/tavla/app/(admin)/components/CreateBoard/NameAndOrganizationSelector.tsx
+++ b/tavla/app/(admin)/components/CreateBoard/NameAndOrganizationSelector.tsx
@@ -52,7 +52,7 @@ function NameAndOrganizationSelector({ folder }: { folder?: TOrganization }) {
                 <FormError {...getFormFeedbackForField('general', state)} />
             </div>
 
-            <div className="flex flex-row mt-8 justify-start">
+            <div className="mt-8 flex flex-row justify-start">
                 <SubmitButton variant="primary" className="max-sm:w-full">
                     Opprett tavle
                 </SubmitButton>

--- a/tavla/app/(admin)/components/CreateFolder/index.tsx
+++ b/tavla/app/(admin)/components/CreateFolder/index.tsx
@@ -36,7 +36,7 @@ function CreateFolder() {
                 <IconButton
                     aria-label="Lukk"
                     onClick={close}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>
@@ -48,7 +48,7 @@ function CreateFolder() {
                     tavleoversikten.
                 </Paragraph>
                 <form
-                    className="flex flex-col w-full"
+                    className="flex w-full flex-col"
                     action={formAction}
                     aria-live="polite"
                     aria-relevant="all"
@@ -68,7 +68,7 @@ function CreateFolder() {
                         {...getFormFeedbackForField('name', state)}
                     />
                     <FormError {...getFormFeedbackForField('general', state)} />
-                    <ButtonGroup className="flex flex-row gap-4 mt-8">
+                    <ButtonGroup className="mt-8 flex flex-row gap-4">
                         <div className="w-1/2">
                             <SubmitButton
                                 variant="primary"

--- a/tavla/app/(admin)/components/Delete/index.tsx
+++ b/tavla/app/(admin)/components/Delete/index.tsx
@@ -82,11 +82,11 @@ function DeleteFolder({
                         close()
                         setNameError(undefined)
                     }}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>
-                <Image src={ducks} alt="" className="h-1/2 w-1/2 mx-auto" />
+                <Image src={ducks} alt="" className="mx-auto h-1/2 w-1/2" />
                 <Heading3 margin="bottom" as="h1">
                     Slett mappe
                 </Heading3>
@@ -94,7 +94,7 @@ function DeleteFolder({
                     {`Er du sikker på at du vil slette mappen 
                     "${organization.name}"? Alle tavlene i mappen vil også bli slettet.`}
                 </Paragraph>
-                <SubParagraph className="font-medium text-left">
+                <SubParagraph className="text-left font-medium">
                     Bekreft ved å skrive inn navnet på mappen
                 </SubParagraph>
                 <form action={submit} aria-live="polite" aria-relevant="all">
@@ -110,7 +110,7 @@ function DeleteFolder({
                         {...getFormFeedbackForField('name', nameError)}
                     />
                     <FormError {...getFormFeedbackForField('general', state)} />
-                    <ButtonGroup className="flex flex-row mt-8">
+                    <ButtonGroup className="mt-8 flex flex-row">
                         <SubmitButton
                             variant="primary"
                             aria-label="Ja, slett"

--- a/tavla/app/(admin)/components/DeleteAccount/index.tsx
+++ b/tavla/app/(admin)/components/DeleteAccount/index.tsx
@@ -56,7 +56,7 @@ function DeleteAccount() {
                 <IconButton
                     aria-label="Lukk"
                     onClick={close}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>
@@ -77,7 +77,7 @@ function DeleteAccount() {
                     </Paragraph>
 
                     <form action={deleteAccountAction}>
-                        <SubParagraph className="font-medium text-left">
+                        <SubParagraph className="text-left font-medium">
                             Bekreft ved å skrive inn din e-postadresse
                         </SubParagraph>
                         <ClientOnlyTextField
@@ -92,7 +92,7 @@ function DeleteAccount() {
                             {...getFormFeedbackForField('general', formError)}
                         />
 
-                        <ButtonGroup className="flex flex-row mt-8">
+                        <ButtonGroup className="mt-8 flex flex-row">
                             <SubmitButton
                                 variant="primary"
                                 aria-label="Ja, slett"

--- a/tavla/app/(admin)/components/Footer/index.tsx
+++ b/tavla/app/(admin)/components/Footer/index.tsx
@@ -11,12 +11,12 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
     const posthog = usePostHog()
     return (
         <footer className="eds-contrast">
-            <div className="container pt-16 pb-20">
+            <div className="container pb-20 pt-16">
                 <Image src={TavlaLogo} alt="Entur Tavla logo" />
-                <div className="flex flex-col sm:flex-row justify-between">
+                <div className="flex flex-col justify-between sm:flex-row">
                     <div>
                         <Heading3 as="h2">Entur AS</Heading3>
-                        <Paragraph className=" items-center">
+                        <Paragraph className="items-center">
                             Rådhusgata 5, 0151 Oslo
                             <br aria-hidden />
                             Postboks 1554, 0117 Oslo
@@ -27,7 +27,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                             917 422 575
                         </Paragraph>
                         <Paragraph
-                            className="items-center flex flex-row gap-1"
+                            className="flex flex-row items-center gap-1"
                             margin="none"
                         >
                             <EnturLink href="https://www.entur.org/kontakt-oss/">
@@ -35,7 +35,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                             </EnturLink>
                             <ExternalIcon aria-hidden className="!top-0" />
                         </Paragraph>
-                        <Paragraph className="items-center flex flex-row gap-1">
+                        <Paragraph className="flex flex-row items-center gap-1">
                             <EnturLink
                                 href="mailto:tavla@entur.org"
                                 target="_blank"
@@ -63,7 +63,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                 Ofte stilte spørsmål
                             </EnturLink>
                         </div>
-                        <div className="flex flex-row gap-1 items-center">
+                        <div className="flex flex-row items-center gap-1">
                             <EnturLink
                                 as={Link}
                                 href="https://uustatus.no/nb/erklaringer/publisert/ffb3d21b-fbb4-48ed-9043-bb2a904f3143"
@@ -74,7 +74,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                             <ExternalIcon aria-hidden />
                         </div>
                         {loggedIn && (
-                            <div className="flex flex-row gap-1 items-center">
+                            <div className="flex flex-row items-center gap-1">
                                 <DeleteAccount />
                             </div>
                         )}
@@ -83,7 +83,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                 Personvernerklæring
                             </EnturLink>
                         </div>
-                        <div className="flex flex-row gap-1 items-center">
+                        <div className="flex flex-row items-center gap-1">
                             <EnturLink
                                 href="https://github.com/entur/tavla"
                                 target="_blank"

--- a/tavla/app/(admin)/components/Login/Create.tsx
+++ b/tavla/app/(admin)/components/Login/Create.tsx
@@ -63,7 +63,7 @@ function Create() {
             <Heading3 margin="bottom" as="h1">
                 Opprett ny bruker
             </Heading3>
-            <form className="flex flex-col gap-4 w-full" action={action}>
+            <form className="flex w-full flex-col gap-4" action={action}>
                 <div>
                     <ClientOnlyTextField
                         name="email"
@@ -115,9 +115,9 @@ function Create() {
                     </div>
                 </ButtonGroup>
             </form>
-            <div className="border-2 rounded-sm w-full mb-8 mt-4"></div>
+            <div className="mb-8 mt-4 w-full rounded-sm border-2"></div>
             <Google />
-            <Paragraph className="text-center mt-10" margin="none">
+            <Paragraph className="mt-10 text-center" margin="none">
                 Har du allerede en bruker?{' '}
                 <Link className="underline" href="?login=email">
                     Logg inn

--- a/tavla/app/(admin)/components/Login/Email.tsx
+++ b/tavla/app/(admin)/components/Login/Email.tsx
@@ -86,7 +86,7 @@ function Email() {
             <Heading3 margin="bottom" as="h1">
                 Logg inn med e-post
             </Heading3>
-            <form className="flex flex-col gap-4 w-full" action={action}>
+            <form className="flex w-full flex-col gap-4" action={action}>
                 <div>
                     <ClientOnlyTextField
                         name="email"
@@ -113,8 +113,8 @@ function Email() {
                         Glemt passord?
                     </Link>
                 </p>
-                <ButtonGroup className="flex sm:flex-row flex-col gap-4 pb-4">
-                    <div className="sm:w-1/2 w-full">
+                <ButtonGroup className="flex flex-col gap-4 pb-4 sm:flex-row">
+                    <div className="w-full sm:w-1/2">
                         <SubmitButton
                             variant="primary"
                             width="fluid"
@@ -129,7 +129,7 @@ function Email() {
                         </SubmitButton>
                     </div>
 
-                    <div className="sm:w-1/2 w-full">
+                    <div className="w-full sm:w-1/2">
                         <Button
                             type="button"
                             as={Link}
@@ -143,9 +143,9 @@ function Email() {
                     </div>
                 </ButtonGroup>
             </form>
-            <div className="border-2 rounded-sm w-full mb-8 mt-4"></div>
+            <div className="mb-8 mt-4 w-full rounded-sm border-2"></div>
             <Google />
-            <Paragraph className="text-center mt-10" margin="none">
+            <Paragraph className="mt-10 text-center" margin="none">
                 Har du ikke en bruker?{' '}
                 <Link className="underline" href={getPathWithParams('create')}>
                     Opprett bruker

--- a/tavla/app/(admin)/components/Login/Google.tsx
+++ b/tavla/app/(admin)/components/Login/Google.tsx
@@ -62,12 +62,12 @@ export default function Google() {
     }
 
     return (
-        <div className="w-full [&>div]:!w-full items-center justify-center flex flex-col mb-4">
+        <div className="mb-4 flex w-full flex-col items-center justify-center [&>div]:!w-full">
             {isLoading ? (
                 <Paragraph className="text-center">Vent litt...</Paragraph>
             ) : (
                 <GoogleButton
-                    className="w-full mb-4"
+                    className="mb-4 w-full"
                     type="light"
                     label="Logg inn med Google"
                     onClick={() => {

--- a/tavla/app/(admin)/components/Login/Reset.tsx
+++ b/tavla/app/(admin)/components/Login/Reset.tsx
@@ -34,7 +34,7 @@ function Reset() {
     }
     const [state, action] = useActionState(submit, undefined)
     return (
-        <div className="flex flex-col text-center items-center">
+        <div className="flex flex-col items-center text-center">
             <Image
                 src={musk}
                 aria-hidden="true"
@@ -48,7 +48,7 @@ function Reset() {
                 Skriv inn e-posten du brukte for å opprette brukeren, så sender
                 vi deg en lenke for å tilbakestille passordet ditt.
             </Paragraph>
-            <form className="flex flex-col gap-4 w-full" action={action}>
+            <form className="flex w-full flex-col gap-4" action={action}>
                 <div>
                     <TextField
                         name="email"

--- a/tavla/app/(admin)/components/Login/index.tsx
+++ b/tavla/app/(admin)/components/Login/index.tsx
@@ -23,7 +23,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 onClick={async () => {
                     await logout()
                 }}
-                className="gap-4 !hidden md:!flex"
+                className="!hidden gap-4 md:!flex"
             >
                 <LogOutIcon />
                 Logg ut
@@ -51,7 +51,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 <IconButton
                     aria-label="Lukk"
                     onClick={() => router.push(pathname ?? '/')}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>

--- a/tavla/app/(admin)/components/MobileNavbar.tsx
+++ b/tavla/app/(admin)/components/MobileNavbar.tsx
@@ -22,7 +22,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
         <div className="block md:hidden">
             <IconButton
                 onClick={() => setIsOpen(!isOpen)}
-                className="!bg-contrast !rounded-full !p-3"
+                className="!rounded-full !bg-contrast !p-3"
             >
                 <MenuIcon content="Meny" color="background" />
             </IconButton>
@@ -32,23 +32,23 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                 onDismiss={() => setIsOpen(false)}
                 size="small"
                 closeLabel="Lukk meny"
-                className="!h-full !w-9/12 !fixed !top-0 !left-0 !max-h-full !rounded-none !p-0 overflow-visible"
+                className="!fixed !left-0 !top-0 !h-full !max-h-full !w-9/12 overflow-visible !rounded-none !p-0"
             >
                 <IconButton
                     aria-label="Lukk"
                     onClick={() => {
                         setIsOpen(false)
                     }}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>
-                <SideNavigation className="!pt-10 !bg-primary">
+                <SideNavigation className="!bg-primary !pt-10">
                     <div className="pl-10">
                         <Link href="/" aria-label="Tilbake til landingssiden">
                             <Image src={TavlaLogoBlue} height={22} alt="" />
                         </Link>
-                        <Heading2 className="!mt-16 !mb-4">Meny</Heading2>
+                        <Heading2 className="!mb-4 !mt-16">Meny</Heading2>
                     </div>
 
                     <div className="bg-secondary">
@@ -61,7 +61,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
 
                         <SideNavigationItem
                             as={Button}
-                            className="[&>button]:justify-start [&>button]:px-10 [&>button]:bg-secondary [&>button]:text-primary"
+                            className="[&>button]:justify-start [&>button]:bg-secondary [&>button]:px-10 [&>button]:text-primary"
                             onClick={async () => {
                                 setIsOpen(false)
                                 await logout()
@@ -73,7 +73,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                 </SideNavigation>
                 <IconButton
                     onClick={() => setIsOpen(false)}
-                    className="!bg-contrast !rounded-full !p-3 !absolute !bottom-[10%] !right-5"
+                    className="!absolute !bottom-[10%] !right-5 !rounded-full !bg-contrast !p-3"
                 >
                     <LeftArrowIcon color="background" />
                 </IconButton>

--- a/tavla/app/(admin)/components/Navbar.tsx
+++ b/tavla/app/(admin)/components/Navbar.tsx
@@ -13,7 +13,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
     const posthog = usePostHog()
 
     return (
-        <nav className="container flex flex-row justify-between items-center py-8">
+        <nav className="container flex flex-row items-center justify-between py-8">
             <Link href="/" aria-label="Tilbake til landingssiden">
                 <Image src={TavlaLogoBlue} height={32} alt="" />
             </Link>
@@ -21,7 +21,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                 <MobileNavbar loggedIn={loggedIn} />
                 <div className="flex flex-row sm:gap-10">
                     {loggedIn ? (
-                        <div className="flex-row hidden md:flex gap-4">
+                        <div className="hidden flex-row gap-4 md:flex">
                             <TopNavigationItem
                                 active={pathname?.includes('/oversikt')}
                                 as={Link}

--- a/tavla/app/(admin)/components/TileSelector/index.tsx
+++ b/tavla/app/(admin)/components/TileSelector/index.tsx
@@ -48,7 +48,7 @@ function TileSelector({
 
     return (
         <form
-            className="flex flex-col lg:flex-row gap-4 mr-6 w-full"
+            className="mr-6 flex w-full flex-col gap-4 lg:flex-row"
             action={action}
             onSubmit={(event) => {
                 if (!selectedStopPlace) {

--- a/tavla/app/(admin)/mapper/[id]/page.tsx
+++ b/tavla/app/(admin)/mapper/[id]/page.tsx
@@ -68,10 +68,10 @@ async function FolderPage(props: TProps) {
     )
 
     return (
-        <div className="flex flex-col gap-4 container pb-20">
+        <div className="container flex flex-col gap-4 pb-20">
             <BreadcrumbsNav folder={folder} />
-            <div className="flex flex-col lg:flex-row justify-between">
-                <Heading1 className="flex flex-row gap-4 items-center">
+            <div className="flex flex-col justify-between lg:flex-row">
+                <Heading1 className="flex flex-row items-center gap-4">
                     <FolderIcon aria-label="Mappe-ikon" className="!top-0" />
                     {folder.name}
                 </Heading1>

--- a/tavla/app/(admin)/mapper/components/MemberAdministration/InviteUser.tsx
+++ b/tavla/app/(admin)/mapper/components/MemberAdministration/InviteUser.tsx
@@ -21,9 +21,9 @@ function InviteUser({ oid }: { oid?: TOrganizationID }) {
     return (
         <form action={action} ref={formRef}>
             <SubParagraph>Legg til medlem</SubParagraph>
-            <div className="flex flex-col sm:flex-row gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row">
                 <HiddenInput id="oid" value={oid} />
-                <div className="flex flex-col w-full">
+                <div className="flex w-full flex-col">
                     <ClientOnlyTextField
                         name="email"
                         id="email"
@@ -36,7 +36,7 @@ function InviteUser({ oid }: { oid?: TOrganizationID }) {
                     aria-label="Legg til medlem"
                     variant="secondary"
                     width="fluid"
-                    className="w-full sm:max-w-48 mb-4"
+                    className="mb-4 w-full sm:max-w-48"
                 >
                     Legg til medlem
                 </SubmitButton>

--- a/tavla/app/(admin)/mapper/components/MemberAdministration/MemberList.tsx
+++ b/tavla/app/(admin)/mapper/components/MemberAdministration/MemberList.tsx
@@ -12,26 +12,26 @@ function MemberList({
 }) {
     return (
         <div>
-            <div className="grid items-center overflow-x-auto grid-cols-3">
-                <p className="flex items-center gap-1 bg-grey70 pl-2 h-10 font-medium py-0 px-0.5 col-span-2">
+            <div className="grid grid-cols-3 items-center overflow-x-auto">
+                <p className="col-span-2 flex h-10 items-center gap-1 bg-grey70 px-0.5 py-0 pl-2 font-medium">
                     Medlemmer
                 </p>
-                <p className="flex items-center gap-1 bg-grey70 pl-2 h-10 font-medium py-0 px-0.5">
+                <p className="flex h-10 items-center gap-1 bg-grey70 px-0.5 py-0 pl-2 font-medium">
                     Handlinger
                 </p>
             </div>
 
-            <div className="grid items-center overflow-x-auto grid-cols-3 [&>*:nth-child(4n+3)]:bg-grey80 [&>*:nth-child(4n+4)]:bg-grey80">
+            <div className="grid grid-cols-3 items-center overflow-x-auto [&>*:nth-child(4n+3)]:bg-grey80 [&>*:nth-child(4n+4)]:bg-grey80">
                 {members.map((member) => (
                     <>
                         <p
-                            className="content-center pl-2 h-16 py-2 col-span-2"
+                            className="col-span-2 h-16 content-center py-2 pl-2"
                             key={'email' + member.uid}
                         >
                             {member.email}
                         </p>
                         <div
-                            className="content-center pl-2 h-16"
+                            className="h-16 content-center pl-2"
                             key={member.uid}
                         >
                             {member.uid !== currentUserId && (

--- a/tavla/app/(admin)/mapper/components/MemberAdministration/RemoveUserButton.tsx
+++ b/tavla/app/(admin)/mapper/components/MemberAdministration/RemoveUserButton.tsx
@@ -46,7 +46,7 @@ function RemoveUserButton({
                 <IconButton
                     aria-label="Lukk"
                     onClick={close}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>

--- a/tavla/app/(admin)/mapper/components/UploadLogo/LogoInput.tsx
+++ b/tavla/app/(admin)/mapper/components/UploadLogo/LogoInput.tsx
@@ -73,11 +73,11 @@ function LogoInput({ oid }: { oid?: TOrganizationID }) {
     }
 
     return (
-        <form action={submit} className="flex flex-col relative">
+        <form action={submit} className="relative flex flex-col">
             <HiddenInput id="oid" value={oid} />
             <Label
                 htmlFor="logo"
-                className="flex flex-col border-2 rounded border-dashed border-primary  w-full items-center justify-center hover:bg-tertiary p-4"
+                className="flex w-full flex-col items-center justify-center rounded border-2 border-dashed border-primary p-4 hover:bg-tertiary"
             >
                 <Filename fileName={fileName} />
                 <input
@@ -102,16 +102,16 @@ function LogoInput({ oid }: { oid?: TOrganizationID }) {
                 <FormError {...getFormFeedbackForField('general', state)} />
             </div>
             {file && (
-                <div className="flex flex-row justify-between gap-4 mt-4">
+                <div className="mt-4 flex flex-row justify-between gap-4">
                     <SubmitButton
                         variant="primary"
                         aria-label="Last opp logo"
-                        className="w-full justify-center "
+                        className="w-full justify-center"
                     >
                         Last opp logo
                     </SubmitButton>
                     <Button
-                        className="w-full justify-center "
+                        className="w-full justify-center"
                         onClick={clearLogo}
                         aria-label="Avbryt opplastning"
                         variant="secondary"
@@ -128,7 +128,7 @@ function Filename({ fileName }: { fileName?: string }) {
     const { pending } = useFormStatus()
     if (pending)
         return (
-            <div className="flex flex-col w-full h-full items-center">
+            <div className="flex h-full w-full flex-col items-center">
                 <Paragraph>Laster opp logo..</Paragraph>
                 <Loader className="w-full" />
             </div>

--- a/tavla/app/(admin)/mapper/components/UploadLogo/index.tsx
+++ b/tavla/app/(admin)/mapper/components/UploadLogo/index.tsx
@@ -26,7 +26,7 @@ function UploadLogo({ folder }: { folder: TOrganization }) {
                     Velg hvilken logo som skal vises på alle tavlene i mappen.
                 </Paragraph>
                 {folder.logo && (
-                    <div className="relative flex items-center justify-center h-40 bg-black border-2 rounded border-tertiary mb-4">
+                    <div className="relative mb-4 flex h-40 items-center justify-center rounded border-2 border-tertiary bg-black">
                         <Image
                             src={folder.logo}
                             alt="Mappelogo"

--- a/tavla/app/(admin)/oversikt/components/Column/ColumnWrapper.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/ColumnWrapper.tsx
@@ -10,7 +10,7 @@ function ColumnWrapper({
     return (
         <div
             id={column}
-            className="pl-2 flex flex-row items-center h-16 table-custom-nth-child"
+            className="table-custom-nth-child flex h-16 flex-row items-center pl-2"
         >
             {children}
         </div>

--- a/tavla/app/(admin)/oversikt/components/Column/Delete.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Delete.tsx
@@ -44,12 +44,12 @@ function Delete({ board, type }: { board: TBoard; type?: 'icon' | 'button' }) {
                 size="small"
                 onDismiss={close}
                 closeLabel="Avbryt sletting"
-                className="flex flex-col justify-start items-center text-center"
+                className="flex flex-col items-center justify-start text-center"
             >
                 <IconButton
                     aria-label="Lukk"
                     onClick={close}
-                    className="absolute top-4 right-4"
+                    className="absolute right-4 top-4"
                 >
                     <CloseIcon />
                 </IconButton>

--- a/tavla/app/(admin)/oversikt/components/Column/Move.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Move.tsx
@@ -87,7 +87,7 @@ function Move({ board }: { board: TBoard }) {
                     />
                     <FormError {...getFormFeedbackForField('general', error)} />
 
-                    <div className="flex flex-row mt-8 justify-start">
+                    <div className="mt-8 flex flex-row justify-start">
                         <SubmitButton
                             variant="primary"
                             className="max-sm:w-full"

--- a/tavla/app/(admin)/oversikt/components/Column/Name.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Name.tsx
@@ -14,7 +14,7 @@ import { getNumberOfBoardsInFolder } from '../../utils/actions'
 function BoardName({ board }: { board: TBoard }) {
     return (
         <ColumnWrapper column="name">
-            <div className="flex flex-row gap-2 items-center">
+            <div className="flex flex-row items-center gap-2">
                 <BoardIcon className="!top-0" aria-label="Tavle-ikon" />
                 <Link
                     href={`/tavler/${board.id}/rediger`}
@@ -54,7 +54,7 @@ function FolderName({ folder }: { folder: TOrganization }) {
 
     return (
         <ColumnWrapper column="name">
-            <div className="flex flex-row gap-2 items-center">
+            <div className="flex flex-row items-center gap-2">
                 <FolderIcon className="!top-0" aria-label="Mappe-ikon" />
                 <Link href={`/mapper/${folder.id}`} className="hover:underline">
                     {folder.name ?? DEFAULT_FOLDER_NAME}

--- a/tavla/app/(admin)/oversikt/components/EmptyOverview.tsx
+++ b/tavla/app/(admin)/oversikt/components/EmptyOverview.tsx
@@ -8,8 +8,8 @@ interface EmptyOverviewProps {
 
 const EmptyOverview: React.FC<EmptyOverviewProps> = ({ text }) => {
     return (
-        <div className="flex flex-col items-center justify-center h-full mb-20">
-            <Image src={leafs} alt="" className="h-1/4 w-1/4 mx-auto" />
+        <div className="mb-20 flex h-full flex-col items-center justify-center">
+            <Image src={leafs} alt="" className="mx-auto h-1/4 w-1/4" />
             <Heading4 className="text-center">{text}</Heading4>
         </div>
     )

--- a/tavla/app/(admin)/oversikt/components/TableHeader/ColumnHeader.tsx
+++ b/tavla/app/(admin)/oversikt/components/TableHeader/ColumnHeader.tsx
@@ -12,11 +12,11 @@ function ColumnHeader({ column }: { column: TTableColumn }) {
     return (
         <div
             key={column}
-            className="flex items-center gap-1 bg-grey70 pl-2 h-10"
+            className="flex h-10 items-center gap-1 bg-grey70 pl-2"
         >
             <div
                 id={TableColumns[column]}
-                className="items-center font-medium py-0 px-0.5"
+                className="items-center px-0.5 py-0 font-medium"
                 aria-sort={
                     sort.column === column && sort.type ? sort.type : 'none'
                 }

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -31,8 +31,8 @@ async function FoldersAndBoardsPage() {
     const elementsListCount = privateBoards.length + folders.length
 
     return (
-        <div className="flex flex-col gap-8 container pb-20">
-            <div className="flex max-sm:flex-col flex-row justify-between">
+        <div className="container flex flex-col gap-8 pb-20">
+            <div className="flex flex-row justify-between max-sm:flex-col">
                 <Heading1>Mine tavler</Heading1>
                 <div className="flex flex-row gap-4">
                     <CreateFolder />
@@ -46,7 +46,7 @@ async function FoldersAndBoardsPage() {
                 ) : (
                     <>
                         <Search />
-                        <div className="flex flex-col mt-8">
+                        <div className="mt-8 flex flex-col">
                             <Label>Totalt antall tavler: {count}</Label>
                             <BoardTable
                                 folders={folders}

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/ActionsMenu/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/ActionsMenu/index.tsx
@@ -30,7 +30,7 @@ function OverflowActionsMenu({
 
 function ButtonsMenu({ board, oid }: { board: TBoard; oid?: TOrganizationID }) {
     return (
-        <div className="flex flex-col md:flex-row md:items-center gap-4 md:hidden">
+        <div className="flex flex-col gap-4 md:hidden md:flex-row md:items-center">
             <DuplicateBoard board={board} oid={oid} />
         </div>
     )

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Preview/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Preview/index.tsx
@@ -18,7 +18,7 @@ function Preview({
             data-theme={board?.theme ?? 'dark'}
         >
             <Header theme={board.theme} organizationLogo={organization?.logo} />
-            <div className="md:h-[50rem] h-96">
+            <div className="h-96 md:h-[50rem]">
                 <Board board={board} />
             </div>
             <Footer board={board} logo={organization?.logo !== undefined} />

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/ChoiceChipGroupGeneral.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/ChoiceChipGroupGeneral.tsx
@@ -33,7 +33,7 @@ function ChoiceChipGroupGeneral<T extends string>({
         <div className="flex flex-col gap-1">
             <Heading4 margin="bottom">{label}</Heading4>
             <ChoiceChipGroup
-                className="h-full mb-2"
+                className="mb-2 h-full"
                 name={name}
                 value={selectedValue}
                 onChange={(e) => handleChange(e.target.value as T)}

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/Footer.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/Footer.tsx
@@ -8,8 +8,8 @@ import ClientOnlyTextField from 'app/components/NoSSR/TextField'
 function Footer({ footer }: { footer?: TFooter }) {
     return (
         <div className="flex flex-col">
-            <div className="flex flex-col items-start sm:flex-row justify-between sm:items-center gap-2">
-                <div className="flex flex-row gap-2 items-center">
+            <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
+                <div className="flex flex-row items-center gap-2">
                     <Heading4 margin="bottom">Infomelding</Heading4>
 
                     <Tooltip

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
@@ -50,10 +50,10 @@ function Settings({
     }
 
     return (
-        <div className="rounded-md md:py-8 py-2 md:px-6 px-2 flex flex-col gap-4 bg-background">
+        <div className="flex flex-col gap-4 rounded-md bg-background px-2 py-2 md:px-6 md:py-8">
             <Heading2>Innstillinger</Heading2>
             <form
-                className="grid grid-cols-1 lg:grid-cols-2 gap-8"
+                className="grid grid-cols-1 gap-8 lg:grid-cols-2"
                 onSubmit={submitSettings}
             >
                 <div className="box">
@@ -71,7 +71,7 @@ function Settings({
                 </div>
                 <div className="box">
                     <Heading3 margin="bottom">Tavlevisning </Heading3>
-                    <div className=" flex flex-col gap-4">
+                    <div className="flex flex-col gap-4">
                         <ViewType
                             hasCombinedTiles={
                                 board.combinedTiles ? true : false

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/TransportModeAndLines.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/TransportModeAndLines.tsx
@@ -54,10 +54,10 @@ function TransportModeAndLines({
 
     return (
         <div>
-            <div className="flex flex-row gap-4 items-center justify-start font-semibold">
+            <div className="flex flex-row items-center justify-start gap-4 font-semibold">
                 <TransportIcon
                     transportMode={transportMode}
-                    className="w-8 h-8"
+                    className="h-8 w-8"
                 />
                 {transportModeNames(transportMode)}
             </div>

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
@@ -160,7 +160,7 @@ function TileCard({
 
     if (!lines)
         return (
-            <div className="flex justify-between items-center bg-blue80 p-4 rounded">
+            <div className="flex items-center justify-between rounded bg-blue80 p-4">
                 Laster...
             </div>
         )
@@ -209,15 +209,15 @@ function TileCard({
         <div>
             <div className="flex flex-row">
                 <div
-                    className={`flex justify-between items-center px-6  py-4 bg-blue80 w-full ${
+                    className={`flex w-full items-center justify-between bg-blue80 px-6 py-4 ${
                         isOpen ? 'rounded-t' : 'rounded'
                     }`}
                 >
-                    <div className="flex flex-row gap-4 items-center ">
+                    <div className="flex flex-row items-center gap-4">
                         <Heading3 margin="none">
                             {tile.displayName ?? tile.name}
                         </Heading3>
-                        <div className="hidden sm:flex flex-row gap-4 h-8">
+                        <div className="hidden h-8 flex-row gap-4 sm:flex">
                             {uniqTransportModeIcons}
                         </div>
                     </div>
@@ -233,7 +233,7 @@ function TileCard({
                     </SecondarySquareButton>
                 </div>
                 <div
-                    className={` flex flex-col ${
+                    className={`flex flex-col ${
                         index !== 0 || index !== totalTiles - 1
                             ? 'justify-center gap-2'
                             : 'justify-between'
@@ -270,7 +270,7 @@ function TileCard({
             </div>
             <BaseExpand open={isOpen}>
                 <div
-                    className={`bg-blue90 px-6 mr-14 py-4  ${
+                    className={`mr-14 bg-blue90 px-6 py-4 ${
                         totalTiles == 1 && 'w-full'
                     } rounded-b`}
                 >
@@ -379,7 +379,7 @@ function TileCard({
                             tavlen.
                         </SubParagraph>
                         {isCombined && (
-                            <SubParagraph className="!text-error mb-2">
+                            <SubParagraph className="mb-2 !text-error">
                                 Har du samlet stoppestedene i én liste vil du
                                 ikke ha mulighet til å velge kolonner.
                             </SubParagraph>
@@ -388,7 +388,7 @@ function TileCard({
                             isOpen={isColumnModalOpen}
                             setIsOpen={setIsColumnModalOpen}
                         />
-                        <div className="flex flex-row flex-wrap gap-4 mb-8 mt-2">
+                        <div className="mb-8 mt-2 flex flex-row flex-wrap gap-4">
                             {Object.entries(Columns).map(([key, value]) => {
                                 const columns = isCombined
                                     ? DEFAULT_COMBINED_COLUMNS
@@ -411,7 +411,7 @@ function TileCard({
                         </div>
 
                         <Heading4>Transportmidler og linjer</Heading4>
-                        <div className="flex flex-col md:flex-row gap-4">
+                        <div className="flex flex-col gap-4 md:flex-row">
                             {linesByModeSorted.map(
                                 ({ transportMode, lines }) => (
                                     <TransportModeAndLines
@@ -428,7 +428,7 @@ function TileCard({
                             value={uniqLines.length.toString()}
                         />
 
-                        <div className="flex flex-col md:flex-row justify-start gap-4 mt-8">
+                        <div className="mt-8 flex flex-col justify-start gap-4 md:flex-row">
                             <SubmitButton
                                 variant="primary"
                                 aria-label="lagre valg"
@@ -471,7 +471,7 @@ function TileCard({
                             <IconButton
                                 aria-label="Lukk"
                                 onClick={reset}
-                                className="absolute top-4 right-4"
+                                className="absolute right-4 top-4"
                             >
                                 <CloseIcon />
                             </IconButton>

--- a/tavla/app/(admin)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/page.tsx
@@ -57,13 +57,13 @@ export default async function EditPage(props: TProps) {
 
     return (
         <div className="bg-gray-50">
-            <div className="flex flex-col gap-6 pt-16 container pb-20">
+            <div className="container flex flex-col gap-6 pb-20 pt-16">
                 <BreadcrumbsNav folder={organization} board={board} />
-                <div className="flex flex-col md:flex-row justify-between pb-2">
+                <div className="flex flex-col justify-between pb-2 md:flex-row">
                     <Heading1 margin="top">
                         Rediger {board.meta?.title}
                     </Heading1>
-                    <div className="flex flex-col md:flex-row md:items-center gap-4">
+                    <div className="flex flex-col gap-4 md:flex-row md:items-center">
                         <Open bid={board.id} type="button" />
                         <RefreshButton board={board} />
                         <Delete board={board} type="button" />
@@ -74,7 +74,7 @@ export default async function EditPage(props: TProps) {
                     <Copy bid={board.id} type="button" />
                 </div>
 
-                <div className="bg-background rounded-md py-8 px-6 flex flex-col gap-4">
+                <div className="flex flex-col gap-4 rounded-md bg-background px-6 py-8">
                     <Heading2>Stoppesteder</Heading2>
                     <TileSelector
                         action={async (data: FormData) => {

--- a/tavla/app/components/ContactForm.tsx
+++ b/tavla/app/components/ContactForm.tsx
@@ -53,7 +53,7 @@ function ContactForm() {
     }
     return (
         <div
-            className="flex items-center justify-center w-full xl:w-1/6"
+            className="flex w-full items-center justify-center xl:w-1/6"
             onClick={() =>
                 isOpen ? posthog.capture('CONTACT_FORM_OPENED') : resetForm()
             }
@@ -65,7 +65,7 @@ function ContactForm() {
             >
                 <form
                     action={submit}
-                    className="flex flex-col gap-4  p-4 sm:p-6 "
+                    className="flex flex-col gap-4 p-4 sm:p-6"
                 >
                     <Paragraph as="h2" margin="none" className="font-bold">
                         Vi setter stor pris på tilbakemeldinger og innspill, og

--- a/tavla/app/components/Expandable.tsx
+++ b/tavla/app/components/Expandable.tsx
@@ -15,14 +15,14 @@ function Expandable({
     children: React.ReactNode
 }) {
     return (
-        <div className="fixed bottom-0 right-3 w-full min-w-96 md:w-1/3 max-w-screen-sm z-10 drop-shadow-lg ">
+        <div className="fixed bottom-0 right-3 z-10 w-full min-w-96 max-w-screen-sm drop-shadow-lg md:w-1/3">
             <div
                 onClick={() => setIsOpen(!isOpen)}
-                className="flex justify-between items-center px-6 py-4 bg-blue80 w-full rounded-t"
+                className="flex w-full items-center justify-between rounded-t bg-blue80 px-6 py-4"
             >
                 <Heading5
                     margin="none"
-                    className=" sm:text-base !text-lg"
+                    className="!text-lg sm:text-base"
                     as="h1"
                 >
                     {title}
@@ -35,7 +35,7 @@ function Expandable({
                 </IconButton>
             </div>
             {isOpen && (
-                <div className="rounded-b p-4 bg-blue90">{children}</div>
+                <div className="rounded-b bg-blue90 p-4">{children}</div>
             )}
         </div>
     )

--- a/tavla/app/components/ImageCarousel/ImageCarousel.tsx
+++ b/tavla/app/components/ImageCarousel/ImageCarousel.tsx
@@ -48,7 +48,7 @@ function ImageCarousel() {
 
     return (
         <div
-            className={`flex flex-row self-center md:scale-90 overflow-hidden transform transition-all duration-1000 ease-in-out ${
+            className={`flex transform flex-row self-center overflow-hidden transition-all duration-1000 ease-in-out md:scale-90 ${
                 fade ? 'opacity-100' : 'opacity-0'
             }`}
         >

--- a/tavla/app/components/PreviewCarousel/index.tsx
+++ b/tavla/app/components/PreviewCarousel/index.tsx
@@ -20,13 +20,13 @@ const CarouselIndicators = ({
 }) => {
     return (
         <div
-            className="flex flex-row md:space-x-3 space-x-5 justify-center mt-4"
+            className="mt-4 flex flex-row justify-center space-x-5 md:space-x-3"
             aria-label="Knapper for å bytte mellom avgangstavler"
         >
             {boards.map((_, index) => (
                 <button
                     key={index}
-                    className={`md:w-5 md:h-5 w-6 h-6 rounded-full  bottom-5 ${
+                    className={`bottom-5 h-6 w-6 rounded-full md:h-5 md:w-5 ${
                         index === activeIndex ? 'bg-blue' : 'bg-tertiary'
                     }`}
                     aria-label={
@@ -68,7 +68,7 @@ function PreviewCarousel({ boards }: { boards: TBoard[] }) {
     return (
         <>
             <div className="flex flex-row">
-                <div className="my-auto hidden md:block ml-2">
+                <div className="my-auto ml-2 hidden md:block">
                     <IconButton
                         onClick={prevSlide}
                         aria-label="Vis forrige tavle"
@@ -77,7 +77,7 @@ function PreviewCarousel({ boards }: { boards: TBoard[] }) {
                     </IconButton>
                 </div>
                 <div
-                    className="w-full mx-auto"
+                    className="mx-auto w-full"
                     data-theme={currentBoard.theme ?? 'dark'}
                 >
                     <div
@@ -89,14 +89,14 @@ function PreviewCarousel({ boards }: { boards: TBoard[] }) {
                             data-theme={currentBoard?.theme ?? 'dark'}
                         >
                             <Header theme={currentBoard.theme} />
-                            <div className="md:h-96 h-72">
+                            <div className="h-72 md:h-96">
                                 <Board board={currentBoard} />
                             </div>
                             <Footer board={currentBoard} />
                         </div>
                     </div>
                 </div>
-                <div className="my-auto hidden md:block mr-2">
+                <div className="my-auto mr-2 hidden md:block">
                     <IconButton
                         onClick={nextSlide}
                         aria-label="Vis neste tavle"

--- a/tavla/app/components/WordCarousel/WordCarousel.tsx
+++ b/tavla/app/components/WordCarousel/WordCarousel.tsx
@@ -23,8 +23,8 @@ function WordCarousel() {
     return (
         <Heading1
             margin="none"
-            className={`italic !text-highlight !font-normal transform transition-all duration-1000 ease-in-out ${
-                fade ? 'opacity-100 -translate-y-4' : 'opacity-0 -translate-y-6'
+            className={`transform !font-normal italic !text-highlight transition-all duration-1000 ease-in-out ${
+                fade ? '-translate-y-4 opacity-100' : '-translate-y-6 opacity-0'
             }`}
         >
             {words[currentWordIndex]}

--- a/tavla/app/demo/components/ExpandableInformation.tsx
+++ b/tavla/app/demo/components/ExpandableInformation.tsx
@@ -10,7 +10,7 @@ function ExpandableInformation() {
     return (
         <div>
             <button
-                className={`flex flex-row justify-between items-center px-6  py-4 bg-blue80 w-full cursor-pointer ${
+                className={`flex w-full cursor-pointer flex-row items-center justify-between bg-blue80 px-6 py-4 ${
                     isOpen ? 'rounded-t' : 'rounded'
                 }`}
                 onClick={() => setIsOpen(!isOpen)}
@@ -20,11 +20,8 @@ function ExpandableInformation() {
                 </Paragraph>
                 {isOpen ? <UpArrowIcon /> : <DownArrowIcon />}
             </button>
-            <BaseExpand
-                open={isOpen}
-                className="bg-blue90 px-6  py-4 rounded-b"
-            >
-                <UnorderedList className="space-y-3 gap-1 pl-6">
+            <BaseExpand open={isOpen} className="rounded-b bg-blue90 px-6 py-4">
+                <UnorderedList className="gap-1 space-y-3 pl-6">
                     <ListItem>
                         Vise stoppestedene hver for seg eller samlet i én liste
                     </ListItem>

--- a/tavla/app/demo/page.tsx
+++ b/tavla/app/demo/page.tsx
@@ -9,8 +9,8 @@ async function Demo() {
     const loggedIn = (await getUserFromSessionCookie()) !== null
 
     return (
-        <main className="container pt-8 pb-20 flex flex-col gap-6">
-            <div className="flex items-center justify-between align-middle h-full">
+        <main className="container flex flex-col gap-6 pb-20 pt-8">
+            <div className="flex h-full items-center justify-between align-middle">
                 <Heading1 className="!mb-0">Test ut Tavla</Heading1>
                 {!loggedIn ? (
                     <CreateUserButton trackingEvent="LOGIN_BTN_DEMO_PAGE" />

--- a/tavla/app/error.tsx
+++ b/tavla/app/error.tsx
@@ -17,7 +17,7 @@ export default function Error({
         Sentry.captureException(error)
     }, [error])
     return (
-        <main className="container pb-10 flex flex-col items-center">
+        <main className="container flex flex-col items-center pb-10">
             <Heading3>Au da! Noe gikk galt!</Heading3>
             <Image
                 src={BeaverIllustration}

--- a/tavla/app/global-error.tsx
+++ b/tavla/app/global-error.tsx
@@ -20,7 +20,7 @@ export default function Error({
     return (
         <html>
             <body>
-                <main className="container pb-10 flex flex-col items-center">
+                <main className="container flex flex-col items-center pb-10">
                     <Heading3>Au da! Noe gikk galt!</Heading3>
                     <Image
                         src={BeaverIllustration}

--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -243,7 +243,7 @@
     }
 
     .divider {
-        @apply border-b-secondary border-b-2 my-2;
+        @apply my-2 border-b-2 border-b-secondary;
     }
 
     .publicCode {
@@ -253,11 +253,11 @@
     }
 
     .pulse {
-        @apply inline-flex rounded-full bg-success h-3 w-3 left-[calc(50%-((0.75em)/2))] bottom-[calc(50%-((h-3)/2))];
+        @apply bottom-[calc(50%-((h-3)/2))] left-[calc(50%-((0.75em)/2))] inline-flex h-3 w-3 rounded-full bg-success;
     }
 
     .previewContainer {
-        @apply rounded p-4 bg-primary border border-secondary;
+        @apply rounded border border-secondary bg-primary p-4;
     }
 
     .table-custom-nth-child {

--- a/tavla/app/help/page.tsx
+++ b/tavla/app/help/page.tsx
@@ -18,7 +18,7 @@ function Help() {
     return (
         <main>
             <div className="bg-secondary">
-                <div className="flex flex-row container gap-10 lg:w-3/4 xl:w-1/2 pt-12 pb-4 justify-between flex-start">
+                <div className="flex-start container flex flex-row justify-between gap-10 pb-4 pt-12 lg:w-3/4 xl:w-1/2">
                     <div className="align-center">
                         <Heading1>Ofte stilte spørsmål</Heading1>
                         <Paragraph>
@@ -39,11 +39,11 @@ function Help() {
                     <Image
                         src={HedgehogIllustration}
                         alt="Illustrasjon av et pinnsvin"
-                        className="max-md:hidden w-1/4 xl:w-1/3"
+                        className="w-1/4 max-md:hidden xl:w-1/3"
                     />
                 </div>
             </div>
-            <div className="container pt-12 pb-20 flex flex-col lg:w-3/4 xl:w-1/2 gap-14">
+            <div className="container flex flex-col gap-14 pb-20 pt-12 lg:w-3/4 xl:w-1/2">
                 <div>
                     <Questions />
                 </div>

--- a/tavla/app/not-found.tsx
+++ b/tavla/app/not-found.tsx
@@ -6,7 +6,7 @@ import BeaverIllustration from 'assets/illustrations/Beaver.png'
 
 function Custom404() {
     return (
-        <main className="container pb-10 flex flex-col items-center">
+        <main className="container flex flex-col items-center pb-10">
             <Heading3>Denne siden finnes ikke!</Heading3>
             <Image
                 src={BeaverIllustration}

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -26,7 +26,7 @@ async function Landing() {
     return (
         <main>
             <div className="bg-secondary">
-                <div className="flex flex-col container py-12 gap-10 lg:flex-row justify-center">
+                <div className="container flex flex-col justify-center gap-10 py-12 lg:flex-row">
                     <div className="flex flex-col lg:w-3/4 xl:w-1/2">
                         <Heading1>Lag en helt gratis avgangstavle for</Heading1>
                         <WordCarousel />
@@ -37,9 +37,9 @@ async function Landing() {
                             nærheten og hjelp folk til å planlegge sin neste
                             kollektivreise.
                         </LeadParagraph>
-                        <div className="flex md:flex-row flex-col w-full gap-4 mt-5">
+                        <div className="mt-5 flex w-full flex-col gap-4 md:flex-row">
                             {!loggedIn ? (
-                                <div className="gap-4 flex flex-col md:flex-row w-full">
+                                <div className="flex w-full flex-col gap-4 md:flex-row">
                                     <CreateUserButton trackingEvent="CREATE_USER_BTN_FROM_LANDING" />
                                     <DemoButton />
                                 </div>
@@ -52,13 +52,13 @@ async function Landing() {
                 </div>
             </div>
 
-            <div className="flex flex-col mx-auto items-center justify-start py-4 container overflow-hidden pb-10">
-                <div className="flex flex-col items-center justify-start gap-4 py-14 w-full">
+            <div className="container mx-auto flex flex-col items-center justify-start overflow-hidden py-4 pb-10">
+                <div className="flex w-full flex-col items-center justify-start gap-4 py-14">
                     <PreviewCarousel boards={previewBoards} />
 
                     <div className="xl:w-1/2">
                         <Heading2>Kort om Tavla</Heading2>
-                        <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
+                        <UnorderedList className="flex flex-col gap-1 space-y-3 pl-6">
                             <ListItem>
                                 Du kan lage avgangstavler helt gratis fra alle
                                 stoppesteder, holdeplasser, knutepunkter,
@@ -78,7 +78,7 @@ async function Landing() {
 
                         <Heading3>Enkelt å tilpasse og samarbeide</Heading3>
 
-                        <UnorderedList className="space-y-3 flex flex-col gap-1 pl-6">
+                        <UnorderedList className="flex flex-col gap-1 space-y-3 pl-6">
                             <ListItem>
                                 Tilpass tekststørrelse, fargetema, logo og
                                 hvilken informasjon som skal vises, slik at

--- a/tavla/app/privacy/components/ExpandableInfo.tsx
+++ b/tavla/app/privacy/components/ExpandableInfo.tsx
@@ -13,7 +13,7 @@ import { ExternalIcon } from '@entur/icons'
 
 function ExpandableInfo() {
     return (
-        <div className="flex flex-col justify-center  items-center gap-1 p-4">
+        <div className="flex flex-col items-center justify-center gap-1 p-4">
             <ExpandablePanel title="Behandling av personopplysninger">
                 <Heading3>Behandlingsansvar</Heading3>
                 <Paragraph>
@@ -74,7 +74,7 @@ function ExpandableInfo() {
                         <EnturLink
                             as={Link}
                             href="https://firebase.google.com/docs/auth"
-                            className="items-center inline-flex flex-row gap-1"
+                            className="inline-flex flex-row items-center gap-1"
                         >
                             Firebase Auth
                             <ExternalIcon />
@@ -83,7 +83,7 @@ function ExpandableInfo() {
                         <EnturLink
                             as={Link}
                             href="https://firebase.google.com/support/privacy"
-                            className="items-center inline-flex flex-row gap-1"
+                            className="inline-flex flex-row items-center gap-1"
                         >
                             Firebase Privacy Policy
                             <ExternalIcon />

--- a/tavla/app/privacy/page.tsx
+++ b/tavla/app/privacy/page.tsx
@@ -14,11 +14,11 @@ function Privacy() {
     return (
         <>
             <main className="container pb-10">
-                <div className="flex flex-col justify-center mb-8">
+                <div className="mb-8 flex flex-col justify-center">
                     <Heading1>Personvern</Heading1>
 
-                    <div className="flex flex-col sm:grid sm:grid-cols-3 text-center items-center gap-4 pt-4">
-                        <div className="flex flex-col justify-center items-center">
+                    <div className="flex flex-col items-center gap-4 pt-4 text-center sm:grid sm:grid-cols-3">
+                        <div className="flex flex-col items-center justify-center">
                             <Image
                                 className="h-40 w-auto"
                                 src={squirrel}
@@ -30,7 +30,7 @@ function Privacy() {
                                 med.
                             </Paragraph>
                         </div>
-                        <div className="flex flex-col justify-center  items-center">
+                        <div className="flex flex-col items-center justify-center">
                             <Image className="h-40 w-auto" src={doves} alt="" />
                             <Heading4>Informasjonskapsler</Heading4>
                             <Paragraph>
@@ -38,7 +38,7 @@ function Privacy() {
                                 er logget inn.
                             </Paragraph>
                         </div>
-                        <div className="flex flex-col justify-center  items-center">
+                        <div className="flex flex-col items-center justify-center">
                             <Image
                                 className="h-40 w-auto"
                                 src={hedgehog}

--- a/tavla/app/reset/[oob]/ResetForm.tsx
+++ b/tavla/app/reset/[oob]/ResetForm.tsx
@@ -39,7 +39,7 @@ function ResetForm({ oob }: { oob: string }) {
     const [state, action] = useActionState(submit, undefined)
 
     return (
-        <form className="flex flex-col gap-4 min-w-40 w-[30%]" action={action}>
+        <form className="flex w-[30%] min-w-40 flex-col gap-4" action={action}>
             <ClientOnlyTextField
                 name="password"
                 label="Nytt passord"

--- a/tavla/app/reset/[oob]/page.tsx
+++ b/tavla/app/reset/[oob]/page.tsx
@@ -4,7 +4,7 @@ import { ResetForm } from './ResetForm'
 async function Reset(props: { params: Promise<{ oob: string }> }) {
     const params = await props.params
     return (
-        <main className="container justify-center flex flex-col items-center mb-10">
+        <main className="container mb-10 flex flex-col items-center justify-center">
             <Heading3>Tilbakestill passord</Heading3>
             <ResetForm oob={params.oob} />
         </main>

--- a/tavla/app/verify/[oob]/page.tsx
+++ b/tavla/app/verify/[oob]/page.tsx
@@ -32,7 +32,7 @@ async function Verify(props: { params: Promise<{ oob: string }> }) {
         } else message = 'Noe gikk galt, prøv igjen senere.'
     }
     return (
-        <main className="container pt-8 pb-20 text-center">
+        <main className="container pb-20 pt-8 text-center">
             <Paragraph>{message}</Paragraph>
             <Button variant="primary" as={Link} href="/?login">
                 Logg inn

--- a/tavla/package.json
+++ b/tavla/package.json
@@ -53,6 +53,7 @@
         "nanoid": "5.0.9",
         "next": "15.2.3",
         "posthog-js": "1.234.7",
+        "prettier-plugin-tailwindcss": "0.6.12",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-google-button": "0.8.0",

--- a/tavla/pages/404.tsx
+++ b/tavla/pages/404.tsx
@@ -6,7 +6,7 @@ import BeaverIllustration from 'assets/illustrations/Beaver.png'
 
 function Custom404() {
     return (
-        <div className="mx-auto h-[70vh] lg:w-1/4 flex flex-col justify-center items-center gap-5">
+        <div className="mx-auto flex h-[70vh] flex-col items-center justify-center gap-5 lg:w-1/4">
             <Heading3>Denne siden finnes ikke!</Heading3>
             <Image
                 src={BeaverIllustration}

--- a/tavla/pages/_error.tsx
+++ b/tavla/pages/_error.tsx
@@ -16,7 +16,7 @@ Error.getInitialProps = async (contextData: NextPageContext) => {
 
 function CustomError() {
     return (
-        <main className="container pb-10 flex flex-col items-center">
+        <main className="container flex flex-col items-center pb-10">
             <Heading3>Au da! Noe gikk galt!</Heading3>
             <Image
                 src={BeaverIllustration}

--- a/tavla/src/Board/components/DataFetchingFailed/index.tsx
+++ b/tavla/src/Board/components/DataFetchingFailed/index.tsx
@@ -8,7 +8,7 @@ export enum FetchErrorTypes {
 
 function DataFetchingFailed({ timeout = false }) {
     return (
-        <div className="w-full h-full flex flex-col items-center justify-center">
+        <div className="flex h-full w-full flex-col items-center justify-center">
             <Image src={LeafIllustration} alt="Illustrasjon av blader" />
             <div className="w-full text-center">
                 <Heading3 className="!text-primary">

--- a/tavla/src/Board/components/TileLoader/index.tsx
+++ b/tavla/src/Board/components/TileLoader/index.tsx
@@ -2,7 +2,7 @@ import { Loader } from '@entur/loader'
 
 function TileLoader() {
     return (
-        <div className="w-full h-full flex flex-col justify-center ">
+        <div className="flex h-full w-full flex-col justify-center">
             <div className="w-full text-center">
                 Henter avganger...
                 <Loader />

--- a/tavla/src/Board/scenarios/Board/index.tsx
+++ b/tavla/src/Board/scenarios/Board/index.tsx
@@ -28,7 +28,7 @@ function Board({ board }: { board: TBoard }) {
 
     return (
         <div
-            className={`max-sm:overflow-y-scroll grid grid-cols-auto-fit-minmax gap-2.5 h-full overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 ${getFontScale(
+            className={`grid h-full grid-cols-auto-fit-minmax gap-2.5 overflow-hidden supports-[not(display:grid)]:flex supports-[not(display:grid)]:*:m-2.5 max-sm:overflow-y-scroll ${getFontScale(
                 board.meta?.fontSize || defaultFontSize(board),
             )} `}
         >

--- a/tavla/src/Board/scenarios/Table/components/Line/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Line/index.tsx
@@ -22,7 +22,7 @@ function Line() {
         <TableColumn title="Linje">
             {lines.map((line) => (
                 <TableRow key={line.key}>
-                    <div className="flex gap-2 justify-start items-center pr-2 w-full">
+                    <div className="flex w-full items-center justify-start gap-2 pr-2">
                         <TravelTag
                             transportMode={line.transportMode}
                             transportSubmode={line.transportSubmode}

--- a/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
@@ -17,8 +17,8 @@ function Situation({
     if (!situationText) return null
 
     return (
-        <div className="text-warning text-[0.65em] flex items-center">
-            <div className="fill-warning flex items-center mr-[0.1em] text-[1.8em]">
+        <div className="flex items-center text-[0.65em] text-warning">
+            <div className="mr-[0.1em] flex items-center fill-warning text-[1.8em]">
                 <ValidationExclamation />
             </div>
             <div className="truncate">{situationText}</div>

--- a/tavla/src/Board/scenarios/Table/components/TableColumn/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableColumn/index.tsx
@@ -9,7 +9,7 @@ function TableColumn({
 }) {
     return (
         <div className={`flex flex-col ${className}`}>
-            <div className="text-primary text-em-sm pb-2 mx-2">{title}</div>
+            <div className="mx-2 pb-2 text-em-sm text-primary">{title}</div>
             {children}
         </div>
     )

--- a/tavla/src/Board/scenarios/Table/components/TableHeader/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableHeader/index.tsx
@@ -9,8 +9,8 @@ function TableHeader({
     walkingDistance?: TWalkingDistance
 }) {
     return (
-        <div className="flex flex-row justify-between items-center mb-2 min-h-em-2">
-            <h1 className="text-[1.5em] font-semibold m-0">{heading}</h1>
+        <div className="mb-2 flex min-h-em-2 flex-row items-center justify-between">
+            <h1 className="m-0 text-[1.5em] font-semibold">{heading}</h1>
             <WalkingDistance walkingDistance={walkingDistance} />
         </div>
     )

--- a/tavla/src/Board/scenarios/Table/components/TableRow/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableRow/index.tsx
@@ -1,7 +1,7 @@
 function TableRow({ children }: { children: React.ReactNode }) {
     return (
-        <div className="flex items-center h-em-3 border-t border-solid border-t-secondary">
-            <div className="w-full mx-em-0.25">{children}</div>
+        <div className="flex h-em-3 items-center border-t border-solid border-t-secondary">
+            <div className="mx-em-0.25 w-full">{children}</div>
         </div>
     )
 }

--- a/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
@@ -45,10 +45,10 @@ function Time({
     if (cancelled)
         return (
             <>
-                <div className="text-right font-semibold text-estimated-time text-em-sm">
+                <div className="text-right text-em-sm font-semibold text-estimated-time">
                     Innstilt
                 </div>
-                <div className="text-right text-em-xs lineThrough">
+                <div className="lineThrough text-right text-em-xs">
                     {formatDateString(aimedDepartureTime)}
                 </div>
             </>
@@ -65,7 +65,7 @@ function Time({
                 <div className="text-right font-semibold text-estimated-time">
                     {getRelativeTimeString(expectedDepartureTime)}
                 </div>
-                <div className="text-right text-em-xs lineThrough">
+                <div className="lineThrough text-right text-em-xs">
                     {formatDateString(aimedDepartureTime)}
                 </div>
             </>

--- a/tavla/src/Board/scenarios/Table/index.tsx
+++ b/tavla/src/Board/scenarios/Table/index.tsx
@@ -38,13 +38,13 @@ function Table({
 
     if (departures.length === 0)
         return (
-            <div className="flex flex-col items-center justify-center text-center h-full w-full text-em-sm pb-4">
+            <div className="flex h-full w-full flex-col items-center justify-center pb-4 text-center text-em-sm">
                 <Image
                     src={theme === 'light' ? leafsLight : leafs}
                     alt=""
-                    className="h-[6em] w-[6em] lg:h-[15em] lg:w-[15em] sm:max-h-[10em] sm:max-w-[10em]"
+                    className="h-[6em] w-[6em] sm:max-h-[10em] sm:max-w-[10em] lg:h-[15em] lg:w-[15em]"
                 />
-                <Paragraph className="!text-primary sm:pb-8 ">
+                <Paragraph className="!text-primary sm:pb-8">
                     Ingen avganger de neste 24 timene.
                 </Paragraph>
             </div>

--- a/tavla/src/Shared/components/Footer/index.tsx
+++ b/tavla/src/Shared/components/Footer/index.tsx
@@ -9,7 +9,7 @@ function Footer({ board, logo }: { board: TBoard; logo?: boolean }) {
 
     const EnturLogo = getLogo(board?.theme ?? 'dark')
     return (
-        <footer className="flex flex-row justify-between min-h-[4vh] items-center gap-em-2">
+        <footer className="flex min-h-[4vh] flex-row items-center justify-between gap-em-2">
             <div
                 className={`truncate text-primary ${
                     getFontScale(board.meta?.fontSize) || defaultFontSize(board)
@@ -21,7 +21,7 @@ function Footer({ board, logo }: { board: TBoard; logo?: boolean }) {
                 <Image
                     src={EnturLogo}
                     alt="Entur logo"
-                    className="ml-4 object-contain w-[70px] h-[20px] md:w-[200px] md:h-[40px]"
+                    className="ml-4 h-[20px] w-[70px] object-contain md:h-[40px] md:w-[200px]"
                 />
             )}
         </footer>

--- a/tavla/src/Shared/components/Header/index.tsx
+++ b/tavla/src/Shared/components/Header/index.tsx
@@ -14,12 +14,12 @@ function Header({
     const tavlaLogo = theme === 'light' ? TavlaLogoBlue : TavlaLogoWhite
 
     return (
-        <div className="flex flex-row justify-between items-center gap-em-3">
-            <div className="relative w-full h-full">
+        <div className="flex flex-row items-center justify-between gap-em-3">
+            <div className="relative h-full w-full">
                 <Image
                     src={organizationLogo ?? tavlaLogo}
                     alt="Logo til tavlen"
-                    className="object-contain object-left w-[104px] h-[27px] md:w-[208px] md:h-[55px]"
+                    className="h-[27px] w-[104px] object-contain object-left md:h-[55px] md:w-[208px]"
                     width="100"
                     height="100"
                 />

--- a/tavla/src/Shared/components/Pulse/index.tsx
+++ b/tavla/src/Shared/components/Pulse/index.tsx
@@ -1,8 +1,8 @@
 function Pulse() {
     return (
         <div className="relative flex h-full w-full">
-            <span className="animate-pulse absolute pulse"></span>
-            <span className="relative pulse "></span>
+            <span className="pulse absolute animate-pulse"></span>
+            <span className="pulse relative"></span>
         </div>
     )
 }

--- a/tavla/src/Shared/components/Tile/index.tsx
+++ b/tavla/src/Shared/components/Tile/index.tsx
@@ -9,7 +9,7 @@ function Tile({
     return (
         <div
             className={classNames(
-                'h-full w-full text-primary bg-secondary p-em-1 rounded overflow-hidden',
+                'h-full w-full overflow-hidden rounded bg-secondary p-em-1 text-primary',
                 className,
             )}
             {...rest}

--- a/tavla/src/Shared/components/TransportIcon/index.tsx
+++ b/tavla/src/Shared/components/TransportIcon/index.tsx
@@ -17,7 +17,7 @@ function TransportIcon({
         mode === 'unknown' ? 'Unknown transport mode' : `${mode} transport mode`
     return (
         <Component
-            className={className ?? 'w-full h-full'}
+            className={className ?? 'h-full w-full'}
             fill={`var(--${mode}-color)`}
             aria-label={altText}
         />

--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -31,16 +31,16 @@ function TravelTag({
     return (
         <div
             aria-label={`${transportModeNames[transportMode]} - linje ${publicCode}`}
-            className={`flex items-center justify-between w-full h-full pl-2 rounded-sm font-bold text-background bg-${
+            className={`flex h-full w-full items-center justify-between rounded-sm pl-2 font-bold text-background bg-${
                 transportMode ?? 'unknown'
             }`}
         >
             <TransportIcon
-                className="w-em-2 h-em-2 fill-background"
+                className="h-em-2 w-em-2 fill-background"
                 transportMode={transportMode}
                 transportSubmode={transportSubmode}
             />
-            <div className="flex flex-row items-center justify-center w-full h-full">
+            <div className="flex h-full w-full flex-row items-center justify-center">
                 {publicCode}
             </div>
         </div>
@@ -60,7 +60,7 @@ function SmallTravelTag({
     return (
         <div
             aria-label={`${transportModeNames[transportMode]} - linje ${publicCode}`}
-            className={`flex items-center justify-between w-full h-5 p-1 rounded-sm font-bold text-background bg-${
+            className={`flex h-5 w-full items-center justify-between rounded-sm p-1 font-bold text-background bg-${
                 transportMode ?? 'unknown'
             }`}
             key={`${transportMode}${publicCode}`}
@@ -69,14 +69,14 @@ function SmallTravelTag({
                 <TransportIcon
                     className={`h-6 fill-background ${
                         publicCode && !isOnlyWhiteSpace(publicCode)
-                            ? 'max-sm:hidden sm:block lg:hidden xl:block w-6'
+                            ? 'w-6 max-sm:hidden sm:block lg:hidden xl:block'
                             : 'block w-4'
                     }`}
                     transportMode={transportMode}
                 />
             )}
             {publicCode && !isOnlyWhiteSpace(publicCode) && (
-                <div className="text-[0.65rem] w-full flex justify-center align-center">
+                <div className="align-center flex w-full justify-center text-[0.65rem]">
                     {publicCode}
                 </div>
             )}

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -12574,6 +12574,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-plugin-tailwindcss@npm:0.6.12":
+  version: 0.6.12
+  resolution: "prettier-plugin-tailwindcss@npm:0.6.12"
+  peerDependencies:
+    "@ianvs/prettier-plugin-sort-imports": "*"
+    "@prettier/plugin-pug": "*"
+    "@shopify/prettier-plugin-liquid": "*"
+    "@trivago/prettier-plugin-sort-imports": "*"
+    "@zackad/prettier-plugin-twig": "*"
+    prettier: ^3.0
+    prettier-plugin-astro: "*"
+    prettier-plugin-css-order: "*"
+    prettier-plugin-import-sort: "*"
+    prettier-plugin-jsdoc: "*"
+    prettier-plugin-marko: "*"
+    prettier-plugin-multiline-arrays: "*"
+    prettier-plugin-organize-attributes: "*"
+    prettier-plugin-organize-imports: "*"
+    prettier-plugin-sort-imports: "*"
+    prettier-plugin-style-order: "*"
+    prettier-plugin-svelte: "*"
+  peerDependenciesMeta:
+    "@ianvs/prettier-plugin-sort-imports":
+      optional: true
+    "@prettier/plugin-pug":
+      optional: true
+    "@shopify/prettier-plugin-liquid":
+      optional: true
+    "@trivago/prettier-plugin-sort-imports":
+      optional: true
+    "@zackad/prettier-plugin-twig":
+      optional: true
+    prettier-plugin-astro:
+      optional: true
+    prettier-plugin-css-order:
+      optional: true
+    prettier-plugin-import-sort:
+      optional: true
+    prettier-plugin-jsdoc:
+      optional: true
+    prettier-plugin-marko:
+      optional: true
+    prettier-plugin-multiline-arrays:
+      optional: true
+    prettier-plugin-organize-attributes:
+      optional: true
+    prettier-plugin-organize-imports:
+      optional: true
+    prettier-plugin-sort-imports:
+      optional: true
+    prettier-plugin-style-order:
+      optional: true
+    prettier-plugin-svelte:
+      optional: true
+  checksum: e1f42168c8ff029c9e90b2abe04ae0df1b7835b32afc2591676b565b31c01506f7584792eb5ffd0e6b612e6a623bc4ce69391aae86523d7df47e21cebdeb4596
+  languageName: node
+  linkType: hard
+
 "prettier@npm:3.3.3":
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
@@ -14553,6 +14611,7 @@ __metadata:
     postcss: 8.4.47
     posthog-js: 1.234.7
     prettier: 3.3.3
+    prettier-plugin-tailwindcss: 0.6.12
     react: 18.3.1
     react-dom: 18.3.1
     react-google-button: 0.8.0


### PR DESCRIPTION
## 🥅 Motivasjon

Vi vil legge til tailwind prettier så det er lettere å skrive tailwind + at alle har samme måte å skrive tailwind på. 

## ✨ Endringer

- [x] Importerer prettier-plugin-tailwindcss
- [x] Justerer på prettier config til å ta inn prettier-plugin-tailwindcss og ha en mer typisk struktur

Todo:
- [ ] Kjøre prettier --write slik at github-linteren ikke feiler

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari
- [ ] Sjekk at det fremdeles ser greit ut
