### PR TITLE
♻️ Bilferge og cleanup

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
@@ -172,6 +172,9 @@ function TransportPaletteSelect({
                                                 <TransportIcon
                                                     key={mode.mode}
                                                     transportMode={mode.mode}
+                                                    transportSubmode={
+                                                        mode.submode
+                                                    }
                                                     background
                                                     className={`text-background`}
                                                 />

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
@@ -285,6 +285,30 @@ function SetVisibleLines({
         return false
     }
 
+    const renderQuay = (quay: QuayWithFrontText) => {
+        const modes = quayModesMap.get(quay.id) || []
+        const title =
+            quay.name && quay.publicCode
+                ? `${modes[0] === 'metro' || modes[0] === 'rail' ? 'Spor' : 'Plattform'} ${quay.publicCode}`
+                : quay.name || 'Ukjent'
+        return (
+            <PlatformAndLines
+                key={quay.id}
+                tile={tile}
+                quayId={quay.id}
+                groupKey={quay.publicCode || quay.id}
+                title={title}
+                description={quay.description}
+                lines={quay.lines}
+                trackingLocation={trackingLocation}
+                transportModes={modes}
+                selectedLineIds={checkedLineIds}
+                onToggleLine={handleToggleLine}
+                onToggleGroup={handleGroupToggle}
+            />
+        )
+    }
+
     return (
         <>
             <Heading4>Plattformer og linjer</Heading4>
@@ -348,87 +372,14 @@ function SetVisibleLines({
                                                     }
                                                     return cmp
                                                 })
-                                                .map((quay) => {
-                                                    const modes =
-                                                        quayModesMap.get(
-                                                            quay.id,
-                                                        ) || []
-                                                    const title =
-                                                        quay.name &&
-                                                        quay.publicCode
-                                                            ? `${modes[0] === 'metro' || modes[0] === 'rail' ? 'Spor' : 'Plattform'} ${quay.publicCode}`
-                                                            : quay.name ||
-                                                              'Ukjent'
-
-                                                    return (
-                                                        <div key={quay.id}>
-                                                            <PlatformAndLines
-                                                                tile={tile}
-                                                                quayId={quay.id}
-                                                                groupKey={
-                                                                    quay.publicCode ||
-                                                                    quay.id
-                                                                }
-                                                                title={title}
-                                                                description={
-                                                                    quay.description
-                                                                }
-                                                                lines={
-                                                                    quay.lines
-                                                                }
-                                                                trackingLocation={
-                                                                    trackingLocation
-                                                                }
-                                                                transportModes={
-                                                                    modes
-                                                                }
-                                                                selectedLineIds={
-                                                                    checkedLineIds
-                                                                }
-                                                                onToggleLine={
-                                                                    handleToggleLine
-                                                                }
-                                                                onToggleGroup={
-                                                                    handleGroupToggle
-                                                                }
-                                                            />
-                                                        </div>
-                                                    )
-                                                })}
+                                                .map((quay) =>
+                                                    renderQuay(quay),
+                                                )}
                                         </div>
                                     )
                                 } else {
                                     const quay = item.data
-                                    const modes =
-                                        quayModesMap.get(quay.id) || []
-                                    const title =
-                                        quay.name && quay.publicCode
-                                            ? `${modes[0] === 'metro' || modes[0] === 'rail' ? 'Spor' : 'Plattform'} ${quay.publicCode}`
-                                            : quay.name || 'Ukjent'
-
-                                    return (
-                                        <div key={quay.id}>
-                                            <PlatformAndLines
-                                                tile={tile}
-                                                quayId={quay.id}
-                                                groupKey={
-                                                    quay.publicCode || quay.id
-                                                }
-                                                title={title}
-                                                description={quay.description}
-                                                lines={quay.lines}
-                                                trackingLocation={
-                                                    trackingLocation
-                                                }
-                                                transportModes={modes}
-                                                selectedLineIds={checkedLineIds}
-                                                onToggleLine={handleToggleLine}
-                                                onToggleGroup={
-                                                    handleGroupToggle
-                                                }
-                                            />
-                                        </div>
-                                    )
+                                    return renderQuay(quay)
                                 }
                             })}
                         </div>

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
@@ -9,7 +9,7 @@ import { useNonNullContext } from 'src/hooks/useNonNullContext'
 import type { BoardTileDB } from 'src/types/db-types/boards'
 import type { TTransportMode } from 'src/types/graphql-schema'
 import { PlatformAndLines } from '../PlatformAndLines'
