### PR TITLE
feat(rediger): make styling improvements to Instillinger on admin page

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
@@ -62,63 +62,63 @@ function TransportPaletteSelect({
     }
 
     return (
-        <>
+        <div>
             <Heading4 margin="bottom" id="transport-palette-heading">
                 Farger på transportmidler
             </Heading4>
-            <Paragraph className="!mb-0">
+            <Paragraph className="mb-3">
                 Velg hvilke farger transportmidlene i tavlevisningen skal ha.
             </Paragraph>
-            <RadioGroup
-                name="transportPalette"
-                value={selectedValue}
-                aria-labelledby="transport-palette-heading"
-                onChange={(e) => {
-                    handleChange(e.target.value as TTransportPalette)
-                }}
-            >
-                {transportPalettes.map((palette) => (
-                    <div key={palette.value}>
-                        <Radio value={palette.value}>{palette.label}</Radio>
-                        <div
-                            className="flex max-w-max flex-col rounded-sm bg-background px-2 py-3"
-                            data-theme={theme}
-                            data-transport-palette={palette.value}
-                        >
-                            <div className="mb-4 flex flex-row gap-2">
-                                {busAndTrainModes.map((mode) => (
-                                    <div
-                                        className="max-w-min"
-                                        key={theme + mode.mode}
-                                    >
-                                        {TravelTag({
-                                            transportMode: mode.mode,
-                                            publicCode: '00',
-                                        })}
-                                    </div>
-                                ))}
-                            </div>
-                            <div className="flex flex-row flex-wrap gap-2">
-                                {transportModes.map((mode) => (
-                                    <div
-                                        className="max-w-min"
-                                        key={
-                                            theme + (mode.submode ?? mode.mode)
-                                        }
-                                    >
-                                        {TravelTag({
-                                            transportMode: mode.mode,
-                                            publicCode: '00',
-                                            transportSubmode: mode.submode,
-                                        })}
-                                    </div>
-                                ))}
+            <div className="flex flex-col gap-4 md:flex-row">
+                <RadioGroup
+                    name="transportPalette"
+                    value={selectedValue}
+                    aria-labelledby="transport-palette-heading"
+                    onChange={(e) => {
+                        handleChange(e.target.value as TTransportPalette)
+                    }}
+                >
+                    {transportPalettes.map((palette) => (
+                        <div key={palette.value}>
+                            <Radio value={palette.value}>{palette.label}</Radio>
+                            <div
+                                className="flex max-w-max flex-col rounded-sm bg-background px-2 py-3"
+                                data-theme={theme}
+                                data-transport-palette={palette.value}
+                            >
+                                <div className="grid grid-cols-2 gap-2">
+                                    {busAndTrainModes.map((mode) => (
+                                        <div
+                                            className="max-w-min"
+                                            key={theme + mode.mode}
+                                        >
+                                            {TravelTag({
+                                                transportMode: mode.mode,
+                                                publicCode: '00',
+                                            })}
+                                        </div>
+                                    ))}
+                                    {transportModes.map((mode) => (
+                                        <div
+                                            key={
+                                                theme +
+                                                (mode.submode ?? mode.mode)
+                                            }
+                                        >
+                                            {TravelTag({
+                                                transportMode: mode.mode,
+                                                publicCode: '00',
+                                                transportSubmode: mode.submode,
+                                            })}
+                                        </div>
+                                    ))}
+                                </div>
                             </div>
                         </div>
-                    </div>
-                ))}
-            </RadioGroup>
-        </>
+                    ))}
+                </RadioGroup>
+            </div>
+        </div>
     )
 }
 

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/WalkingDistance.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/WalkingDistance.tsx
@@ -32,7 +32,8 @@ function WalkingDistance({
         <div className="flex flex-col">
             <Heading4 margin="bottom">Gangavstand</Heading4>
             <Paragraph className="mb-2">
-                Vis gangavstand fra tavlens adresse til stoppestedet.
+                Skriv inn hvor tavlen befinner seg for å vise gangavstand til
+                stoppestedet.
             </Paragraph>
             <ClientOnly>
                 <SearchableDropdown

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
@@ -59,6 +59,14 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
                             onBlur={submitSettings}
                         />
                         <Folder folder={folder} onChange={submitSettings} />
+                        <WalkingDistance
+                            location={board.meta.location}
+                            onChange={submitSettings}
+                        />
+                        <Footer
+                            infoMessage={board.footer}
+                            onBlur={submitSettings}
+                        />
                     </div>
                 </div>
                 <div className="box">
@@ -70,6 +78,10 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
                             }
                             onChange={submitSettings}
                         />
+                        <FontSelect
+                            font={board.meta.fontSize}
+                            onChange={submitSettings}
+                        />
                         <ThemeSelect
                             theme={board.theme}
                             onChange={submitSettings}
@@ -79,18 +91,7 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
                             theme={board.theme ?? 'dark'}
                             onChange={submitSettings}
                         />
-                        <FontSelect
-                            font={board.meta.fontSize}
-                            onChange={submitSettings}
-                        />
-                        <WalkingDistance
-                            location={board.meta.location}
-                            onChange={submitSettings}
-                        />
-                        <Footer
-                            infoMessage={board.footer}
-                            onBlur={submitSettings}
-                        />
+
                         <HiddenInput id="bid" value={board.id} />
                     </div>
                 </div>

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/index.tsx
@@ -43,11 +43,8 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
             <FormError
                 {...getFormFeedbackForField('general', formErrors.general)}
             />
-            <form
-                className="grid grid-cols-1 gap-8 lg:grid-cols-2"
-                ref={formRef}
-            >
-                <div className="box">
+            <form className="flex flex-col gap-6 lg:flex-row" ref={formRef}>
+                <div className="box shrink">
                     <Heading3 margin="bottom"> Generelt </Heading3>
                     <div className="flex flex-col gap-4">
                         <Title
@@ -69,7 +66,7 @@ function Settings({ board, folder }: { board: TBoard; folder?: TFolder }) {
                         />
                     </div>
                 </div>
-                <div className="box">
+                <div className="box md:min-w-[480px]">
                     <Heading3 margin="bottom">Tavlevisning </Heading3>
                     <div className="flex flex-col gap-4">
                         <ViewType


### PR DESCRIPTION
## 🥅 Motivasjon
"Instillinger" har blitt veldig "høyre-tung" særlig med alle buss-farge-valgene. Så på noen småendringer for å forbedre litt

## ✨ Endringer
- [x] Flytter "Gangavstand" og "Info-melding" fra Tavlevisning til Generelt
- [x] Endrer "Farger på transport midler"-radioknappene så de går horistontalt i stedet for vertikalt. Lagt på en minimumsbredde for å hindre at "Grønn buss" kan brekke på to linjer
- [x] Endret tekst-forklaringen på Gangavstand

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
|<img width="1258" height="1527" alt="image" src="https://github.com/user-attachments/assets/961f656d-e9cb-4a98-b743-c45c3a9c35c0" />| <img width="1258" height="1527" alt="image" src="https://github.com/user-attachments/assets/4df7c375-79f2-4010-8c57-190628e4ac61" />|

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og ~Safari~
- [ ] ~Testet i BrowserStack~
