### PR TITLE
fix(): make footer stay at bottom

### DIFF
--- a/tavla/app/layout.tsx
+++ b/tavla/app/layout.tsx
@@ -40,7 +40,7 @@ async function RootLayout({ children }: { children: ReactNode }) {
     return (
         <html lang="nb">
             <PHProvider>
-                <body>
+                <body className="min-h-screen">
                     <EnturToastProvider>
                         <Navbar loggedIn={loggedIn} />
                         <Suspense>


### PR DESCRIPTION
## 🥅 Motivasjon
Footer har luft under seg hvis det ikke er nok innhold på skjermen og gjør at UI ikke blir brukervennlig

## ✨ Endringer

- [x] Lagt til `min-h-screen` i body-tag for å presse footer ned hvis det ikke er nok innhold til å fylle skjermen

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="3251" height="1330" alt="Screenshot 2025-08-26 at 15 31 39" src="https://github.com/user-attachments/assets/36bfc49d-bc8f-4a3f-b066-3745ce2180ce" /> | <img width="3250" height="1332" alt="Screenshot 2025-08-26 at 15 32 30" src="https://github.com/user-attachments/assets/5111607a-50c9-4c0e-ada5-702be5fb25ba" /> |

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Testet i BrowserStack
