### PR TITLE
Fjern feature flag toggle på linje/retning

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/PlatformAndLines.tsx
@@ -4,13 +4,11 @@ import { SkeletonRectangle } from '@entur/loader'
 import { TransportIcon } from 'app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportIcon'
 import type { EventProps } from 'app/posthog/events'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import type { BoardTileDB } from 'src/types/db-types/boards'
 import type {
     TTransportMode,
     TTransportSubmode,
 } from 'src/types/graphql-schema'
-import { FeatureFlags } from '../../../../../../posthog/featureFlags'
 import type { LineWithFrontText } from './types'
 
 function getColorMode(
@@ -38,20 +36,11 @@ function PublicCode({ line }: { line: LineWithFrontText }) {
     )
 }
 
-function DisplayName({
-    line,
-    showByFrontText,
-}: {
-    line: LineWithFrontText
-    showByFrontText: boolean | undefined
-}) {
-    if (showByFrontText) {
-        if (line.frontTexts) {
-            return <>{line.frontTexts.join(' / ')}</>
-        }
-        return <SkeletonRectangle width="6rem" height="1rem" />
+function DisplayName({ line }: { line: LineWithFrontText }) {
+    if (line.frontTexts) {
+        return <>{line.frontTexts.join(' / ')}</>
     }
-    return <>{line.name ?? ''}</>
+    return <SkeletonRectangle width="6rem" height="1rem" />
 }
 
 function PlatformAndLines({
@@ -80,10 +69,6 @@ function PlatformAndLines({
     onToggleGroup: (compositeKeys: string[], checked: boolean) => void
 }) {
     const posthog = usePosthogTracking()
-
-    const isShowLinesByFrontTextEnabled = useFeatureFlagEnabled(
-        FeatureFlags.ShowLinesByFrontText,
-    )
 
     const selectedLinesInGroup = lines.filter((l) =>
         selectedLineIds.has(`${quayId}||${l.id}`),
@@ -114,11 +99,7 @@ function PlatformAndLines({
     }
 
     const filterLineFragment = (line: LineWithFrontText) => {
-        if (isShowLinesByFrontTextEnabled) {
-            return !line.frontTexts || line.frontTexts.length > 0
-        } else {
-            return true
-        }
+        return !line.frontTexts || line.frontTexts.length > 0
     }
 
     return (
@@ -184,10 +165,7 @@ function PlatformAndLines({
                     >
                         <div className="flex flex-row items-center gap-2">
                             <PublicCode line={line} />
-                            <DisplayName
-                                line={line}
-                                showByFrontText={isShowLinesByFrontTextEnabled}
-                            />
+                            <DisplayName line={line} />
                         </div>
                     </Checkbox>
                 ))}

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -109,7 +109,7 @@ async function Landing() {
 
                     <Heading3>Enkelt å tilpasse og samarbeide</Heading3>
 
-                    <UnorderedList className="flex flex-col gap-1 space-y-3 pl-6">
+                    <UnorderedList className="flex flex-col gap-1 space-y-3 pl-6 m-1">
                         <ListItem>
                             Tilpass tekststørrelse, fargetema, logo og hvilken
                             informasjon som skal vises, slik at tavlen(e) passer

--- a/tavla/app/posthog/featureFlags.ts
+++ b/tavla/app/posthog/featureFlags.ts
@@ -1,4 +1,3 @@
 export enum FeatureFlags {
     CreateBoardWithoutUser = 'create_board_without_user',
-    ShowLinesByFrontText = 'show_lines_by_front_text',
 }


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi har lagt til funksjonalitet for å vise retning på linjene istedenfor å vise navnet (ofte ikke veldig intutivt.) Denne funksjonaliteten har vært gated bak en feature flag som gjør at man må akseptere cookies for å få denne featuren. Vi ønsker nå å rulle denne ut til hele brukerbasen.

### ✨ Løsning
- Fjern referanser til feature flaget og alltid ha navn på retning skrudd på. Det vil si at prod kommer til å etterligne slik det er i dev i dag!