### PR TITLE
feat(tavla): implement new cancelled call design

### DIFF
--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -140,18 +140,17 @@
 
     /* Light theme palettes */
     [data-transport-palette='blue-bus'] {
-        --bus-color: var(--standard-train);
+        --bus-color: var(--colors-transport-default-train);
         --bus-color-transparent: var(--standard-train-transparent);
-        --rail-color: var(--standard-bus);
+        --rail-color: var(--colors-transport-default-bus);
         --rail-color-transparent: var(--standard-bus-transparent);
     }
 
     /* Dark theme palettes */
-
     [data-theme='dark'][data-transport-palette='blue-bus'] {
-        --bus-color: var(--contrast-train);
+        --bus-color: var(--colors-transport-contrast-train);
         --bus-color-transparent: var(--contrast-train-transparent);
-        --rail-color: var(--contrast-bus);
+        --rail-color: var(--colors-transport-contrast-bus);
         --rail-color-transparent: var(--contrast-bus-transparent);
     }
 

--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -47,6 +47,20 @@
         --water-color: var(--colors-transport-default-ferry);
         --taxi-color: var(--colors-transport-default-taxi);
 
+        --metro-color-transparent: var(--standard-metro-transparent);
+        --bus-color-transparent: var(--standard-bus-transparent);
+        --tram-color-transparent: var(--standard-tram-transparent);
+        --funicular-color-transparent: var(--standard-funicular-transparent);
+        --cableway-color-transparent: var(--standard-cableway-transparent);
+        --rail-color-transparent: var(--standard-train-transparent);
+        --air-color-transparent: var(--standard-plane-transparent);
+        --coach-color-transparent: var(--standard-bus-transparent);
+        --lift-color-transparent: var(--standard-cableway-transparent);
+        --monorail-color-transparent: var(--standard-tram-transparent);
+        --trolleybus-color-transparent: var(--standard-bus-transparent);
+        --water-color-transparent: var(--standard-ferry-transparent);
+        --taxi-color-transparent: var(--standard-taxi-transparent);
+
         --data-visualization-azure: var(--colors-data-default-azure);
         --data-visualization-blue: var(--colors-data-default-blue);
         --data-visualization-coral: var(--colors-data-default-coral);
@@ -100,6 +114,20 @@
         --water-color: var(--colors-transport-contrast-ferry);
         --taxi-color: var(--colors-transport-contrast-taxi);
 
+        --metro-color-transparent: var(--contrast-metro-transparent);
+        --bus-color-transparent: var(--contrast-bus-transparent);
+        --tram-color-transparent: var(--contrast-tram-transparent);
+        --funicular-color-transparent: var(--contrast-funicular-transparent);
+        --cableway-color-transparent: var(--contrast-cableway-transparent);
+        --rail-color-transparent: var(--contrast-train-transparent);
+        --air-color-transparent: var(--contrast-plane-transparent);
+        --coach-color-transparent: var(--contrast-bus-transparent);
+        --lift-color-transparent: var(--contrast-cableway-transparent);
+        --monorail-color-transparent: var(--contrast-tram-transparent);
+        --trolleybus-color-transparent: var(--contrast-bus-transparent);
+        --water-color-transparent: var(--contrast-ferry-transparent);
+        --taxi-color-transparent: var(--contrast-taxi-transparent);
+
         --data-visualization-azure: var(--colors-data-contrast-azure);
         --data-visualization-blue: var(--colors-data-contrast-blue);
         --data-visualization-coral: var(--colors-data-contrast-coral);
@@ -111,17 +139,20 @@
     }
 
     /* Light theme palettes */
