### PR TITLE
chore(oversikt): change order create tavle and create folder

### DIFF
--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -31,8 +31,8 @@ async function FoldersAndBoardsPage() {
             <div className="flex flex-row justify-between max-sm:flex-col">
                 <Heading1>Mine tavler</Heading1>
                 <div className="flex flex-row gap-4">
-                    <CreateFolder />
                     <CreateBoard />
+                    <CreateFolder />
                 </div>
             </div>
 


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Det er vanlig at primary button, altså opprett tavle, kommer før secondary, så byttet om plassen på disse.

## ✨ Endringer

- [x] Endret rekkefølge på Opprett Tavle og Opprett Mappe på oversiktssiden

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1547" height="825" alt="image" src="https://github.com/user-attachments/assets/cfc6156b-1b1a-4807-a7a5-de6a3f07787a" /> | <img width="1547" height="825" alt="image" src="https://github.com/user-attachments/assets/c8f49cc9-d80b-4fa5-8fbe-426e82abbc1f" /> |

## ✅ Sjekkliste

- [x] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
