### PR TITLE
fix(): add transparent colors for transport palettes

### DIFF
--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -126,29 +126,29 @@
     /* Light theme palettes */
     [data-transport-palette='blue-bus'] {
         --bus-color: var(--standard-train);
-        --bus-color-transparent: var(--standard-train-transparent);
+        --bus-color-transparent: rgba(0, 54, 127, 0.15);
         --rail-color: var(--standard-bus);
-        --rail-color-transparent: var(--standard-bus-transparent);
+        --rail-color-transparent: rgba(197, 4, 78, 0.15);
     }
 
     /* Dark theme palettes */
     [data-theme='dark'][data-transport-palette='blue-bus'] {
         --bus-color: var(--dark-train);
-        --bus-color-transparent: var(--dark-train-transparent);
+        --bus-color-transparent: rgba(96, 162, 215, 0.15);
         --rail-color: var(--dark-bus);
-        --rail-color-transparent: var(--dark-bus-transparent);
+        --rail-color-transparent: rgba(239, 115, 152, 0.15);
     }
 
     /* Light theme palettes */
     [data-transport-palette='green-bus'] {
         --bus-color: var(--standard-mobility);
-        --bus-color-transparent: var(--standard-mobility-transparent);
+        --bus-color-transparent: rgba(51, 130, 107, 0.15);
     }
 
     /* Dark theme palettes */
     [data-theme='dark'][data-transport-palette='green-bus'] {
         --bus-color: var(--dark-mobility);
-        --bus-color-transparent: var(--dark-mobility-transparent);
+        --bus-color-transparent: rgba(77, 178, 149, 0.15);
     }
 
     [data-theme='entur'] {


### PR DESCRIPTION
## 🥅 Motivasjon

De gjennomsiktige fargene for transportfargene brukte fortsatt farger definert i hex. Denne PRen skriver de om til hardkodet rgba-verdier. 

## ✨ Endringer

- Lagt til rgba-verdier for blå busser og grønne busser for både light og dark theme

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Testet i Browserstack
