### PR TITLE
fix(landing): fix navbar hover highlight

### DIFF
--- a/tavla/app/(admin)/components/Navbar.tsx
+++ b/tavla/app/(admin)/components/Navbar.tsx
@@ -36,7 +36,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                             onClick={() => {
                                 posthog.capture('DEMO_FROM_NAV_BAR_BTN')
                             }}
-                            className="flex:col hidden !text-primary md:flex"
+                            className="hidden flex-col !text-primary md:flex"
                         >
                             Test ut Tavla
                         </TopNavigationItem>


### PR DESCRIPTION
## 🥅 Motivasjon

Ved hover på "Test ut Tavla" i navbaren når en bruker er logget ut kommer den rødoransje linjen til høyre for teksten, i stedet for under. Vi vil at den skal være under. 

## ✨ Endringer

- Endret fra `flex:col` til `flex-col` :))

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="575" height="109" alt="image" src="https://github.com/user-attachments/assets/9d045afd-80cf-4f68-81c9-f6a9b8a87b28" /> | <img width="591" height="99" alt="image" src="https://github.com/user-attachments/assets/139ac7de-b338-4e0d-9113-8a6dc68dc28c" /> |

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
