### PR TITLE
feat(tavle): filter out already shown situations from destinations

### DIFF
--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -12,6 +12,26 @@ import { useQueries } from 'hooks/useQuery'
 import { DEFAULT_COMBINED_COLUMNS } from 'types/column'
 import { sortBy } from 'lodash'
 
+function combineIdenticalSituations(situations: TSituationFragment[]) {
+    const situationById: { [id: string]: TSituationFragment } = {}
+
+    situations.map((situation) => {
+        const id = situation.id
+        if (situationById[id]) {
+            const existingOrigins = situationById[id].origin
+                ?.split(', ')
+                .concat([situation.origin ?? ''])
+                .sort()
+
+            situationById[id].origin = existingOrigins?.join(', ')
+        } else {
+            situationById[id] = situation
+        }
+    })
+
+    return Object.values(situationById)
+}
+
 export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
     const quayQueries = combinedTile
         .filter(({ type }) => type === 'quay')
@@ -94,6 +114,7 @@ export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
             }))
         }) ?? []),
     ]
+    const combinedSituations = combineIdenticalSituations(situations)
 
     const sortedEstimatedCalls = sortBy(estimatedCalls, (call) => {
         const time = new Date(call.expectedDepartureTime).getTime()
@@ -104,7 +125,7 @@ export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
         <Tile className="flex flex-col max-sm:min-h-[30vh]">
             <Table
                 departures={sortedEstimatedCalls}
-                situations={situations}
+                situations={combinedSituations}
                 columns={DEFAULT_COMBINED_COLUMNS}
             />
         </Tile>

--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -5,19 +5,49 @@ import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
 import { isNotNullOrUndefined } from 'utils/typeguards'
 import { nanoid } from 'nanoid'
+import { TSituationFragment } from 'graphql/index'
 
-function Destination({ deviations = true }: { deviations?: boolean }) {
+function filterIdenticalSituations(
+    originSituations?: TSituationFragment[],
+    departureSituations?: TSituationFragment[],
+) {
+    if (!originSituations || !departureSituations) {
+        return departureSituations ?? []
+    }
+    const filteredSituations = departureSituations.filter(
+        (departureSituation) => {
+            let shouldKeep = true
+            originSituations.map((originSituation) => {
+                if (departureSituation.id === originSituation.id) {
+                    shouldKeep = false
+                    return
+                }
+            })
+            return shouldKeep
+        },
+    )
+    return filteredSituations
+}
+
+function Destination({
+    deviations = true,
+    situations,
+}: {
+    deviations?: boolean
+    situations?: TSituationFragment[]
+}) {
     const departures = useNonNullContext(DeparturesContext)
 
     const destinations = departures.map((departure) => ({
         destination: departure.destinationDisplay?.frontText ?? '',
-        situations: departure.situations ?? [],
+        situations: filterIdenticalSituations(situations, departure.situations),
         via:
             departure.destinationDisplay?.via
                 ?.filter(isNotNullOrUndefined)
                 .join(', ') ?? '',
         key: nanoid(),
     }))
+
     return (
         <div className="grow overflow-hidden">
             <TableColumn title="Destinasjon">

--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -26,6 +26,7 @@ function filterIdenticalSituations(
             return shouldKeep
         },
     )
+
     return filteredSituations
 }
 
@@ -47,7 +48,6 @@ function Destination({
                 .join(', ') ?? '',
         key: nanoid(),
     }))
-
     return (
         <div className="grow overflow-hidden">
             <TableColumn title="Destinasjon">

--- a/tavla/src/Board/scenarios/Table/index.tsx
+++ b/tavla/src/Board/scenarios/Table/index.tsx
@@ -57,7 +57,7 @@ function Table({
                     {columns.includes('arrivalTime') && <ArrivalTime />}
                     {columns.includes('line') && <Line />}
                     {columns.includes('destination') && (
-                        <Destination deviations />
+                        <Destination deviations situations={situations} />
                     )}
                     {columns.includes('name') && <Name />}
                     {columns.includes('platform') && <Platform />}


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Vi ønsker ikke å vise avvik som allerede vises under stoppested/plattform for å forhindre rot. Derfor skal en filtreringsfunksjon fjerne de fra situasjonsobjektet til en destinasjon (nå) og en hel tavle (senere). 

Slår også sammen situasjonsobjekter ved kombinert tavle om de deler ID og slår sammen origin. Trodde jeg kunne bruke den nye filtreringsfunksjonen til dette derfor gjorde jeg det her hehe

## ✨ Endringer

- [x] Sender situasjonsobjektet ned til Destination slik at man kan filtrere ut så nærme hvor avviket skal vises (midlertidig endring antageligvis)
- [x] Lager en filterfunksjon som filtrerer vekk avvik som vises under stoppested/plattform
- [x] Slår sammen situasjonsobjekter dersom de deler ID og legger til hvilken plass meldingen kommer fra kommaseparert

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1490" alt="image" src="https://github.com/user-attachments/assets/a082863d-9a7e-44b6-8c71-6b2f3aefb150" /> | <img width="1490" alt="image" src="https://github.com/user-attachments/assets/42861fb5-a7b4-4ab1-99fd-89deeae5814f" /> |
|<img width="1490" alt="image" src="https://github.com/user-attachments/assets/5bfe9f9e-c29e-4dd7-9d1e-46dfbeda40ae" />|<img width="1490" alt="image" src="https://github.com/user-attachments/assets/5caf79dd-484a-481a-9ed4-604be79b3c3f" />|

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari
- [ ] Testet i Browserstack
