### PR TITLE
💄  Liten styling av palettvelger

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/colorPalettes.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/colorPalettes.ts
@@ -50,6 +50,13 @@ export const useAllowedPalettes = (board: BoardDB) =>
         return Array.from(themes)
     }, [board.tiles])
 
+const PALETTE_TO_COUNTY = Object.fromEntries(
+    Object.entries(COUNTY_THEME_MAP).map(([county, palette]) => [
+        palette,
+        county,
+    ]),
+) as Record<string, string>
+
 export const generateTransportPalettes = (
     allowedPalettes: TransportPalette[],
 ) => {
@@ -62,28 +69,13 @@ export const generateTransportPalettes = (
         : baseTransportPalettes
 
     const localPalettes = filteredPalettes.filter(
-        (palette) => palette.value === 'atb' || palette.value === 'fram',
+        (palette) => PALETTE_TO_COUNTY[palette.value] !== undefined,
     )
 
     if (localPalettes.length > 1) {
         return filteredPalettes.map((palette) => {
-            if (palette.value === 'atb') {
-                return {
-                    ...palette,
-                    label: 'Lokal (Trøndelag)',
-                }
-            } else if (palette.value === 'fram') {
-                return {
-                    ...palette,
-                    label: 'Lokal (Møre og Romsdal)',
-                }
-            } else if (palette.value === 'reis') {
-                return {
-                    ...palette,
-                    label: 'Lokal (Nordland)',
-                }
-            }
-            return palette
+            const county = PALETTE_TO_COUNTY[palette.value]
+            return county ? { ...palette, label: `Lokal (${county})` } : palette
         })
     }
 

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/components/TransportPaletteSelect.tsx
@@ -26,12 +26,7 @@ const busAndTrainModes: {
         mode: 'rail',
     },
     {
-        mode: 'bus',
-        submode: 'airportLinkBus',
-    },
-    {
-        mode: 'rail',
-        submode: 'airportLinkRail',
+        mode: 'coach',
     },
 ]
 
@@ -50,9 +45,7 @@ const transportModes: { mode: TTransportMode; submode?: TTransportSubmode }[] =
         {
             mode: 'metro',
         },
-        {
-            mode: 'taxi',
-        },
+
         {
             mode: 'tram',
         },


### PR DESCRIPTION
### 🥅 Bakgrunn
Det var dobbelt opp av like busser og tog for hvert punkt i palettvelgeren. I tillegg manglet "Lokal(Nordland)" som tittel på radio button.

### ✨ Løsning

- satte opp en dynamisk generering av listen over lokale selskapsfarger slik at vi ikke manuelt må endre `localPalettes`(linje 64) når nye lokale paletter legges til. Dette fikset samtidig at "reis" ikke var lagt til.
- fjerner flybuss, flytog og taxi i listen av ikoner som rendres. Legger så til langdistansebuss

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="644" height="413" alt="image" src="https://github.com/user-attachments/assets/04cb1dbe-657c-437e-aa29-aa95b985b320" /> | <img width="644" height="315" alt="image" src="https://github.com/user-attachments/assets/fb5a229f-73e1-45ab-a0dd-9bc233d6c574" /> |

