### PR TITLE
fix(mapper): rename totalt antall tavler

### DIFF
--- a/tavla/app/(admin)/mapper/[id]/page.tsx
+++ b/tavla/app/(admin)/mapper/[id]/page.tsx
@@ -96,7 +96,7 @@ async function FolderPage(props: TProps) {
                     <EmptyOverview text="Her var det tomt gitt! Start med å opprette en tavle" />
                 ) : (
                     <div className="flex flex-col">
-                        <Label>Totalt antall tavler: {boardCount}</Label>
+                        <Label>Antall tavler: {boardCount}</Label>
                         <BoardTable boards={boardsInFolder} />
                     </div>
                 )}


### PR DESCRIPTION
## 🥅 Motivasjon
Endret fra Totalt antall tavler til Antall tavler for å unngå forvirring i en mappe

## ✨ Endringer

- [x] Endret tekst fra "Totalt antall tavler" til "Antall tavler" i en mappe

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1569" height="179" alt="Screenshot 2025-08-26 at 10 05 06" src="https://github.com/user-attachments/assets/6854f706-e308-4dd6-b486-2970f57c5275" /> | <img width="1590" height="170" alt="Screenshot 2025-08-26 at 10 05 28" src="https://github.com/user-attachments/assets/9d0d3bc7-ac93-441f-9b67-cb056f65fc9c" /> |

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [ ] UU-sjekk: Testet i LightHouse
