### PR TITLE
fix(oversikt): update folder count when moving boards

### DIFF
--- a/tavla/app/(admin)/mapper/[id]/page.tsx
+++ b/tavla/app/(admin)/mapper/[id]/page.tsx
@@ -97,7 +97,12 @@ async function FolderPage(props: TProps) {
                 ) : (
                     <div className="flex flex-col">
                         <Label>Totalt antall tavler: {boardCount}</Label>
-                        <BoardTable boards={boardsInFolder} />
+                        <BoardTable
+                            boards={boardsInFolder}
+                            folderBoardCounts={{
+                                [folder.id]: boardsInFolder.length,
+                            }}
+                        />
                     </div>
                 )}
             </div>

--- a/tavla/app/(admin)/oversikt/components/BoardTable/index.tsx
+++ b/tavla/app/(admin)/oversikt/components/BoardTable/index.tsx
@@ -4,13 +4,13 @@ import { TableRows } from 'app/(admin)/oversikt/components/TableRows'
 import { TableColumns } from 'app/(admin)/utils/types'
 import { TBoard, TFolder } from 'types/settings'
 
-function BoardTable({
-    folders,
-    boards,
-}: {
+type BoardTableProps = {
     folders?: TFolder[]
     boards: TBoard[]
-}) {
+    folderBoardCounts: Record<string, number>
+}
+
+function BoardTable({ folders, boards, folderBoardCounts }: BoardTableProps) {
     const numOfColumns = Object.keys(TableColumns).length
 
     return (
@@ -21,7 +21,11 @@ function BoardTable({
             }}
         >
             <TableHeader />
-            <TableRows folders={folders ?? []} boards={boards} />
+            <TableRows
+                folders={folders ?? []}
+                boards={boards}
+                folderBoardCounts={folderBoardCounts}
+            />
         </div>
     )
 }

--- a/tavla/app/(admin)/oversikt/components/Column/Name.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Name.tsx
@@ -1,14 +1,10 @@
 import { BoardIcon, FolderIcon } from '@entur/icons'
-import { SkeletonRectangle } from '@entur/loader'
-import * as Sentry from '@sentry/nextjs'
 import {
     DEFAULT_BOARD_NAME,
     DEFAULT_FOLDER_NAME,
 } from 'app/(admin)/utils/constants'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 import { TBoard, TFolder } from 'types/settings'
-import { getNumberOfBoardsInFolder } from '../../utils/actions'
 import { ColumnWrapper } from './ColumnWrapper'
 
 function BoardName({ board }: { board: TBoard }) {
@@ -27,31 +23,7 @@ function BoardName({ board }: { board: TBoard }) {
     )
 }
 
-function FolderName({ folder }: { folder: TFolder }) {
-    const [boardsInFolderCount, setBoardsInFolderCount] = useState<
-        number | undefined
-    >()
-    const [isLoading, setIsLoading] = useState(true)
-
-    useEffect(() => {
-        async function fetchNumberOfBoards(id?: string) {
-            try {
-                const boardsInFolderCount = await getNumberOfBoardsInFolder(
-                    id ?? undefined,
-                )
-
-                setBoardsInFolderCount(boardsInFolderCount)
-            } catch (error) {
-                Sentry.captureException(error)
-                setBoardsInFolderCount(undefined)
-            } finally {
-                setIsLoading(false)
-            }
-        }
-
-        fetchNumberOfBoards(folder.id)
-    }, [folder.id])
-
+function FolderName({ folder, count }: { folder: TFolder; count?: number }) {
     return (
         <ColumnWrapper column="name">
             <div className="flex flex-row items-center gap-2">
@@ -59,13 +31,7 @@ function FolderName({ folder }: { folder: TFolder }) {
                 <Link href={`/mapper/${folder.id}`} className="hover:underline">
                     {folder.name ?? DEFAULT_FOLDER_NAME}
                 </Link>
-                {isLoading ? (
-                    <SkeletonRectangle width="1rem" />
-                ) : (
-                    boardsInFolderCount != undefined && (
-                        <>({boardsInFolderCount})</>
-                    )
-                )}
+                {typeof count === 'number' && <>({count})</>}
             </div>
         </ColumnWrapper>
     )

--- a/tavla/app/(admin)/oversikt/components/Column/index.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/index.tsx
@@ -4,15 +4,14 @@ import { BoardActions, FolderActions } from './Actions'
 import { LastModified } from './LastModified'
 import { BoardName, FolderName } from './Name'
 
-function Column({
-    board,
-    folder,
-    column,
-}: {
+type ColumnProps = {
     board?: TBoard
     folder?: TFolder
     column: TTableColumn
-}) {
+    folderBoardCount?: number
+}
+
+function Column({ board, folder, column, folderBoardCount }: ColumnProps) {
     if (board) {
         switch (column) {
             case 'name':
@@ -25,7 +24,7 @@ function Column({
     } else if (folder) {
         switch (column) {
             case 'name':
-                return <FolderName folder={folder} />
+                return <FolderName folder={folder} count={folderBoardCount} />
             case 'actions':
                 return <FolderActions folder={folder} />
             case 'lastModified':

--- a/tavla/app/(admin)/oversikt/components/TableRows/index.tsx
+++ b/tavla/app/(admin)/oversikt/components/TableRows/index.tsx
@@ -12,13 +12,13 @@ import {
 } from '../../hooks/useSortBoardFunction'
 import { Column } from '../Column'
 
-function TableRows({
-    folders,
-    boards,
-}: {
+type TableRowsProps = {
     folders: TFolder[]
     boards: TBoard[]
-}) {
+    folderBoardCounts: Record<string, number>
+}
+
+function TableRows({ folders, boards, folderBoardCounts }: TableRowsProps) {
     const search = useSearchParam('search') ?? ''
     const sortBoardFunction = useSortBoardFunction()
     const sortFolderFunction = useSortFolderFunction()
@@ -47,9 +47,15 @@ function TableRows({
         .sort(sortFolderFunction)
     return (
         <>
-            {sortedFolders.map((folder: TFolder) => (
-                <FolderTableRow key={folder.id} folder={folder} />
-            ))}
+            {sortedFolders.map((folder: TFolder) =>
+                folder.id !== undefined ? (
+                    <FolderTableRow
+                        key={folder.id}
+                        folder={folder}
+                        count={folderBoardCounts[String(folder.id)] ?? 0}
+                    />
+                ) : null,
+            )}
             {sortedBoards.map((board: TBoard) => (
                 <BoardTableRow key={board.id} board={board} />
             ))}
@@ -68,12 +74,17 @@ function BoardTableRow({ board }: { board: TBoard }) {
     )
 }
 
-function FolderTableRow({ folder }: { folder: TFolder }) {
+function FolderTableRow({ folder, count }: { folder: TFolder; count: number }) {
     const columns = DEFAULT_BOARD_COLUMNS
     return (
         <Fragment key={folder.id}>
             {columns.map((column: TTableColumn) => (
-                <Column key={column} folder={folder} column={column} />
+                <Column
+                    key={column}
+                    folder={folder}
+                    column={column}
+                    folderBoardCount={count}
+                />
             ))}
         </Fragment>
     )

--- a/tavla/app/(admin)/oversikt/page.tsx
+++ b/tavla/app/(admin)/oversikt/page.tsx
@@ -26,6 +26,13 @@ async function FoldersAndBoardsPage() {
     const count = await countAllBoards(folders, privateBoards)
     const elementsListCount = privateBoards.length + folders.length
 
+    const counts: Record<string, number> = {}
+    for (const folder of folders) {
+        if (folder.id) {
+            counts[folder.id] = folder.boards?.length ?? 0
+        }
+    }
+
     return (
         <div className="container flex flex-col gap-8 pb-20">
             <div className="flex flex-row justify-between max-sm:flex-col">
@@ -47,6 +54,7 @@ async function FoldersAndBoardsPage() {
                             <BoardTable
                                 folders={folders}
                                 boards={privateBoards}
+                                folderBoardCounts={counts}
                             />
                         </div>
                     </>


### PR DESCRIPTION
## 🥅 Motivasjon
Antall tavler i en mappe oppdateres ikke når man flytter tavler, tvinger brukere til å refreshe siden for å se oppdatert statistikk

## ✨ Endringer

- [ ] Flytter telling av tavler opp i component-hierarkiet. 
- [ ] 

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| bilde | bilde |

## ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Testet i BrowserStack
- [ ] UU-sjekk: Testet i LightHouse
- [ ] ...
