### PR TITLE
chore(): rename TableRow to TableCell

### DIFF
--- a/tavla/src/Board/scenarios/Table/components/Destination.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Destination.tsx
@@ -4,8 +4,8 @@ import { nanoid } from 'nanoid'
 import { isNotNullOrUndefined } from 'utils/typeguards'
 import { DeparturesContext } from '../contexts'
 import { Situations } from './Situations'
+import { TableCell } from './TableCell'
 import { TableColumn } from './TableColumn'
-import { TableRow } from './TableRow'
 
 function filterIdenticalSituations(
     originSituations?: TSituationFragment[],
@@ -52,7 +52,7 @@ function Destination({
         <div className="grow overflow-hidden">
             <TableColumn title="Destinasjon">
                 {destinations.map((destination) => (
-                    <TableRow
+                    <TableCell
                         key={destination.key}
                         className="flex align-middle"
                     >
@@ -65,7 +65,7 @@ function Destination({
                         {deviations && (
                             <Situations situations={destination.situations} />
                         )}
-                    </TableRow>
+                    </TableCell>
                 ))}
             </TableColumn>
         </div>
@@ -79,11 +79,11 @@ function Name() {
         <div className="grow overflow-hidden">
             <TableColumn title="Stoppested">
                 {departures.map((departure) => (
-                    <TableRow key={nanoid()}>
+                    <TableCell key={nanoid()}>
                         <div className="line-clamp-2 justify-items-end overflow-ellipsis hyphens-auto text-em-base/em-base">
                             {departure.quay.name}
                         </div>
-                    </TableRow>
+                    </TableCell>
                 ))}
             </TableColumn>
         </div>

--- a/tavla/src/Board/scenarios/Table/components/Deviation.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Deviation.tsx
@@ -4,8 +4,8 @@ import {
 } from '@entur/icons'
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { DeparturesContext } from '../contexts'
+import { TableCell } from './TableCell'
 import { TableColumn } from './TableColumn'
-import { TableRow } from './TableRow'
 
 function Deviation() {
     const departures = useNonNullContext(DeparturesContext)
@@ -20,13 +20,13 @@ function Deviation() {
         <TableColumn>
             {deviations.map((deviation) =>
                 deviation.cancelled ? (
-                    <TableRow key={deviation.key}>
+                    <TableCell key={deviation.key}>
                         <div className="flex w-10 items-center justify-center text-error">
                             <ValidationErrorFilledIcon />
                         </div>
-                    </TableRow>
+                    </TableCell>
                 ) : (
-                    <TableRow key={deviation.key}>
+                    <TableCell key={deviation.key}>
                         <div className="flex w-10 items-center justify-center text-warning">
                             {deviation.situations.length > 0 ? (
                                 <ValidationExclamationCircleFilledIcon />
@@ -34,7 +34,7 @@ function Deviation() {
                                 <div />
                             )}
                         </div>
-                    </TableRow>
+                    </TableCell>
                 ),
             )}
         </TableColumn>

--- a/tavla/src/Board/scenarios/Table/components/Line/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Line/index.tsx
@@ -3,8 +3,8 @@ import { useNonNullContext } from 'hooks/useNonNullContext'
 import { nanoid } from 'nanoid'
 import { getAirPublicCode } from 'utils/publicCode'
 import { DeparturesContext } from '../../contexts'
+import { TableCell } from '../TableCell'
 import { TableColumn } from '../TableColumn'
-import { TableRow } from '../TableRow'
 
 function Line() {
     const departures = useNonNullContext(DeparturesContext)
@@ -22,7 +22,7 @@ function Line() {
     return (
         <TableColumn title="Linje">
             {lines.map((line) => (
-                <TableRow key={line.key}>
+                <TableCell key={line.key}>
                     <div className="flex w-full items-center justify-start gap-2 pr-2">
                         <TravelTag
                             transportMode={line.transportMode}
@@ -35,7 +35,7 @@ function Line() {
                             cancelled={line.cancelled}
                         />
                     </div>
-                </TableRow>
+                </TableCell>
             ))}
         </TableColumn>
     )

--- a/tavla/src/Board/scenarios/Table/components/Platform.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Platform.tsx
@@ -1,8 +1,8 @@
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { nanoid } from 'nanoid'
 import { DeparturesContext } from '../contexts'
+import { TableCell } from './TableCell'
 import { TableColumn } from './TableColumn'
-import { TableRow } from './TableRow'
 
 function Platform() {
     const departures = useNonNullContext(DeparturesContext)
@@ -15,7 +15,7 @@ function Platform() {
     return (
         <TableColumn title="Plf.">
             {platforms.map((platform) => (
-                <TableRow key={platform.key}>{platform.publicCode}</TableRow>
+                <TableCell key={platform.key}>{platform.publicCode}</TableCell>
             ))}
         </TableColumn>
     )

--- a/tavla/src/Board/scenarios/Table/components/TableCell/index.tsx
+++ b/tavla/src/Board/scenarios/Table/components/TableCell/index.tsx
@@ -1,4 +1,4 @@
-function TableRow({
+function TableCell({
     className,
     children,
 }: {
@@ -14,4 +14,4 @@ function TableRow({
     )
 }
 
-export { TableRow }
+export { TableCell }

--- a/tavla/src/Board/scenarios/Table/components/Time/AimedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/AimedTime.tsx
@@ -1,8 +1,8 @@
 import { DeparturesContext } from 'Board/scenarios/Table/contexts'
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { nanoid } from 'nanoid'
+import { TableCell } from '../TableCell'
 import { TableColumn } from '../TableColumn'
-import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
 
 function AimedTime() {
@@ -16,9 +16,9 @@ function AimedTime() {
     return (
         <TableColumn title="Planlagt" className="text-right">
             {time.map((t) => (
-                <TableRow key={t.key}>
+                <TableCell key={t.key}>
                     <FormattedTime time={t.aimedDepartureTime} />
-                </TableRow>
+                </TableCell>
             ))}
         </TableColumn>
     )

--- a/tavla/src/Board/scenarios/Table/components/Time/ArrivalTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ArrivalTime.tsx
@@ -1,8 +1,8 @@
 import { DeparturesContext } from 'Board/scenarios/Table/contexts'
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { nanoid } from 'nanoid'
+import { TableCell } from '../TableCell'
 import { TableColumn } from '../TableColumn'
-import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
 
 function ArrivalTime() {
@@ -16,9 +16,9 @@ function ArrivalTime() {
     return (
         <TableColumn title="Ankomst" className="text-right">
             {time.map((t) => (
-                <TableRow key={t.key}>
+                <TableCell key={t.key}>
                     <FormattedTime time={t.expectedArrivalTime} />
-                </TableRow>
+                </TableCell>
             ))}
         </TableColumn>
     )

--- a/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
+++ b/tavla/src/Board/scenarios/Table/components/Time/ExpectedTime.tsx
@@ -2,8 +2,8 @@ import { DeparturesContext } from 'Board/scenarios/Table/contexts'
 import { useNonNullContext } from 'hooks/useNonNullContext'
 import { nanoid } from 'nanoid'
 import { formatDateString, getRelativeTimeString } from 'utils/time'
+import { TableCell } from '../TableCell'
 import { TableColumn } from '../TableColumn'
-import { TableRow } from '../TableRow'
 import { FormattedTime } from './components/FormattedTime'
 
 const TWO_MINUTES = 120
@@ -21,13 +21,13 @@ function ExpectedTime() {
     return (
         <TableColumn title="Forventet" className="text-right">
             {time.map((t) => (
-                <TableRow key={t.key}>
+                <TableCell key={t.key}>
                     <Time
                         expectedDepartureTime={t.expectedDepartureTime}
                         aimedDepartureTime={t.aimedDepartureTime}
                         cancelled={t.cancelled}
                     />
-                </TableRow>
+                </TableCell>
             ))}
         </TableColumn>
     )


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
TableRow er feilaktig kalt det da det er en celle egentlig. 

## ✨ Endringer

- [x] Endret TableRow til å hete TableCell

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari
- [x] Test i Browserstack

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
