### PR TITLE
fix(tavle): fix overlapping timestamps and cut destination column

### DIFF
--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -22,19 +22,18 @@ function Destination({ deviations = true }: { deviations?: boolean }) {
         <div className="grow overflow-hidden">
             <TableColumn title="Destinasjon">
                 {destinations.map((destination) => (
-                    <TableRow key={destination.key} className="flex flex-row">
-                        <div className="flex-[7] overflow-ellipsis whitespace-nowrap">
+                    <TableRow
+                        key={destination.key}
+                        className="flex align-middle"
+                    >
+                        <div className="line-clamp-2 overflow-ellipsis hyphens-auto leading-em-base">
                             {destination.via
                                 ? `${destination.destination} via ${destination.via}`
                                 : destination.destination}
                         </div>
 
                         {deviations && (
-                            <div className="flex-[3]">
-                                <Situations
-                                    situations={destination.situations}
-                                />
-                            </div>
+                            <Situations situations={destination.situations} />
                         )}
                     </TableRow>
                 ))}

--- a/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
@@ -17,7 +17,7 @@ function Situation({
     if (!situationText) return null
 
     return (
-        <div className="mt-[0.1em] flex items-center text-[0.65em] text-warning">
+        <div className="mt-[0.1em] flex items-center text-em-situation/em-situation text-warning">
             <div className="mr-[0.1em] flex items-center fill-warning text-[1.8em]">
                 <ValidationExclamation />
             </div>

--- a/tavla/src/Board/scenarios/Table/components/TableColumn/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableColumn/index.tsx
@@ -9,7 +9,9 @@ function TableColumn({
 }) {
     return (
         <div className={`flex flex-col ${className}`}>
-            <div className="mx-2 pb-2 text-em-sm text-primary">{title}</div>
+            <div className="mx-2 pb-2 text-em-sm/em-base text-primary">
+                {title}
+            </div>
             {children}
         </div>
     )

--- a/tavla/src/Board/scenarios/Table/components/TableHeader/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableHeader/index.tsx
@@ -10,7 +10,7 @@ function TableHeader({
 }) {
     return (
         <div className="mb-2 flex min-h-em-2 flex-row items-center justify-between">
-            <h1 className="m-0 text-[1.5em] font-semibold">{heading}</h1>
+            <h1 className="m-0 text-em-xl font-semibold">{heading}</h1>
             <WalkingDistance walkingDistance={walkingDistance} />
         </div>
     )

--- a/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
@@ -45,10 +45,10 @@ function Time({
     if (cancelled)
         return (
             <>
-                <div className="text-right text-em-sm font-semibold text-estimated-time">
+                <div className="text-right text-em-sm/em-sm font-semibold text-estimated-time">
                     Innstilt
                 </div>
-                <div className="lineThrough text-right text-em-xs">
+                <div className="lineThrough text-right text-em-xs/em-xs">
                     {formatDateString(aimedDepartureTime)}
                 </div>
             </>
@@ -62,10 +62,10 @@ function Time({
     if (timeDeviationInSeconds > TWO_MINUTES) {
         return (
             <>
-                <div className="text-right font-semibold text-estimated-time">
+                <div className="text-right font-semibold leading-em-base text-estimated-time">
                     {getRelativeTimeString(expectedDepartureTime)}
                 </div>
-                <div className="lineThrough text-right text-em-xs">
+                <div className="lineThrough text-right text-em-xs/em-xs">
                     {formatDateString(aimedDepartureTime)}
                 </div>
             </>

--- a/tavla/src/Board/scenarios/Table/components/Time/components/FormattedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/components/FormattedTime.tsx
@@ -3,11 +3,13 @@ import { getDate, getRelativeTimeString, isDateStringToday } from 'utils/time'
 function FormattedTime({ time }: { time: string }) {
     return (
         <>
-            <div className="text-right font-semibold">
+            <div className="text-right font-semibold leading-em-base">
                 {getRelativeTimeString(time)}
             </div>
             {!isDateStringToday(time) && (
-                <div className="text-right text-em-xs">{getDate(time)}</div>
+                <div className="text-right text-em-xs/em-xs">
+                    {getDate(time)}
+                </div>
             )}
         </>
     )

--- a/tavla/src/Shared/components/Footer/index.tsx
+++ b/tavla/src/Shared/components/Footer/index.tsx
@@ -11,7 +11,7 @@ function Footer({ board, logo }: { board: TBoard; logo?: boolean }) {
     return (
         <footer className="flex min-h-[4vh] flex-row items-center justify-between gap-em-2">
             <div
-                className={`truncate text-primary ${
+                className={`truncate leading-em-base text-primary ${
                     getFontScale(board.meta?.fontSize) || defaultFontSize(board)
                 }`}
             >

--- a/tavla/tailwind.config.ts
+++ b/tavla/tailwind.config.ts
@@ -72,6 +72,16 @@ module.exports = {
                 'em-sm': '0.7em',
                 'em-base': '1em',
                 'em-lg': '1.3em',
+                'em-xl': '1.5em',
+                'em-situation': '0.65em',
+            },
+            lineHeight: {
+                'em-xs': '0.5625em',
+                'em-sm': '0.7em',
+                'em-base': '1em',
+                'em-lg': '1.3em',
+                'em-xl': '1.5em',
+                'em-situation': '0.65em',
             },
             spacing: {
                 'em-0.25': '0.25em',


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Etter hotfixen for å slippe at teksten blir voldsomt kuttet så var det ikke alt som var helt bra. Denne PRen prøver å fikse det ved å legge inn riktig linjehøyde. Legger også til bedre håndtering av titlene på destinasjonene sånn at man lettere kan lese hvor den går ved lang destinasjon + lite plass. 

## ✨ Endringer

- [x] Lagt inn riktig linjehøyde på alle tidspunkter, tittelen på Destinasjons-kolonnen, alle destinasjoner, og footeren i tavla
     - Her er `text-em-sm/em-sm` det samme som `text-em-sm leading-em-sm`
     - Måtte spesifisere på kolonnenavnene at den skulle ha `leading-em-base` i stedet for `leading-em-sm` når den har em-sm tekststørrelse fordi det var kun da tittelen sluttet å bli kuttet
- [x] Disse linjehøydene er definert etter de predefinerte tavla-tekststørrelsene i tailwind-config
- [x] La også inn to nye tekststørrelse bare for å være konsekvent
- [x] Lagt inn maks 2 linjer på destinasjoner, samt hyphen-auto og overflow-ellipsis

## 📸 Screenshots

|Zoom | Før   | Etter |
|---| ----- | ----- |
|100% | ![image](https://github.com/user-attachments/assets/ddaff1dc-3c57-41f1-b0d7-c9468df0813a) | ![image](https://github.com/user-attachments/assets/679a4bcd-7f99-4245-9fa0-fc95808774f9) |
|150%|![image](https://github.com/user-attachments/assets/0e7fc223-5af2-4467-8380-d332ab787554)|![image](https://github.com/user-attachments/assets/7effd152-568d-4801-a536-47400542f4c8)|
|50%|![image](https://github.com/user-attachments/assets/fc40012e-edfc-4ef0-af5b-3d4aaf9ec96e)|![image](https://github.com/user-attachments/assets/a701c7b3-649b-42c1-869d-de48fa940d30)|

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari
