### PR TITLE
chore(): create separate component for combined situations

### DIFF
--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -11,6 +11,7 @@ import { Table } from '../Table'
 import { useQueries } from 'hooks/useQuery'
 import { DEFAULT_COMBINED_COLUMNS } from 'types/column'
 import { sortBy } from 'lodash'
+import { CombinedTileDeviation } from '../Table/components/StopPlaceDeviation'
 
 function combineIdenticalSituations(situations: TSituationFragment[]) {
     const situationById: { [id: string]: TSituationFragment } = {}
@@ -123,6 +124,7 @@ export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
 
     return (
         <Tile className="flex flex-col max-sm:min-h-[30vh]">
+            <CombinedTileDeviation situations={combinedSituations} />
             <Table
                 departures={sortedEstimatedCalls}
                 situations={combinedSituations}

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -10,6 +10,7 @@ import {
     DataFetchingFailed,
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
+import { StopPlaceQuayDeviation } from '../Table/components/StopPlaceDeviation'
 
 export function QuayTile({
     placeId,
@@ -58,6 +59,7 @@ export function QuayTile({
                 heading={displayName ?? heading}
                 walkingDistance={walkingDistance}
             />
+            <StopPlaceQuayDeviation situations={data.quay.situations} />
             <Table
                 columns={columns}
                 departures={data.quay.estimatedCalls}

--- a/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -9,6 +9,7 @@ import {
     DataFetchingFailed,
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
+import { StopPlaceQuayDeviation } from '../Table/components/StopPlaceDeviation'
 
 export function StopPlaceTile({
     placeId,
@@ -53,6 +54,7 @@ export function StopPlaceTile({
                 heading={displayName ?? data.stopPlace.name}
                 walkingDistance={walkingDistance}
             />
+            <StopPlaceQuayDeviation situations={data.stopPlace.situations} />
             <Table
                 departures={data.stopPlace.estimatedCalls}
                 situations={data.stopPlace.situations}

--- a/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Situation/index.tsx
@@ -20,9 +20,7 @@ function TitleSituation({
     if (!situationText) return null
 
     return (
-        <div
-            className={`mt-[0.1em] flex min-h-max items-center gap-[8px] text-em-situation/em-situation text-warning ${origin && 'mt-[2.5em] pb-[1em]'}`}
-        >
+        <div className="mt-[0.1em] flex min-h-max items-center gap-[8px] text-em-situation/em-situation text-warning">
             <div className="flex self-start pt-[0.05em] text-[1.8em]">
                 <PageNavigationIcon aria-label="" size="0.5em" />
             </div>

--- a/tavla/src/Board/scenarios/Table/components/StopPlaceDeviation/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/StopPlaceDeviation/index.tsx
@@ -2,12 +2,14 @@ import { TSituationFragment } from 'graphql/index'
 import { useCycler } from '../../useCycler'
 import { TitleSituation } from '../Situation'
 
-function StopPlaceDeviation({
+const timerInMilliseconds = 10000
+
+function StopPlaceQuayDeviation({
     situations,
 }: {
     situations?: TSituationFragment[]
 }) {
-    const index = useCycler(situations, 10000)
+    const index = useCycler(situations, timerInMilliseconds)
     const numberOfSituations = situations?.length ?? 0
 
     return (
@@ -21,4 +23,23 @@ function StopPlaceDeviation({
     )
 }
 
-export { StopPlaceDeviation }
+function CombinedTileDeviation({
+    situations,
+}: {
+    situations?: TSituationFragment[]
+}) {
+    const index = useCycler(situations, timerInMilliseconds)
+    const numberOfSituations = situations?.length ?? 0
+
+    return (
+        <div className="mt-[0.5em] min-h-[1.5em] pb-[1em]">
+            {situations && numberOfSituations > 0 && (
+                <TitleSituation
+                    situation={situations[index % numberOfSituations]}
+                />
+            )}
+        </div>
+    )
+}
+
+export { StopPlaceQuayDeviation, CombinedTileDeviation }

--- a/tavla/src/Board/scenarios/Table/index.tsx
+++ b/tavla/src/Board/scenarios/Table/index.tsx
@@ -9,7 +9,6 @@ import { ArrivalTime } from './components/Time/ArrivalTime'
 import { Platform } from './components/Platform'
 import { ExpectedTime } from './components/Time/ExpectedTime'
 import { Line } from './components/Line'
-import { StopPlaceDeviation } from './components/StopPlaceDeviation'
 import Image from 'next/image'
 import leafs from 'assets/illustrations/leafs.svg'
 import leafsLight from 'assets/illustrations/leafs-light.png'
@@ -50,7 +49,6 @@ function Table({
         )
     return (
         <div className="flex flex-col">
-            <StopPlaceDeviation situations={situations} />
             <div className="flex shrink-0">
                 <DeparturesContext.Provider value={departures}>
                     {columns.includes('aimedTime') && <AimedTime />}


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Jeg forsto ikke hvorfor dersom det er inkludert origin for en situasjon at den skulle få mer spacing på topp og bunn selv om det var jeg som la inn stylingen for en uke siden. Da det ble lagt inn var det kun kombinerte tavler som skulle ha origin, noe som ikke er tilfellet lengre. Så jeg lagde en separat komponent for situasjoner som skal ligge på kombinerte tavler da den trenger mer spacing på topp og bunn enn en ordinær situasjon gjør, i håp om at det blir mer forklarende i fremtiden. 

## ✨ Endringer

- [x] Flyttet ut hvor vi henter situasjonsobjektet som skal vises på toppen slik at man kan definere om man vil ha ordinær (StopPlaceQuaySituation) eller en for en kombinert tavle (CombinedTileDeviation)
- [x] Flyttet ut timeren slik at man ikke ender opp med to ulike timer-lengder

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
