### PR TITLE
fix(mapper): hotfix collection name

### DIFF
--- a/tavla/app/(admin)/components/CreateBoard/actions.ts
+++ b/tavla/app/(admin)/components/CreateBoard/actions.ts
@@ -40,7 +40,7 @@ export async function createBoard(
         if (!createdBoard) return getFormFeedbackForError('firebase/general')
 
         await firestore()
-            .collection(oid ? 'folder' : 'users')
+            .collection(oid ? 'folders' : 'users')
             .doc(oid ? oid : user.uid)
             .update({
                 [oid ? 'boards' : 'owner']:


### PR DESCRIPTION
## 🥅 Motivasjon

Det går ikke an å opprette en tavle i en mappe fordi koden refererer til en collection kalt "folder" og ikke "folders" 🫠

## ✨ Endringer

Endret fra "folder" til "folders" 🤠

## ✅ Sjekkliste

- [x] Fungerer det å opprette en tavle?
