### PR TITLE
chore(colors): update success color on dark theme

### DIFF
--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -1,3 +1,4 @@
+@import '@entur/tokens/dist/semantic.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -84,7 +85,7 @@
 
         --error-color: var(--colors-validation-lava-contrast);
         --warning-color: var(--colors-validation-canary-contrast);
-        --success-color: #75daad;
+        --success-color: var(--fill-success-contrast);
 
         --estimated-time-color: var(--colors-brand-coral);
         --divider-color: var(--colors-blues-blue20);


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Det er lettere å maintaine styling om vi bruker fargene fra Linje slik at vi slipper å passe det på selv. 

## ✨ Endringer

- [x] Endret hardkodet verdi for success-color på dark theme til mint-fargen på den nye måten man er ment å gjøre det
- [x] Importerer de semantiske fargene for å kunne bruke fargen

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="121" height="122" alt="image" src="https://github.com/user-attachments/assets/78106150-79f3-41ee-b190-c42d7ff61c3c" /> | <img width="121" height="122" alt="image" src="https://github.com/user-attachments/assets/759ad7f4-5f51-482e-9cc5-b0e472b83328" /> |

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari
- [x] [UU-sjekk](https://webaim.org/resources/contrastchecker/?fcolor=5AC39B&bcolor=121212)
- [x] Testet i Browserstack


<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
