### PR TITLE
fix(): update tailwindcss prettier config

### DIFF
--- a/tavla/.prettierrc.js
+++ b/tavla/.prettierrc.js
@@ -10,9 +10,10 @@ const config = {
     semi: false,
     singleQuote: true,
     plugins: [
-        'prettier-plugin-tailwindcss',
         'prettier-plugin-organize-imports',
+        'prettier-plugin-tailwindcss',
     ],
+    tailwindConfig: './tailwind.config.ts',
 }
 
 module.exports = config


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Tailwindcss prettier slutta å funke tydeligvis etter import organizer prettier pluginen ble lagt til.

## ✨ Endringer

- [x] Oppdaterte tailwindcss prettier
- [x] Endret tailwindcss prettier innstillingene etter [denne kommentaren](https://stackoverflow.com/questions/75628944/prettier-tailwind-plugin-isnt-working-as-expected-when-i-hit-save-in-vscode) og da funka det

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
