### PR TITLE
🐛 Reset index for cycler if length of array changes and current index is out of bounds

### DIFF
--- a/tavla/src/Board/scenarios/Table/useCycler.ts
+++ b/tavla/src/Board/scenarios/Table/useCycler.ts
@@ -1,6 +1,25 @@
 import { useEffect, useState } from 'react'
 
-function useCycler<T>(array: T[] | undefined, step = 5000) {
+/**
+ * Custom React hook that cycles through the indices of a given array at a specified interval.
+ *
+ * @param {T[] | undefined} array - The array to cycle through. If undefined or has length <= 1, cycling is disabled.
+ * @param {number} [step=5000] - The interval in milliseconds between each cycle.
+ * @returns {number} The current index in the array.
+ *
+ * @remarks
+ * - The hook uses `useState` to track the current index and `useEffect` to set up an interval for cycling.
+ * - If the array is undefined or has one or fewer elements, the cycling interval is not set.
+ * - The index wraps around to the start of the array when it reaches the end.
+ *
+ * @example
+ * ```tsx
+ * const items = ['A', 'B', 'C'];
+ * const currentIndex = useCycler(items, 2000);
+ * // currentIndex will update every 2 seconds, cycling through 0, 1, 2
+ * ```
+ */
+export function useCycler<T>(array: T[] | undefined, step = 5000) {
     const [index, setIndex] = useState(0)
 
     const length = array?.length ?? 0
@@ -9,13 +28,18 @@ function useCycler<T>(array: T[] | undefined, step = 5000) {
         if (length <= 1) {
             return
         }
-        const interval = setInterval(
-            () => setIndex((i) => (i + 1) % length),
-            step,
-        )
+        const interval = setInterval(() => {
+            setIndex((i) => (i + 1) % length)
+        }, step)
         return () => clearInterval(interval)
     }, [length, step])
+
+    //Reset index if array lenght changes and current index is out of bounds
+    useEffect(() => {
+        if (index >= length || (length === 0 && index !== 0)) {
+            setIndex(0)
+        }
+    }, [length, index])
+
     return index
 }
-
-export { useCycler }

--- a/tavla/src/Board/scenarios/Table/useCycler.ts
+++ b/tavla/src/Board/scenarios/Table/useCycler.ts
@@ -36,7 +36,7 @@ export function useCycler<T>(array: T[] | undefined, step = 5000) {
 
     //Reset index if array lenght changes and current index is out of bounds
     useEffect(() => {
-        if (index >= length || (length === 0 && index !== 0)) {
+        if (index >= length) {
             setIndex(0)
         }
     }, [length, index])

--- a/tavla/src/Board/scenarios/Table/useCycler.ts
+++ b/tavla/src/Board/scenarios/Table/useCycler.ts
@@ -34,8 +34,15 @@ export function useCycler<T>(array: T[] | undefined, step = 5000) {
         return () => clearInterval(interval)
     }, [length, step])
 
-    //Reset index if array lenght changes and current index is out of bounds
+    // Reset index if array length changes and current index is out of bounds
     useEffect(() => {
+        // Avoid unnecessary state update when length is 0 and index already 0
+        if (length === 0) {
+            if (index !== 0) {
+                setIndex(0)
+            }
+            return
+        }
         if (index >= length) {
             setIndex(0)
         }


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi opplevde at innimellom vistes ikke avviksmeldingen på bunnen av en tile, selv om det fantes avvik på en eller flere av avgangene. Var ikke tydelig hva som forårsaket det. 

### ✨ Løsning
Etter litt detektivarbeid fant jeg ut at dette skjer når lista med avvik blir kortere (fordi avgangene endres, finnes ikke lenger like mange avvik) og index-en blir "out of bounds". Feks vises avvik 4/4, men så hentes nye avganger og det finnes bare 3 avviksmeldinger. 
-  Har lagt på en til `useEffect` som kjører dersom length eller index endrer seg, den setter index til 0 dersom index er større eller lik lengten på lista (out of bounds) 

### 📸 Bilder
Bildet viser et eksempel der feilen oppstod hvor index for Majorstua var `1`, men lengden på lista var `1` og dermed var index 1 out of bounds
<img width="2020" height="1396" alt="image" src="https://github.com/user-attachments/assets/a67e352b-6067-455d-8838-d38904f08697" />


### ✅ Sjekkliste
- [X] Testet i BrowserStack (hvis endring på tavlevisning)