-
     [data-transport-palette='blue-bus'] {
-        --bus-color: var(--colors-transport-default-train);
-        --rail-color: var(--colors-transport-default-bus);
+        --bus-color: var(--standard-train);
+        --bus-color-transparent: var(--standard-train-transparent);
+        --rail-color: var(--standard-bus);
+        --rail-color-transparent: var(--standard-bus-transparent);
     }
 
     /* Dark theme palettes */
 
     [data-theme='dark'][data-transport-palette='blue-bus'] {
-        --bus-color: var(--colors-transport-contrast-train);
-        --rail-color: var(--colors-transport-contrast-bus);
+        --bus-color: var(--contrast-train);
+        --bus-color-transparent: var(--contrast-train-transparent);
+        --rail-color: var(--contrast-bus);
+        --rail-color-transparent: var(--contrast-bus-transparent);
     }
 
     [data-theme='entur'] {

--- a/tavla/src/Board/scenarios/Table/components/Deviation.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Deviation.tsx
@@ -1,25 +1,42 @@
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { DeparturesContext } from '../contexts'
-import { Situations } from './Situations'
 import { TableColumn } from './TableColumn'
 import { TableRow } from './TableRow'
+import {
+    ValidationErrorFilledIcon,
+    ValidationExclamationCircleFilledIcon,
+} from '@entur/icons'
 
-function Deviation({ situations = true }: { situations?: boolean }) {
+function Deviation() {
     const departures = useNonNullContext(DeparturesContext)
 
     const deviations = departures.map((departure) => ({
         situations: departure.situations ?? [],
         key: `${departure.serviceJourney.id}_${departure.aimedDepartureTime}`,
+        cancelled: departure.cancellation,
     }))
+
     return (
-        <TableColumn title="Avvik" className="grow">
-            {deviations.map((deviation) => (
-                <TableRow key={deviation.key}>
-                    {situations && (
-                        <Situations situations={deviation.situations} />
-                    )}
-                </TableRow>
-            ))}
+        <TableColumn>
+            {deviations.map((deviation) =>
+                deviation.cancelled ? (
+                    <TableRow key={deviation.key}>
+                        <div className="flex w-10 items-center justify-center text-error">
+                            <ValidationErrorFilledIcon />
+                        </div>
+                    </TableRow>
+                ) : (
+                    <TableRow key={deviation.key}>
+                        <div className="flex w-10 items-center justify-center text-warning">
+                            {deviation.situations.length > 0 ? (
+                                <ValidationExclamationCircleFilledIcon />
+                            ) : (
+                                <div />
+                            )}
+                        </div>
+                    </TableRow>
+                ),
+            )}
         </TableColumn>
     )
 }

--- a/tavla/src/Board/scenarios/Table/components/Line/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Line/index.tsx
@@ -16,6 +16,7 @@ function Line() {
         publicCode: departure.serviceJourney.line.publicCode ?? '',
         key: nanoid(),
         id: departure.serviceJourney.id ?? '',
+        cancelled: departure.cancellation,
     }))
 
     return (
@@ -31,6 +32,7 @@ function Line() {
                                     ? (getAirPublicCode(line.id) ?? '')
                                     : line.publicCode
                             }
+                            cancelled={line.cancelled}
                         />
                     </div>
                 </TableRow>

--- a/tavla/src/Board/scenarios/Table/components/TableColumn/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableColumn/index.tsx
@@ -3,14 +3,14 @@ function TableColumn({
     children,
     className,
 }: {
-    title: string
+    title?: string
     children: React.ReactNode
     className?: string
 }) {
     return (
         <div className={`flex flex-col ${className}`}>
             <div className="mx-2 pb-2 text-em-sm/em-base text-primary">
-                {title}
+                {title ?? <div className="h-[1.1em]" />}
             </div>
             {children}
         </div>

--- a/tavla/src/Board/scenarios/Table/index.tsx
+++ b/tavla/src/Board/scenarios/Table/index.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image'
 import leafs from 'assets/illustrations/leafs.svg'
 import leafsLight from 'assets/illustrations/leafs-light.png'
 import { Paragraph } from '@entur/typography'
+import { Deviation } from './components/Deviation'
 
 function Table({
     departures,
@@ -51,6 +52,7 @@ function Table({
         <div className="flex flex-col">
             <div className="flex shrink-0">
                 <DeparturesContext.Provider value={departures}>
+                    <Deviation />
                     {columns.includes('aimedTime') && <AimedTime />}
                     {columns.includes('arrivalTime') && <ArrivalTime />}
                     {columns.includes('line') && <Line />}

--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -23,24 +23,30 @@ function TravelTag({
     transportMode,
     publicCode,
     transportSubmode,
+    cancelled,
 }: {
     transportMode: TTransportMode
     publicCode: string
     transportSubmode?: TTransportSubmode
+    cancelled?: boolean
 }) {
+    const travelTagBackround = `bg-${transportMode}${cancelled && transportMode !== 'unknown' ? '-transparent' : ''}`
+    const iconPublicCodeColor =
+        cancelled && transportMode !== 'unknown' ? transportMode : 'background'
+
     return (
         <div
             aria-label={`${transportModeNames[transportMode]} - linje ${publicCode}`}
-            className={`flex h-full w-full items-center justify-between rounded-sm pl-2 font-bold text-background bg-${
-                transportMode ?? 'unknown'
-            }`}
+            className={`flex h-full w-full items-center justify-between rounded-sm pl-2 font-bold ${travelTagBackround}`}
         >
             <TransportIcon
-                className="h-em-2 w-em-2 fill-background"
+                className={`h-em-2 w-em-2 fill-${iconPublicCodeColor}`}
                 transportMode={transportMode}
                 transportSubmode={transportSubmode}
             />
-            <div className="flex h-full w-full flex-row items-center justify-center">
+            <div
+                className={`flex h-full w-full flex-row items-center justify-center text-${iconPublicCodeColor}`}
+            >
                 {publicCode}
             </div>
         </div>

--- a/tavla/tailwind.config.ts
+++ b/tavla/tailwind.config.ts
@@ -17,6 +17,22 @@ const transportModes = {
     water: 'var(--water-color)',
     taxi: 'var(--taxi-color)',
 }
+const transportModesTransparent = {
+    'metro-transparent': 'var(--metro-color-transparent)',
+    'bus-transparent': 'var(--bus-color-transparent)',
+    'tram-transparent': 'var(--tram-color-transparent)',
+    'rail-transparent': 'var(--rail-color-transparent)',
+    'air-transparent': 'var(--air-color-transparent)',
+    'funicular-transparent': 'var(--funicular-color-transparent)',
+    'cableway-transparent': 'var(--cableway-color-transparent)',
+    'coach-transparent': 'var(--coach-color-transparent)',
+    'lift-transparent': 'var(--lift-color-transparent)',
+    'monorail-transparent': 'var(--monorail-color-transparent)',
+    'trolleybus-transparent': 'var(--trolleybus-color-transparent)',
+    'unknown-transparent': 'var(--unknown-color-transparent)',
+    'water-transparent': 'var(--water-color-transparent)',
+    'taxi-transparent': 'var(--taxi-color-transparent)',
+}
 
 module.exports = {
     content: [
@@ -57,6 +73,7 @@ module.exports = {
                 tooltip: 'var(--tooltip-color)',
                 'tooltip-text': 'var(--tooltip-text-color)',
                 ...transportModes,
+                ...transportModesTransparent,
                 ...dataColors,
             },
             borderRadius: {
@@ -106,7 +123,11 @@ module.exports = {
             },
         },
     },
-    safelist: Object.keys(transportModes).map((key) => `bg-${key}`),
+    safelist: [
+        ...Object.keys(transportModes).map((key) => `bg-${key}`),
+        ...Object.keys(transportModesTransparent).map((key) => `bg-${key}`),
+        ...Object.keys(transportModes).map((key) => `text-${key}`),
+    ],
 
     plugins: [],
 } satisfies Config


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Dette er en oppgave som er en del av arbeidet med å forbedre avviksinformasjon i Tavla. Denne PRen implementerer ny visning av en avviks-kolonne helt til venstre i Tavla som skal vise om en avgang er innstilt, eller om den har et avvik. Den endrer også designet på TravelTag dersom en avgang er innstilt til det nye designet. 

## ✨ Endringer

- [x] Implementerte gjennomsiktige farger fra designsystemet ved å legge de til i globals.css og tailwind og safeliste de i tailwind-configen
- [x] Endrer designet på TravelTag til å ha gjennomsiktig fremkomstmiddel-farget bakgrunn og fremkomstmiddel-farge på ikon og tekst dersom avgangen er innstilt
- [x] Endrer den gamle Deviation-kolonnen til å vise rød sirkel med x om avgangen er innstilt, eller gul sirkel med utropstegn om det er et avvik på avgangen
- [x] Legger til Deviation-kolonnen slik at den alltid vises i Tavla
- [x] Håndterer manglende tittel på en kolonne ved å sette en fast høyde på den dersom det ikke er noen tittel

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1678" height="1252" alt="image" src="https://github.com/user-attachments/assets/6fa592b8-9624-40ce-9575-0d4f4f9e17e4" /> | <img width="1678" height="1252" alt="image" src="https://github.com/user-attachments/assets/81206d53-e5b9-4eeb-988e-971f4431916a" /> |
|<img width="1678" height="1252" alt="image" src="https://github.com/user-attachments/assets/45cd1fa4-4b44-40ad-b28d-9d6a5477444b" />|<img width="1678" height="1252" alt="image" src="https://github.com/user-attachments/assets/bd158f19-7d66-4161-9042-55c0c9f9441d" />|
|<img width="1678" height="1252" alt="image" src="https://github.com/user-attachments/assets/8d69fd05-371e-4307-b60b-6da6e8747012" />|<img width="1678" height="1252" alt="image" src="https://github.com/user-attachments/assets/0de10883-583c-423a-8079-8bbb526927c9" />|

Hvordan en gjennomsiktig TravelTag ser ut dersom avgangen er kansellert:
|Lys|Mørk|
|---|-----|
|<img width="626" height="437" alt="image" src="https://github.com/user-attachments/assets/995d5272-c6e9-4bc6-b81e-32bf6e789acb" />|<img width="626" height="437" alt="image" src="https://github.com/user-attachments/assets/41107fa2-a774-4e4d-aa07-868737efc2a7" />|

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari
- [x] Testet i browserstack

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
