### PR TITLE
fix(navbar): add navbar responsiveness for mobile

### DIFF
--- a/tavla/app/(admin)/components/Login/index.tsx
+++ b/tavla/app/(admin)/components/Login/index.tsx
@@ -23,7 +23,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 onClick={async () => {
                     await logout()
                 }}
-                className="!hidden gap-4 md:!flex"
+                className="shrink-0 gap-2 md:!flex"
             >
                 <LogOutIcon />
                 Logg ut
@@ -36,7 +36,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 as={Link}
                 href="?login"
                 scroll={false}
-                className="gap-4 p-4"
+                className="shrink-0 gap-2"
             >
                 <UserIcon />
                 Logg inn

--- a/tavla/app/(admin)/components/MobileNavbar.tsx
+++ b/tavla/app/(admin)/components/MobileNavbar.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Button, IconButton } from '@entur/button'
+import { IconButton, PrimaryButton } from '@entur/button'
 import { CloseIcon, LeftArrowIcon, MenuIcon } from '@entur/icons'
 import { SideNavigation, SideNavigationItem } from '@entur/menu'
 import { Modal } from '@entur/modal'
@@ -8,23 +8,23 @@ import TavlaLogoBlue from 'assets/logos/Tavla-blue.svg'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import posthog from 'posthog-js'
 import { useState } from 'react'
-import { logout } from './Login/actions'
 
 function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
     const pathname = usePathname()
     const [isOpen, setIsOpen] = useState(false)
 
-    if (!loggedIn) return null
-
     return (
         <div className="block md:hidden">
-            <IconButton
+            <PrimaryButton
+                size="medium"
                 onClick={() => setIsOpen(!isOpen)}
-                className="!rounded-full !bg-contrast !p-3"
+                width="fluid"
+                className="!min-w-0"
             >
-                <MenuIcon content="Meny" color="background" />
-            </IconButton>
+                <MenuIcon content="Meny" color="background" /> Meny
+            </PrimaryButton>
 
             <Modal
                 open={isOpen}
@@ -51,22 +51,43 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                     </div>
 
                     <div className="bg-secondary">
-                        <SideNavigationItem
-                            href="/oversikt"
-                            active={pathname?.includes('/oversikt')}
-                        >
-                            Mine tavler
-                        </SideNavigationItem>
+                        {loggedIn ? (
+                            <SideNavigationItem
+                                active={pathname?.includes('/oversikt')}
+                                onClick={async () => {
+                                    setIsOpen(false)
+                                }}
+                                as={Link}
+                                href="/oversikt"
+                                className="!text-primary"
+                            >
+                                Mine tavler
+                            </SideNavigationItem>
+                        ) : (
+                            <SideNavigationItem
+                                active={pathname?.includes('/demo')}
+                                as={Link}
+                                href="/demo"
+                                onClick={async () => {
+                                    posthog.capture('DEMO_FROM_NAV_BAR_BTN')
+                                    setIsOpen(false)
+                                }}
+                                className="!text-primary"
+                            >
+                                Test ut Tavla
+                            </SideNavigationItem>
+                        )}
 
                         <SideNavigationItem
-                            as={Button}
-                            className="[&>button]:justify-start [&>button]:bg-secondary [&>button]:px-10 [&>button]:text-primary"
+                            active={pathname?.includes('/help')}
                             onClick={async () => {
                                 setIsOpen(false)
-                                await logout()
                             }}
+                            as={Link}
+                            href="/help"
+                            className="!text-primary"
                         >
-                            Logg ut
+                            Ofte stilte spørsmål
                         </SideNavigationItem>
                     </div>
                 </SideNavigation>

--- a/tavla/app/(admin)/components/Navbar.tsx
+++ b/tavla/app/(admin)/components/Navbar.tsx
@@ -13,24 +13,21 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
     const posthog = usePostHog()
 
     return (
-        <nav className="container flex flex-row items-center justify-between py-8">
-            <Link href="/" aria-label="Tilbake til landingssiden">
+        <nav className="container flex flex-row items-center justify-between gap-3 py-8">
+            <Link href="/" aria-label="Tilbake til landingssiden ">
                 <Image src={TavlaLogoBlue} height={32} alt="" />
             </Link>
-            <div className="flex flex-row items-center gap-4">
-                <MobileNavbar loggedIn={loggedIn} />
+            <div className="flex shrink-0 flex-row items-center gap-4">
                 <div className="flex flex-row sm:gap-10">
                     {loggedIn ? (
-                        <div className="hidden flex-row gap-4 md:flex">
-                            <TopNavigationItem
-                                active={pathname?.includes('/oversikt')}
-                                as={Link}
-                                href="/oversikt"
-                                className="!text-primary"
-                            >
-                                Mine tavler
-                            </TopNavigationItem>
-                        </div>
+                        <TopNavigationItem
+                            active={pathname?.includes('/oversikt')}
+                            as={Link}
+                            href="/oversikt"
+                            className="hidden flex-col !text-primary md:flex"
+                        >
+                            Mine tavler
+                        </TopNavigationItem>
                     ) : (
                         <TopNavigationItem
                             active={pathname?.includes('/demo')}
@@ -39,7 +36,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                             onClick={() => {
                                 posthog.capture('DEMO_FROM_NAV_BAR_BTN')
                             }}
-                            className="!text-primary"
+                            className="flex:col hidden !text-primary md:flex"
                         >
                             Test ut Tavla
                         </TopNavigationItem>
@@ -48,12 +45,14 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                         active={pathname?.includes('/help')}
                         as={Link}
                         href="/help"
-                        className="!text-primary"
+                        className="hidden flex-col !text-primary md:flex"
                     >
                         Ofte stilte spørsmål
                     </TopNavigationItem>
+
                     <Login loggedIn={loggedIn} />
                 </div>
+                <MobileNavbar loggedIn={loggedIn} />
             </div>
         </nav>
     )


### PR DESCRIPTION
## 🥅 Motivasjon

Navbaren på mobil skalerer dårlig, logoen blir veldig liten og knappene tar større plass enn de trenger. 

## ✨ Endringer

- For ikke-innlogget bruker: 
  - Menyen vises nå for ikke-innloggede brukere (før bare synlig for innlogget)
  - "Ofte stilte spørsmål" og "Test ut tavla" er begge flyttet fra navbaren og inn i menyen på mobilvisning
- For innlogget bruker: 
  - "Mine tavler" er flyttet inn i menyen

`gap` og størrelse på knapper som vises i mobil navbar er justert slik at de bedre skal skalere på små mobiler. 

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="384" height="676" alt="image" src="https://github.com/user-attachments/assets/26b5756c-4636-4314-bd1b-ab9590f8ff44" /> | <img width="382" height="670" alt="image" src="https://github.com/user-attachments/assets/560a9458-0c09-4c6f-82ff-94583eecee79" /> |

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [ ] Testet i BrowserStack (trenger ikke det:)))
- [ ] UU-sjekk
