### PR TITLE
🚸 huke bort alle elementer i liste

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SaveCancelDeleteTileButtonGroup.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SaveCancelDeleteTileButtonGroup.tsx
@@ -1,3 +1,4 @@
+import { SmallAlertBox } from '@entur/alert'
 import { Button, ButtonGroup, IconButton } from '@entur/button'
 import { CloseIcon } from '@entur/icons'
 import { Modal } from '@entur/modal'
@@ -18,6 +19,7 @@ function SaveCancelDeleteTileButtonGroup({
     setIsTileOpen,
     setConfirmOpen,
     deleteTile,
+    showValidationError = false,
 }: {
     confirmOpen: boolean
     hasTileChanged: boolean
@@ -25,6 +27,7 @@ function SaveCancelDeleteTileButtonGroup({
     setIsTileOpen: (isOpen: boolean) => void
     setConfirmOpen: (confirmOpen: boolean) => void
     deleteTile: (boardId: string, tile: TTile, demoBoard?: TBoard) => void
+    showValidationError?: boolean
 }) {
     const tile = useNonNullContext(TileContext)
     return (
@@ -48,6 +51,11 @@ function SaveCancelDeleteTileButtonGroup({
                     isWideScreen={false}
                     deleteTile={deleteTile}
                 />
+                {showValidationError && (
+                    <SmallAlertBox variant="warning">
+                        Du må velge en eller flere linjer for å lagre
+                    </SmallAlertBox>
+                )}
             </div>
 
             <Modal

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
@@ -47,6 +47,7 @@ function TileCard({
     const [isOpen, setIsOpen] = useState(false)
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
     const [confirmOpen, setConfirmOpen] = useState(false)
+    const [showValidationError, setShowValidationError] = useState(false)
     const { addToast } = useToast()
 
     const submit = async (
@@ -72,6 +73,13 @@ function TileCard({
         }
         // If the length of lines equals all the lines, we don't want to include any
         lines = lines.length == count ? [] : lines
+
+        if (lines.length === 0 && count !== null && count > 0) {
+            setShowValidationError(true)
+            return getFormFeedbackForError('board/tiles-no-lines-selected')
+        }
+
+        setShowValidationError(false)
 
         if (isCombined) {
             columns = tile.columns ?? DEFAULT_COLUMNS
@@ -104,6 +112,7 @@ function TileCard({
         setConfirmOpen(false)
         setHasUnsavedChanges(false)
         setIsOpen(false)
+        setShowValidationError(false)
     }
 
     let lines = useLines(tile)
@@ -213,6 +222,7 @@ function TileCard({
                                 resetTile={reset}
                                 setIsTileOpen={setIsOpen}
                                 setConfirmOpen={setConfirmOpen}
+                                showValidationError={showValidationError}
                                 deleteTile={() =>
                                     bid === 'demo'
                                         ? deleteTileDemoBoard()


### PR DESCRIPTION
### 🥅 Bakgrunn
Brukere kan huke bort alle elementer alle linjer og elementer på tavla.

### ✨ Løsning
- Legger til en alert hvis brukere prøver å lagre med ingen valgte elementer i listen
- Forrige gyldige løsning blir valgt

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="1136" height="823" alt="Screenshot 2025-10-03 at 14 47 03" src="https://github.com/user-attachments/assets/d1906ce6-f5f5-49ca-881d-bc563cb33790" /> | <img width="1244" height="828" alt="Screenshot 2025-10-03 at 14 47 29" src="https://github.com/user-attachments/assets/5a9b77a4-e0ff-4fb7-b38e-4a13201c1e23" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
