### PR TITLE
👷‍♀️ Fjern at cd-backend-dev kjøres ved merge

### DIFF
--- a/.github/workflows/cd-backend-dev.yml
+++ b/.github/workflows/cd-backend-dev.yml
@@ -2,11 +2,6 @@ name: cd/backend-dev
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - "backend/**"
 
 jobs:
   docker-push:


### PR DESCRIPTION
### 🥅 Bakgrunn
Per nå kjøres både cd-backend og cd-backend-dev ved merge, og begge deployer til dev. Det vil vi ikke, vil bare at cd-backend kjøres ved merge til main. 

### ✨ Løsning
- fjerner kjøring ved `push` til `main`


