### PR TITLE
🐛 legg til firebase i frame sikkerhetsheader

### DIFF
--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -24,7 +24,7 @@ const cspHeaderCommon = `
 `
 
 const securityHeaders = `
-        frame-src 'self' https://privacy-proxy.usercentrics.eu;
+        frame-src 'self' https://privacy-proxy.usercentrics.eu https://ent-tavla-dev.firebaseapp.com/;
         img-src 'self' data: https://*.usercentrics.eu https://firebasestorage.googleapis.com;
       `
 


### PR DESCRIPTION
### 🥅 Bakgrunn
SSO innlogging via Google sluttet å funke da vi merget inn #1922 siden vi gjorde endringer i CSPen som gjorde den strengere. Ved å legge til Firebase i frame-src tillater vi iFrame med opprinnelse fra Firebase.

### ✨ Løsning

- Leg til https://ent-tavla-dev.firebaseapp.com/ i frame-src 'self' i next.config.js

### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
