### PR TITLE
chore(): airport colors

### DIFF
--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -30,7 +30,11 @@ function TravelTag({
     transportSubmode?: TTransportSubmode
     cancelled?: boolean
 }) {
-    const travelTagBackround = `bg-${transportMode}${cancelled && transportMode !== 'unknown' ? '-transparent' : ''}`
+    const colorMode = transportSubmode?.startsWith('airport')
+        ? 'air'
+        : transportMode
+
+    const travelTagBackround = `bg-${colorMode}${cancelled && transportMode !== 'unknown' ? '-transparent' : ''}`
     const iconPublicCodeColor =
         cancelled && transportMode !== 'unknown'
             ? `text-${transportMode}`


### PR DESCRIPTION
## 🥅 Motivasjon
Flytog og flybuss har ikke lilla slik som i appen, bruker sine standard farger for tog og buss. 

## ✨ Endringer

- [x] Lage en sjekk for om buss eller tog er tilknyttet fly, har dermed 'Air' fargen hvis sant. 

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1448" height="810" alt="Screenshot 2025-08-26 at 13 20 26" src="https://github.com/user-attachments/assets/ac83c293-cf59-4c5b-8498-19d9f08961fd" />  | <img width="1449" height="537" alt="Screenshot 2025-08-26 at 13 21 00" src="https://github.com/user-attachments/assets/13812449-45b4-4268-9db8-f08db83fef49" /> |

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Testet i BrowserStack
