### PR TITLE
feat(tavle): show quay situations on stop place

### DIFF
--- a/tavla/src/Shared/graphql/index.ts
+++ b/tavla/src/Shared/graphql/index.ts
@@ -276,6 +276,26 @@ export type TStopPlaceQuery = {
         __typename?: 'StopPlace'
         name: string
         transportMode: Array<Types.TTransportMode | null> | null
+        quays: Array<{
+            __typename?: 'QuaySituations'
+            publicCode: string | null
+            name: string
+
+            situations: Array<{
+                __typename?: 'PtSituationElement'
+                id: string
+                description: Array<{
+                    __typename?: 'MultilingualString'
+                    value: string
+                    language: string | null
+                }>
+                summary: Array<{
+                    __typename?: 'MultilingualString'
+                    value: string
+                    language: string | null
+                }>
+            }>
+        }>
         estimatedCalls: Array<{
             __typename?: 'EstimatedCall'
             aimedDepartureTime: DateTime
@@ -678,6 +698,13 @@ query StopPlace($stopPlaceId: String!, $whitelistedTransportModes: [TransportMod
     }
     situations {
       ...situation
+    }
+    quays {
+      publicCode
+      name
+      situations {
+        ...situation
+      }
     }
   }
 }


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
[Se oppgave her.](https://enturas.atlassian.net/browse/ETU-60266?atlOrigin=eyJpIjoiNjJmMGQ2NTg5ZWM1NDdjZDhmM2M0YjQ0N2JhN2VmNjQiLCJwIjoiaiJ9)  
I blant legger operatørene inn situasjoner på plattformer som også burde ligget på stoppestedet. Vi vil hente situasjonene opp fra plattformen og opp på stoppestedsnivå her. 

## ✨ Endringer

- [x] Endre datainnhentingen slik at stopPlaceQuery henter plattformene på stoppestedet med deres tilhørende situasjoner
- [x] Kombinerer situasjonene til stoppestedet med situasjonene på de ulike plattformene
- [ ] Ideelt sett ville vi ha lagt til en origin som heter "Plattform A, B, ..." men det går ikke da mange plattformer mangler en offentlig ID

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1334" height="1266" alt="image" src="https://github.com/user-attachments/assets/6ce37575-8f58-440b-a71e-2a007739d418" /> | <img width="1334" height="1266" alt="image" src="https://github.com/user-attachments/assets/11d04a41-07ec-433d-91b5-622c96cee4ac" /> |

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari
- [ ] UU-sjekk/gjennomgang
- [ ] Skrevet eventuell dokumentasjon/tester
- [ ] ...

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
