### PR TITLE
🧹 Lagt til firebase-export til gitignore

### DIFF
--- a/tavla/.gitignore
+++ b/tavla/.gitignore
@@ -9,6 +9,7 @@ migrations/scripts/__pycache__
 
 node_modules/
 **/.firebase
+firebase-export-*
 
 .vscode/
 .next/


### PR DESCRIPTION
### 🥅 Bakgrunn

Firebase-export for lokal database skal ikke være en del av git-repo


### ✨ Løsning

- La til `firebase-export-*` i `.gitignore`

