### PR TITLE
chore(rediger): add clearable on text fields

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/Footer.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/Footer.tsx
@@ -3,9 +3,18 @@ import { ValidationInfoFilledIcon } from '@entur/icons'
 import { Tooltip } from '@entur/tooltip'
 import { Heading4 } from '@entur/typography'
 import ClientOnlyTextField from 'app/components/NoSSR/TextField'
+import { HiddenInput } from 'components/Form/HiddenInput'
+import { useState } from 'react'
 import { TFooter } from 'types/settings'
 
-function Footer({ footer }: { footer?: TFooter }) {
+function Footer({ infoMessage }: { infoMessage?: TFooter }) {
+    const [selectedValue, setSelectedValue] = useState<string>(
+        infoMessage?.footer ?? '',
+    )
+    const handleChange = (value: string) => {
+        setSelectedValue(value)
+    }
+
     return (
         <div className="flex flex-col">
             <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
@@ -15,21 +24,25 @@ function Footer({ footer }: { footer?: TFooter }) {
                     <Tooltip
                         content="Skriv en kort tekst som skal vises nederst i tavlen."
                         placement="top"
-                        id="tooltip-footer"
+                        id="tooltip-info-message"
                     >
                         <ValidationInfoFilledIcon
                             size={20}
-                            aria-labelledby="tooltip-footer"
+                            aria-labelledby="tooltip-info-message"
                         />
                     </Tooltip>
                 </div>
             </div>
             <ClientOnlyTextField
+                value={selectedValue}
+                onChange={(f) => handleChange(f.target.value as string)}
                 label="Infomelding"
                 name="footer"
-                defaultValue={footer?.footer ?? ''}
                 className="w-full"
+                clearable
+                onClear={() => setSelectedValue('')}
             />
+            <HiddenInput id="infoMessage" value={selectedValue} />
         </div>
     )
 }

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
@@ -79,7 +79,7 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
                         ></TransportPaletteSelect>
                         <FontSelect font={board.meta.fontSize} />
                         <WalkingDistance location={board.meta.location} />
-                        <Footer footer={board.footer} />
+                        <Footer infoMessage={board.footer} />
                         <HiddenInput id="bid" value={board.id} />
                     </div>
                 </div>

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
@@ -359,6 +359,10 @@ function TileCard({
                                 type="number"
                                 min={0}
                                 className="!w-full md:!w-1/2 lg:!w-1/4"
+                                clearable
+                                onClear={() => {
+                                    setOffset('')
+                                }}
                                 value={offset}
                                 onChange={(e) => {
                                     setOffset(e.target.valueAsNumber || '')


### PR DESCRIPTION
## 🥅 Motivasjon

<!--Hvorfor gjør vi denne endringen? Hva løser PRen?-->
Vi vil oppdatere tekstfelter som mangler clearable til å ha det for å forbedre brukeropplevelsen på Tavla. 

## ✨ Endringer

- [ ] legger til clearable på gangavstand-offset
- [ ] legger til clearable på infomelding ved å legge til state-håndtering og hiddeninput slik at det fremdeles fungerer med Form
- [ ] endrer fra footer til infomelding på input i Footer men beholder større endringer til PRen hvor det skal tas

## ✅ Sjekkliste

- [ ] Testet i både Firefox, Chrome og Safari

<!--Liten merknad om at dette er en oppgave som er blitt jobbet med alene-->

> 🌞 En av Annika sine aleneoppgaver 🌞
