### PR TITLE
:lipstick: fiks gjennomsiktig farge for flytransport

### DIFF
--- a/tavla/src/Shared/components/TravelTag/index.tsx
+++ b/tavla/src/Shared/components/TravelTag/index.tsx
@@ -37,7 +37,7 @@ function TravelTag({
     const travelTagBackround = `bg-${colorMode}${cancelled && transportMode !== 'unknown' ? '-transparent' : ''}`
     const iconPublicCodeColor =
         cancelled && transportMode !== 'unknown'
-            ? `text-${transportMode}`
+            ? `text-${colorMode}`
             : 'text-background'
 
     return (


### PR DESCRIPTION
### 🥅 Bakgrunn

Flytransportfargene blir ikke gjennomsiktig lilla når f.eks flytoget er innstilt. 

### ✨ Løsning

- `transportMode` --> `colorMode`

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="1481" height="898" alt="image" src="https://github.com/user-attachments/assets/2de56575-b64a-49ad-ad55-33bacb2bf575" /> | <img width="1479" height="895" alt="image" src="https://github.com/user-attachments/assets/e9422233-8eff-4035-8957-c8177e65a940" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari

