### PR TITLE
fix(rediger): show dark travel tags on dark bg

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
@@ -49,7 +49,7 @@ function TransportPaletteSelect({
     theme,
 }: {
     transportPalette?: TTransportPalette
-    theme?: TTheme
+    theme: TTheme
 }) {
     const [selectedValue, setSelectedValue] =
         useState<TTransportPalette>(transportPalette)

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
@@ -75,7 +75,7 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
                         <ThemeSelect theme={board.theme} />
                         <TransportPaletteSelect
                             transportPalette={board.transportPalette}
-                            theme={board.theme}
+                            theme={board.theme ?? 'dark'}
                         ></TransportPaletteSelect>
                         <FontSelect font={board.meta.fontSize} />
                         <WalkingDistance location={board.meta.location} />


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
I #1962 håndterte jeg bare at bakgrunnen skulle være dark dersom man ikke hadde satt noe, slik at travel tags fremdeles viser feil format. Nå ser det riktig ut. 

## ✨ Endringer

- [ ] Endret at theme ikke kunne være undefined slik at man heller setter default lengre ute

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="488" height="397" alt="image" src="https://github.com/user-attachments/assets/37ca1ec6-8c65-4997-a72c-e5a5d332b506" /> | <img width="488" height="397" alt="image" src="https://github.com/user-attachments/assets/055aee91-39b3-4ad0-a206-019fb487e227" /> |
|Ser fremdeles greit ut når man bytter til lightmode|<img width="488" height="397" alt="image" src="https://github.com/user-attachments/assets/99731567-5e16-4dd6-893a-43f8593ea5e0" />|

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
