### PR TITLE
fix(rediger): make dark bg default for transport settings

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
@@ -76,7 +76,7 @@ function TransportPaletteSelect({
                     <div key={palette.value}>
                         <Radio value={palette.value}>{palette.label}</Radio>
                         <div
-                            className={`max-w-max rounded-sm ${theme === 'dark' ? 'bg-black' : 'bg-white'} flex flex-col px-2 py-3`}
+                            className={`max-w-max rounded-sm ${theme === 'light' ? 'bg-white' : 'bg-black'} flex flex-col px-2 py-3`}
                             data-theme={theme}
                             data-transport-palette={palette.value}
                         >


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Default tema på en tavle er mørk, og da vil vi at dette skal reflekteres i transportfargeforhåndsvisningen også. 

## ✨ Endringer

- [x] Endret den logiske sjekken fra å sjekke om temaet er mørkt til å sjekke om temaet er lyst slik at man vil ha mørk bakgrunn på transportfargene som default

## 📸 Screenshots

Ved opprettelse av en helt fersk tavle: 
| Før   | Etter |
| ----- | ----- |
| <img width="1334" height="1266" alt="image" src="https://github.com/user-attachments/assets/0779e0fb-2b27-4109-bcd9-fd4f4b2e247e" /> | <img width="1334" height="1266" alt="image" src="https://github.com/user-attachments/assets/5c21132c-e329-40e1-8c1e-952cc1f431a8" /> |

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
