### PR TITLE
fix(rediger): move server action

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/page.tsx
@@ -55,6 +55,19 @@ export default async function EditPage(props: TProps) {
     const access = await userCanEditBoard(params.id)
     if (!access) return redirect('/')
 
+    async function walkingDistanceAction(data: FormData) {
+        'use server'
+
+        const tile = await getWalkingDistanceTile(
+            formDataToTile(data),
+            board?.meta?.location,
+        )
+        if (!tile.placeId) return
+        await addTile(params.id, tile)
+        if (board?.combinedTiles) await addTileToCombinedList(board, tile.uuid)
+        revalidatePath(`/tavler/${params.id}/rediger`)
+    }
+
     return (
         <div className="bg-gray-50">
             <div className="container flex flex-col gap-6 pb-20 pt-16">
@@ -79,21 +92,7 @@ export default async function EditPage(props: TProps) {
                     className="flex flex-col gap-4 rounded-md bg-background px-6 py-8"
                 >
                     <Heading2>Stoppesteder</Heading2>
-                    <TileSelector
-                        action={async (data: FormData) => {
-                            'use server'
-
-                            const tile = await getWalkingDistanceTile(
-                                formDataToTile(data),
-                                board.meta?.location,
-                            )
-                            if (!tile.placeId) return
-                            await addTile(params.id, tile)
-                            if (board.combinedTiles)
-                                await addTileToCombinedList(board, tile.uuid)
-                            revalidatePath(`/tavler/${params.id}/rediger`)
-                        }}
-                    />
+                    <TileSelector action={walkingDistanceAction} />
 
                     <TileList board={board} />
                     <div


### PR DESCRIPTION
## 🥅 Motivasjon
Får error melding i Sentry: `Attempted to call a temporary Client Reference from the server but it is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.`

## ✨ Endringer

- [x] Flytte server action ut av client-komponent til egen async funksjon

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
