### PR TITLE
fix(): change from dark-mobility to contrast-mobility

### DIFF
--- a/tavla/app/globals.css
+++ b/tavla/app/globals.css
@@ -147,8 +147,8 @@
 
     /* Dark theme palettes */
     [data-theme='dark'][data-transport-palette='green-bus'] {
-        --bus-color: var(--dark-mobility);
-        --bus-color-transparent: rgba(77, 178, 149, 0.15);
+        --bus-color: var(--contrast-mobility);
+        --bus-color-transparent: rgba(0, 219, 155, 0.15);
     }
 
     [data-theme='entur'] {


### PR DESCRIPTION
## 🥅 Motivasjon
Tidligere grønn farge for busser er for blasst.

## ✨ Endringer

- [x] Endre til å bruke `contrast-mobility` for grønne busser i dark mode

## 📸 Screenshots

| Før   | Etter |
| ----- | ----- |
| <img width="655" height="485" alt="Screenshot 2025-09-09 at 13 36 57" src="https://github.com/user-attachments/assets/c4af90dc-1d92-46b2-90b9-06226778fa40" /> | <img width="777" height="562" alt="Screenshot 2025-09-09 at 13 35 48" src="https://github.com/user-attachments/assets/bfee44fc-85f0-4a5e-80f3-aeecff17e987" /> |

## ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Testet i BrowserStack
