### PR TITLE
fix(rediger): avoid error message that occurs when opening admin for a Tavle

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -70,15 +70,17 @@ export async function saveSettings(data: FormData) {
         return errors
     }
 
+    const boardTitle = title ?? board.meta.title //Ugly hack, should re-evaluate the whole structure
+
     try {
-        if (isEmptyOrSpaces(title))
+        if (isEmptyOrSpaces(boardTitle))
             errors['name'] = getFormFeedbackForError('board/tiles-name-missing')
 
         if (Object.keys(errors).length !== 0) {
             return errors
         }
 
-        await saveTitle(bid, title)
+        await saveTitle(bid, boardTitle)
         await moveBoard(bid, newFolder, oldFolder)
         await saveLocation(board, location)
         await saveFont(bid, font)

--- a/tavla/app/(admin)/tavler/[id]/utils.ts
+++ b/tavla/app/(admin)/tavler/[id]/utils.ts
@@ -117,7 +117,7 @@ export function getIcons(layer?: string, category?: TCategory[]) {
 }
 
 export function isEmptyOrSpaces(str?: string) {
-    return str === undefined || str.match(/^ *$/) !== null
+    return str === undefined || str?.match(/^ *$/) !== null
 }
 export function isOnlyWhiteSpace(str: string) {
     if (str === undefined || str === null || str === '') return false


### PR DESCRIPTION
## 🥅 Motivasjon
Etter #1986 så dukker det opp en feilmelding når man kommer fra /oversikt eller /mapper/[id] til /rediger, denne dukker ikke opp hvis man refresher /rediger. 

Viser seg at title ikke er satt i formData når /rediger-endepunktet kalles første gang - derfor trigges en feilmelding. På sikt burde man se på hele flyten ved endringer her - men for å fikse uten større omskrivning så er det gjort en enkel fiks. 

## ✨ Endringer
- [ ] Feilmeldingen skyldtes at str i `isEmptyOrSpaces` kunne være `undefined`, men det ble ikke håndtert. Lagt på `?` for å håndtere at str kan være `undefined`
- [ ] For å unngå at feilmeldingen kastes så har jeg lagt inn at vi også sjekker om `board.title` finnes, og fallbacker til den hvis ikke title i formData finnes. 



## ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] UU-sjekk: Testet i LightHouse 
