### PR TITLE
fix(tavle): add line spacing and text overflow handling for stopplace column

### DIFF
--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -80,7 +80,7 @@ function Name() {
             <TableColumn title="Stoppested">
                 {departures.map((departure) => (
                     <TableRow key={nanoid()}>
-                        <div className="justify-items-end">
+                        <div className="line-clamp-2 justify-items-end overflow-ellipsis hyphens-auto text-em-base/em-base">
                             {departure.quay.name}
                         </div>
                     </TableRow>

--- a/tavla/src/Board/scenarios/Table/components/Platform.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Platform.tsx
@@ -13,7 +13,7 @@ function Platform() {
     }))
 
     return (
-        <TableColumn title="Plattform">
+        <TableColumn title="Plf.">
             {platforms.map((platform) => (
                 <TableRow key={platform.key}>{platform.publicCode}</TableRow>
             ))}


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Hadde ikke fikset alle kolonnene når jeg håndterte problemet med tekstoverflow, men dette skal være den siste kolonnen. La til riktig linjehøyde og håndtering av overflow. 

Endret også "Plattform" til "Plf." som tittel på kolonnen fordi det irriterer meg at det tar opp så voldsomt mye plass, og dette er det Ruter bruker i sin løsning så det burde gå ganske greit (forhåpentligvis). Kan endre tilbake om vi finner ut at folk ikke forstår hva det er. 

## ✨ Endringer

- [x] Fjernet overflow-hidden og la til riktig tekststørrelse og linjehøyde
- [x] La til bindestrek og ellipser ved overflow
- [x] La til formatering slik at det er maks 2 linjer høyt

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1696" height="1266" alt="image" src="https://github.com/user-attachments/assets/77efb6f4-aff3-4065-a03a-86d2f65c8975" /> | <img width="1696" height="1266" alt="image" src="https://github.com/user-attachments/assets/845ed1d7-0535-43c7-8bb6-75cb86f91332" /> |

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
