### PR TITLE
fix(rediger): sort quays on id

### DIFF
--- a/tavla/app/(admin)/hooks/useQuaySearch.ts
+++ b/tavla/app/(admin)/hooks/useQuaySearch.ts
@@ -31,16 +31,20 @@ function useQuaySearch(stopPlaceId: string, icons = true) {
                     quay.lines.some((line) => line.transportMode !== 'air'),
                 )
                 .sort((q1, q2) => {
+                    if (q1.publicCode && q2.publicCode) {
+                        if (q1.publicCode < q2.publicCode) return -1
+                        else return 1
+                    } else if (q1.publicCode) return -1
+                    else if (q2.publicCode) return 1
+
                     const q1Value = parseInt(q1.id.split(':')[2] ?? '', 10)
                     const q2Value = parseInt(q2.id.split(':')[2] ?? '', 10)
                     if (!q1Value || !q2Value) {
-                        if (q1.id < q2.id) return 1
-                        if (q1.id > q2.id) return -1
-                        else return 0
+                        if (q1.id < q2.id) return -1
+                        else return 1
                     } else {
-                        if (q1Value > q2Value) return 1
                         if (q1Value < q2Value) return -1
-                        else return 0
+                        else return 1
                     }
                 })
                 .map((quay, index) => ({

--- a/tavla/app/(admin)/hooks/useQuaySearch.ts
+++ b/tavla/app/(admin)/hooks/useQuaySearch.ts
@@ -30,6 +30,19 @@ function useQuaySearch(stopPlaceId: string, icons = true) {
                 .filter((quay) =>
                     quay.lines.some((line) => line.transportMode !== 'air'),
                 )
+                .sort((q1, q2) => {
+                    const q1Value = parseInt(q1.id.split(':')[2] ?? '', 10)
+                    const q2Value = parseInt(q2.id.split(':')[2] ?? '', 10)
+                    if (!q1Value || !q2Value) {
+                        if (q1.id < q2.id) return 1
+                        if (q1.id > q2.id) return -1
+                        else return 0
+                    } else {
+                        if (q1Value > q2Value) return 1
+                        if (q1Value < q2Value) return -1
+                        else return 0
+                    }
+                })
                 .map((quay, index) => ({
                     value: quay.id,
                     label: getPlatformLabel(


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
I noen tilfeller om man legger inn et stoppested og ønsker å velge flere plattformer så hopper plattformene rundt, noe som blir synlig ved at neste gang man vil legge til en plattform så er det endringer i fremkomstmidlene som er tilgjengelige. Dette skjer kun når plattformen ikke har publicCode eller description. Tallet som vises da er indexen i map som brukes for å gå gjennom alle plattformene som tilhører et stoppested. 
Ett eksempel på dette er Brensholmen ferjekai, hvor en av plattformene er en ferjekai og de to andre er buss, her har ferjen ID "NSR:Quay:96171" mens bussene har ID "NSR:Quay:110819" og "NSR:Quay:110820". 
| | |
|-|-|
|<img width="1024" height="488" alt="image" src="https://github.com/user-attachments/assets/b7c306ca-2e31-4d51-9a6f-e2c5b20aba30" />|<img width="1024" height="503" alt="image" src="https://github.com/user-attachments/assets/f4ee3593-17eb-4526-8697-860d35ed1e6e" />|

Dette gjorde meg oppmerksom på denne stasjonen hvor plattform 2, 3 og 4 (uten buss) har publicCode, mens den siste mangler publicCode. Det er et eksisterende problem som denne PRen ikke forverrer. 
|Før |Etter |
|-|-|
|<img width="1296" height="446" alt="image" src="https://github.com/user-attachments/assets/fe8ba332-e5ea-4c26-994b-b313f3257146" />|<img width="1296" height="446" alt="image" src="https://github.com/user-attachments/assets/4b582101-fc49-4844-a3f3-e6bfecf52b38" />|

## ✨ Endringer

- [x] La til en sortering som først sjekker om stoppestedet har publicCode og så sorterer på det
- [x] Deretter sorterer den på den numeriske delen av plattform-IDen (dersom mulig), men hvis ikke bare sorterer på hele IDen siden det er bedre å ha samme håndtering alltid selv om det kan bli litt whack i forhold til NSR-IDen

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1024" height="488" alt="image" src="https://github.com/user-attachments/assets/49dc59ba-9a52-46f3-b827-22b6c27ecea0" /> | <img width="1071" height="551" alt="image" src="https://github.com/user-attachments/assets/c7ea8474-e30f-451e-9d5a-5a27ffa3fc44" /> |

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari
