### PR TITLE
chore(): change lineheight for base font size and switch to base for cancelled-text

### DIFF
--- a/tavla/src/Board/scenarios/Table/components/TableHeader/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableHeader/index.tsx
@@ -9,8 +9,10 @@ function TableHeader({
     walkingDistance?: TWalkingDistance
 }) {
     return (
-        <div className="mb-2 flex min-h-em-2 flex-row items-center justify-between">
-            <h1 className="m-0 text-em-xl font-semibold">{heading}</h1>
+        <div className="mb-2 flex min-h-em-3 flex-row items-center justify-between">
+            <h1 className="m-0 line-clamp-2 hyphens-auto text-em-xl font-semibold leading-em-base">
+                {heading}
+            </h1>
             <WalkingDistance walkingDistance={walkingDistance} />
         </div>
     )

--- a/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
@@ -45,7 +45,7 @@ function Time({
     if (cancelled)
         return (
             <>
-                <div className="text-right text-em-sm/em-sm font-semibold text-estimated-time">
+                <div className="text-right text-em-sm/em-base font-semibold text-estimated-time">
                     Innstilt
                 </div>
                 <div className="lineThrough text-right text-em-xs/em-xs">

--- a/tavla/tailwind.config.ts
+++ b/tavla/tailwind.config.ts
@@ -78,7 +78,7 @@ module.exports = {
             lineHeight: {
                 'em-xs': '0.5625em',
                 'em-sm': '0.7em',
-                'em-base': '1em',
+                'em-base': '1.1em',
                 'em-lg': '1.3em',
                 'em-xl': '1.5em',
                 'em-situation': '0.65em',


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Bokstaver i destinasjonsnavn som går inn i kjelleren blir kuttet på bunnen, så vi vil øke lineheight med litt der det skjer. Testet det på andre tekststørrelser og det ser ikke ut som det var nødvendig (vet ikke hvorfor).
Testet med 1.05em og det ble ikke bra nok, så 1.1em it is. 

Så også i firefox at Innstilt fløt inn i oppsatt tid, så endret den linjehøyden fra sm til base også.

## ✨ Endringer

- [x] Endret em-base lineheight fra å være 1em til 1.1em
- [x] Endret fra em-sm til em-base linjehøyde på innstilt

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/7a71d396-e103-4cee-a200-a53dfe3a222a) | ![image](https://github.com/user-attachments/assets/6963ca25-3418-446a-bd87-a8ced0150b14) |
|<img width="259" alt="image" src="https://github.com/user-attachments/assets/e9d9ce26-04e4-4a59-a8e2-6ca7fc869b20" />|<img width="246" alt="image" src="https://github.com/user-attachments/assets/f9c88657-3d6a-4692-a9c7-83ebd63c7d50" />|


## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari
- [ ] Sjekk for skriftstørrelsene liten, medium og stor
