### PR TITLE
:bug: fiks mappelukking ved 'avbryt'

### DIFF
--- a/tavla/app/(admin)/components/CreateFolder/index.tsx
+++ b/tavla/app/(admin)/components/CreateFolder/index.tsx
@@ -26,7 +26,7 @@ function CreateFolder() {
                 className="flex flex-col items-center"
                 open={isOpen}
                 size="small"
-                onDismiss={close}
+                onDismiss={() => setIsOpen(false)}
                 closeLabel="Avbryt oppretting"
             >
                 <IconButton
@@ -81,7 +81,7 @@ function CreateFolder() {
                                 width="fluid"
                                 variant="secondary"
                                 aria-label="Avbryt oppretting"
-                                onClick={close}
+                                onClick={() => setIsOpen(false)}
                             >
                                 Avbryt
                             </Button>


### PR DESCRIPTION
### 🥅 Bakgrunn

Når en bruker trykker på "avbryt" på "Opprett mappe" på oversiktssiden eller trykker utenfor modalen lukkes den ikke, det er uheldig, men ikke kjempekritisk fordi man kan trykke seg ut ved "X". 

### ✨ Løsning

- `onClick={close}` => `onClick={() => setIsOpen(false)}`

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="570" height="656" alt="image" src="https://github.com/user-attachments/assets/fced2413-e124-43c2-a664-f4c7494e4592" /> | <img width="963" height="661" alt="image" src="https://github.com/user-attachments/assets/4dedb5ac-f77e-4f0b-a587-2ba5a25a71c3" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
