### PR TITLE
fix(tavla): move tile situations to bottom if few departures

### DIFF
--- a/tavla/src/Board/scenarios/CombinedTile/index.tsx
+++ b/tavla/src/Board/scenarios/CombinedTile/index.tsx
@@ -114,7 +114,7 @@ export function CombinedTile({ combinedTile }: { combinedTile: TTile[] }) {
 
     return (
         <Tile className="flex flex-col max-sm:min-h-[30vh]">
-            <div className="overflow-hidden">
+            <div className="flex-grow overflow-hidden">
                 <CombinedTileDeviation situations={combinedSituations} />
                 <Table
                     departures={sortedEstimatedCalls}

--- a/tavla/src/Board/scenarios/QuayTile/index.tsx
+++ b/tavla/src/Board/scenarios/QuayTile/index.tsx
@@ -70,7 +70,7 @@ export function QuayTile({
 
     return (
         <Tile className="flex flex-col max-sm:min-h-[30vh]">
-            <div className="overflow-hidden">
+            <div className="flex-grow overflow-hidden">
                 <TableHeader
                     heading={displayName ?? heading}
                     walkingDistance={walkingDistance}

--- a/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
+++ b/tavla/src/Board/scenarios/StopPlaceTile/index.tsx
@@ -59,7 +59,7 @@ export function StopPlaceTile({
 
     return (
         <Tile className="flex flex-col max-sm:min-h-[30vh]">
-            <div className="overflow-hidden">
+            <div className="flex-grow overflow-hidden">
                 <TableHeader
                     heading={displayName ?? data.stopPlace.name}
                     walkingDistance={walkingDistance}


### PR DESCRIPTION
## 🥅 Motivasjon
Avviksmeldinger havner midt på skjermen ved få avganger, skal ligge i bunn

## ✨ Endringer

- [x] Lagt på flex-grow for diven som inneholder selve avgangene sånn at avvikene dyttes i bunn (både CombinedTile, QuayTile og StopPlaceTile)

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="1832" height="1527" alt="image" src="https://github.com/user-attachments/assets/421dac1c-f796-4a2d-980c-26d9e5a01f2d" />|<img width="1832" height="1527" alt="image" src="https://github.com/user-attachments/assets/27bd8f79-83b7-4a73-84f8-1aae8d5a9eb0" />|