-import type { LineWithFrontText, QuayWithFrontText } from '../types'
+import type { QuayWithFrontText } from '../types'
 import { transportModeNames } from '../utils'
 
 function getInitialCheckedLineIds(

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
@@ -201,7 +201,6 @@ function SetVisibleLines({
     onFieldChanged,
 }: {
     quays: QuayWithFrontText[]
-    allLines: LineWithFrontText[]
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     onFieldChanged: (field: string) => void
 }) {

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx
@@ -269,21 +269,20 @@ function SetVisibleLines({
     }
 
     const isModeSelected = (mode: TTransportMode) => {
-        const keysInMode: string[] = []
         for (const q of quays) {
             const quayIsActive = q.lines.some((l) =>
                 checkedLineIds.has(`${q.id}||${l.id}`),
             )
             if (!quayIsActive) continue
-
             for (const l of q.lines) {
-                if (l.transportMode === mode) {
-                    keysInMode.push(`${q.id}||${l.id}`)
-                }
+                if (
+                    l.transportMode === mode &&
+                    checkedLineIds.has(`${q.id}||${l.id}`)
+                )
+                    return true
             }
         }
-        if (keysInMode.length === 0) return false
-        return keysInMode.some((key) => checkedLineIds.has(key))
+        return false
     }
 
     return (

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/index.tsx
@@ -292,7 +292,6 @@ function TileCard({
                             />
                             <SetVisibleLines
                                 quays={quaysWithFilteredLines}
-                                allLines={uniqLines}
                                 trackingLocation={trackingLocation}
                                 onFieldChanged={onFieldChanged}
                             />


### PR DESCRIPTION
### 🥅 Bakgrunn
Bilferge og ferge brukte samme ikon på palettvelgeren, men er ulike i designsystemet.

### ✨ Løsning

- sendte inn submode til TransportIcon der man lister opp bilferger i palettvelgervisningen

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="533" height="451" alt="image" src="https://github.com/user-attachments/assets/0f407047-61fb-48cb-8697-a6a1c500b6e4" /> | <img width="533" height="451" alt="image" src="https://github.com/user-attachments/assets/3bee89ed-9148-4330-b2df-55b7969ba923" /> |


### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari

### ⚠️  Denne oppgaven åpner for flere tanker, noen av dem har jeg gjort noe med i selve PR-en, andre kan vi ta med oss videre:
1. Da jeg prøvde å sette meg inn i koden, forenklet jeg litt i samme slengen. Dette gjelder `tavla/app/(admin)/tavler/[id]/rediger/components/TileCard/components/SetVisibleLines.tsx`. Til neste gang, foretrekker dere at sånne ting kommer i egen PR, at det ikke gjøres noe med eller bare at man tar det fortløpende i halvrelaterte PR-er som uansett ikke er så store?
2. Vi bruker nå fortsatt kun det ene båtikonet i listen over valgte stoppesteder (se bilde). Ønsker vi også her å skille på disse ikonene?
<img width="1022" height="545" alt="image" src="https://github.com/user-attachments/assets/eabf2d8c-06a2-4169-af49-969abce3834d" />

3. Må ta et valg på om vi skal ha dobbelt opp med busser og tog i samme farge under palettvelgeren, eller om vi skal ha a) kun en av hver eller b) dobbelt opp, men i ulik farge (egen for flytog og flybuss). Har hørt med Hanna om dette