### PR TITLE
feat(tavle): show stop place situation on chosen quay

### DIFF
--- a/tavla/src/Board/scenarios/Board/utils.ts
+++ b/tavla/src/Board/scenarios/Board/utils.ts
@@ -1,3 +1,4 @@
+import { TSituationFragment } from 'graphql/index'
 import { TFontSize } from 'types/meta'
 import { TBoard } from 'types/settings'
 export function getFontScale(fontSize: TFontSize | undefined) {
@@ -23,4 +24,24 @@ export function defaultFontSize(board: TBoard) {
         default:
             return 'small'
     }
+}
+
+export function combineIdenticalSituations(situations: TSituationFragment[]) {
+    const situationById: { [id: string]: TSituationFragment } = {}
+
+    situations.map((situation) => {
+        const id = situation.id
+        if (situationById[id]) {
+            const existingOrigins = situationById[id].origin
+                ?.split(', ')
+                .concat([situation.origin ?? ''])
+                .sort()
+
+            situationById[id].origin = existingOrigins?.join(', ')
+        } else {
+            situationById[id] = situation
+        }
+    })
+
+    return Object.values(situationById)
 }

--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -12,26 +12,7 @@ import { useQueries } from 'hooks/useQuery'
 import { DEFAULT_COMBINED_COLUMNS } from 'types/column'
 import { sortBy } from 'lodash'
 import { CombinedTileDeviation } from '../Table/components/StopPlaceDeviation'
-
-function combineIdenticalSituations(situations: TSituationFragment[]) {
-    const situationById: { [id: string]: TSituationFragment } = {}
-
-    situations.map((situation) => {
-        const id = situation.id
-        if (situationById[id]) {
-            const existingOrigins = situationById[id].origin
-                ?.split(', ')
-                .concat([situation.origin ?? ''])
-                .sort()
-
-            situationById[id].origin = existingOrigins?.join(', ')
-        } else {
-            situationById[id] = situation
-        }
-    })
-
-    return Object.values(situationById)
-}
+import { combineIdenticalSituations } from '../Board/utils'
 
 export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
     const quayQueries = combinedTile

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -1,6 +1,6 @@
 import { TQuayTile } from 'types/tile'
 import { Table } from '../Table'
-import { GetQuayQuery } from 'graphql/index'
+import { GetQuayQuery, TSituationFragment } from 'graphql/index'
 import { Tile } from 'components/Tile'
 import { TableHeader } from '../Table/components/TableHeader'
 import { isNotNullOrUndefined } from 'utils/typeguards'
@@ -11,6 +11,7 @@ import {
     FetchErrorTypes,
 } from 'Board/components/DataFetchingFailed'
 import { StopPlaceQuayDeviation } from '../Table/components/StopPlaceDeviation'
