### PR TITLE
fix(mapper): able to go back after delete modal

### DIFF
--- a/tavla/app/(admin)/oversikt/hooks/useModalWithValue.ts
+++ b/tavla/app/(admin)/oversikt/hooks/useModalWithValue.ts
@@ -25,7 +25,7 @@ function useModalWithValues(...queryParams: QueryParam[]) {
         for (const queryParam of queryParams) {
             newParams.set(queryParam.key, queryParam.value)
         }
-        router.push(`${pathname}?${newParams.toString()}`)
+        router.replace(`${pathname}?${newParams.toString()}`)
     }, [router, pathname, params, queryParams])
 
     const close = useCallback(() => {
@@ -33,7 +33,7 @@ function useModalWithValues(...queryParams: QueryParam[]) {
         for (const queryParam of queryParams) {
             newParams.delete(queryParam.key)
         }
-        router.push(`${pathname}?${newParams.toString()}`)
+        router.replace(`${pathname}?${newParams.toString()}`)
     }, [router, pathname, params, queryParams])
 
     return { isOpen, open, close }


### PR DESCRIPTION
## 🥅 Motivasjon
Brukere får ikke gått tilbake til forrige side når man lukker modal for å slette en tavle

## ✨ Endringer

- [ ] Bruke `router.replace` for å la brukere gå tilbake


## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