+import { combineIdenticalSituations } from '../Board/utils'
 
 export function QuayTile({
     placeId,
@@ -30,6 +31,11 @@ export function QuayTile({
         },
         { poll: true, offset: offset ?? 0 },
     )
+
+    const situations: TSituationFragment[] = combineIdenticalSituations([
+        ...(data?.quay?.stopPlace.situations ?? []),
+        ...(data?.quay?.situations ?? []),
+    ])
 
     if (isLoading && !data) {
         return (
@@ -59,11 +65,11 @@ export function QuayTile({
                 heading={displayName ?? heading}
                 walkingDistance={walkingDistance}
             />
-            <StopPlaceQuayDeviation situations={data.quay.situations} />
+            <StopPlaceQuayDeviation situations={situations} />
             <Table
                 columns={columns}
                 departures={data.quay.estimatedCalls}
-                situations={data.quay.situations}
+                situations={situations}
             />
         </Tile>
     )

--- a/tavla/src/Shared/graphql/index.ts
+++ b/tavla/src/Shared/graphql/index.ts
@@ -156,6 +156,22 @@ export type TGetQuayQuery = {
                 language: string | null
             }>
         }>
+        stopPlace: {
+            situations: Array<{
+                __typename?: 'PtSituationElement'
+                id: string
+                description: Array<{
+                    __typename?: 'MultilingualString'
+                    value: string
+                    language: string | null
+                }>
+                summary: Array<{
+                    __typename?: 'MultilingualString'
+                    value: string
+                    language: string | null
+                }>
+            }>
+        }
         lines: Array<{
             __typename?: 'Line'
             id: string
@@ -417,8 +433,7 @@ export class TypedDocumentString<TResult, TVariables>
     }
 }
 export const SituationFragment = new TypedDocumentString(
-    `
-    fragment situation on PtSituationElement {
+    `fragment situation on PtSituationElement {
   id
   description {
     value
@@ -428,13 +443,11 @@ export const SituationFragment = new TypedDocumentString(
     value
     language
   }
-}
-    `,
+}`,
     { fragmentName: 'situation' },
 ) as unknown as TypedDocumentString<TSituationFragment, unknown>
 export const DepartureFragment = new TypedDocumentString(
-    `
-    fragment departure on EstimatedCall {
+    `fragment departure on EstimatedCall {
   quay {
     publicCode
     name
@@ -465,7 +478,8 @@ export const DepartureFragment = new TypedDocumentString(
     ...situation
   }
 }
-    fragment situation on PtSituationElement {
+
+fragment situation on PtSituationElement {
   id
   description {
     value
@@ -487,22 +501,25 @@ export const LinesFragment = new TypedDocumentString(
     name
     transportMode
   }
-}
-    `,
+}`,
     { fragmentName: 'lines' },
 ) as unknown as TypedDocumentString<TLinesFragment, unknown>
 export const GetQuayQuery = new TypedDocumentString(`
-    query getQuay($quayId: String!, $whitelistedTransportModes: [TransportMode], $whitelistedLines: [ID!], $numberOfDepartures: Int = 20, $startTime: DateTime) {
-  quay(id: $quayId) {
+query getQuay($quayId: String!, $whitelistedTransportModes: [TransportMode], $whitelistedLines: [ID!], $numberOfDepartures: Int = 20, $startTime: DateTime) {
+  quay(
+    id: $quayId
+  ) {
     name
     description
     publicCode
     ...lines
     estimatedCalls(
-      numberOfDepartures: $numberOfDepartures
-      whiteListedModes: $whitelistedTransportModes
-      whiteListed: {lines: $whitelistedLines}
-      includeCancelledTrips: true
+      numberOfDepartures: $numberOfDepartures,
+      whiteListedModes: $whitelistedTransportModes,
+      whiteListed: {
+        lines: $whitelistedLines
+      },
+      includeCancelledTrips: true,
       startTime: $startTime
     ) {
       ...departure
@@ -510,9 +527,15 @@ export const GetQuayQuery = new TypedDocumentString(`
     situations {
       ...situation
     }
+    stopPlace {
+      situations {
+        ...situation
+      }
+    }
   }
 }
-    fragment departure on EstimatedCall {
+
+fragment departure on EstimatedCall {
   quay {
     publicCode
     name
@@ -543,6 +566,7 @@ export const GetQuayQuery = new TypedDocumentString(`
     ...situation
   }
 }
+
 fragment lines on Quay {
   lines {
     id
@@ -551,6 +575,7 @@ fragment lines on Quay {
     transportMode
   }
 }
+
 fragment situation on PtSituationElement {
   id
   description {
@@ -563,24 +588,28 @@ fragment situation on PtSituationElement {
   }
 }`) as unknown as TypedDocumentString<TGetQuayQuery, TGetQuayQueryVariables>
 export const QuayCoordinatesQuery = new TypedDocumentString(`
-    query quayCoordinates($id: String!) {
-  quay(id: $id) {
+query quayCoordinates($id: String!) {
+  quay(
+    id: $id
+  ) {
     id
     longitude
     latitude
   }
-}
-    `) as unknown as TypedDocumentString<
+}`) as unknown as TypedDocumentString<
     TQuayCoordinatesQuery,
     TQuayCoordinatesQueryVariables
 >
 export const QuayEditQuery = new TypedDocumentString(`
-    query quayEdit($placeId: String!) {
-  quay(id: $placeId) {
+query quayEdit($placeId: String!) {
+  quay(
+    id: $placeId
+  ) {
     ...lines
   }
 }
-    fragment lines on Quay {
+
+fragment lines on Quay {
   lines {
     id
     publicCode
@@ -589,22 +618,24 @@ export const QuayEditQuery = new TypedDocumentString(`
   }
 }`) as unknown as TypedDocumentString<TQuayEditQuery, TQuayEditQueryVariables>
 export const QuayNameQuery = new TypedDocumentString(`
-    query QuayName($id: String!) {
-  quay(id: $id) {
+query QuayName($id: String!) {
+  quay(
+    id: $id
+  ) {
     name
     description
     publicCode
     id
   }
-}
-    `) as unknown as TypedDocumentString<
-    TQuayNameQuery,
-    TQuayNameQueryVariables
->
+}`) as unknown as TypedDocumentString<TQuayNameQuery, TQuayNameQueryVariables>
 export const QuaysSearchQuery = new TypedDocumentString(`
-    query quaysSearch($stopPlaceId: String!) {
-  stopPlace(id: $stopPlaceId) {
-    quays(filterByInUse: true) {
+query quaysSearch($stopPlaceId: String!) {
+  stopPlace(
+    id: $stopPlaceId
+  ) {
+    quays(
+      filterByInUse: true
+    ) {
       id
       publicCode
       description
@@ -615,7 +646,8 @@ export const QuaysSearchQuery = new TypedDocumentString(`
     }
   }
 }
-    fragment lines on Quay {
+
+fragment lines on Quay {
   lines {
     id
     publicCode
@@ -627,15 +659,19 @@ export const QuaysSearchQuery = new TypedDocumentString(`
     TQuaysSearchQueryVariables
 >
 export const StopPlaceQuery = new TypedDocumentString(`
-    query StopPlace($stopPlaceId: String!, $whitelistedTransportModes: [TransportMode], $whitelistedLines: [ID!], $numberOfDepartures: Int = 20, $startTime: DateTime) {
-  stopPlace(id: $stopPlaceId) {
+query StopPlace($stopPlaceId: String!, $whitelistedTransportModes: [TransportMode], $whitelistedLines: [ID!], $numberOfDepartures: Int = 20, $startTime: DateTime) {
+  stopPlace(
+    id: $stopPlaceId
+  ) {
     name
     transportMode
     estimatedCalls(
-      numberOfDepartures: $numberOfDepartures
-      whiteListedModes: $whitelistedTransportModes
-      whiteListed: {lines: $whitelistedLines}
-      includeCancelledTrips: true
+      numberOfDepartures: $numberOfDepartures,
+      whiteListedModes: $whitelistedTransportModes,
+      whiteListed: {
+        lines: $whitelistedLines
+      },
+      includeCancelledTrips: true,
       startTime: $startTime
     ) {
       ...departure
@@ -645,7 +681,8 @@ export const StopPlaceQuery = new TypedDocumentString(`
     }
   }
 }
-    fragment departure on EstimatedCall {
+
+fragment departure on EstimatedCall {
   quay {
     publicCode
     name
@@ -676,6 +713,7 @@ export const StopPlaceQuery = new TypedDocumentString(`
     ...situation
   }
 }
+
 fragment situation on PtSituationElement {
   id
   description {
@@ -688,27 +726,33 @@ fragment situation on PtSituationElement {
   }
 }`) as unknown as TypedDocumentString<TStopPlaceQuery, TStopPlaceQueryVariables>
 export const StopPlaceCoordinatesQuery = new TypedDocumentString(`
-    query stopPlaceCoordinates($id: String!) {
-  stopPlace(id: $id) {
+query stopPlaceCoordinates($id: String!) {
+  stopPlace(
+    id: $id
+  ) {
     id
     longitude
     latitude
   }
-}
-    `) as unknown as TypedDocumentString<
+}`) as unknown as TypedDocumentString<
     TStopPlaceCoordinatesQuery,
     TStopPlaceCoordinatesQueryVariables
 >
 export const StopPlaceEditQuery = new TypedDocumentString(`
-    query stopPlaceEdit($placeId: String!) {
-  stopPlace(id: $placeId) {
+query stopPlaceEdit($placeId: String!) {
+  stopPlace(
+    id: $placeId
+  ) {
     name
-    quays(filterByInUse: true) {
+    quays(
+      filterByInUse: true
+    ) {
       ...lines
     }
   }
 }
-    fragment lines on Quay {
+
+fragment lines on Quay {
   lines {
     id
     publicCode
@@ -720,22 +764,30 @@ export const StopPlaceEditQuery = new TypedDocumentString(`
     TStopPlaceEditQueryVariables
 >
 export const StopPlaceNameQuery = new TypedDocumentString(`
-    query StopPlaceName($id: String!) {
-  stopPlace(id: $id) {
+query StopPlaceName($id: String!) {
+  stopPlace(
+    id: $id
+  ) {
     name
     id
   }
-}
-    `) as unknown as TypedDocumentString<
+}`) as unknown as TypedDocumentString<
     TStopPlaceNameQuery,
     TStopPlaceNameQueryVariables
 >
 export const WalkDistanceQuery = new TypedDocumentString(`
-    query walkDistance($from: InputCoordinates!, $to: InputCoordinates!) {
+query walkDistance($from: InputCoordinates!, $to: InputCoordinates!) {
   trip(
-    from: {coordinates: $from}
-    to: {coordinates: $to}
-    modes: {directMode: foot, transportModes: []}
+    from: {
+      coordinates: $from
+    },
+    to: {
+      coordinates: $to
+    },
+    modes: {
+      directMode: foot
+      transportModes: []
+    }
   ) {
     tripPatterns {
       duration
@@ -752,8 +804,7 @@ export const WalkDistanceQuery = new TypedDocumentString(`
       }
     }
   }
-}
-    `) as unknown as TypedDocumentString<
+}`) as unknown as TypedDocumentString<
     TWalkDistanceQuery,
     TWalkDistanceQueryVariables
 >


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
På grunn av hvordan data legges inn litt vilkårlig på plattform og stoppested vil vi vise situasjoner som er lagt inn på stoppested på plattform. Dersom det er lagt inn riktig vil en situasjon som gjelder et stoppested også gjelde for en plattform, og hvis det er lagt inn feil vil situasjonen passe like godt på en plattform som på et stoppested og vil gi brukeren mer informasjon. 

## ✨ Endringer

- [ ] Flyttet combineIdenticalSituations fra hvor den lå i combinedTile ut til board-utils siden den blir brukt flere steder
- [ ] Henter inn situasjonene for stoppestedet plattformen tilhører i datainnhentingen (og oppdaterer typen for quayQuery resultatet)
- [ ] Kombinerer situasjonene på plattformen med situasjonene på stoppestedet og bruker combineIdenticalSituations for å kun vise unike situasjoner på selve quayTile
- [ ] Brukte prettify i Shamash til å oppdatere formatet på queryene fordi de var litt stygge

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1696" height="1266" alt="image" src="https://github.com/user-attachments/assets/a4414227-e348-4af1-83c6-375805a99494" /> | <img width="1696" height="1266" alt="image" src="https://github.com/user-attachments/assets/73785cad-b3ea-433a-a968-dd4d5c4ad938" /> |

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
