### PR TITLE
📦 bump basic-ftp from 5.2.0 to 5.3.0

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -88,7 +88,7 @@
         "node": "22.13.0"
     },
     "resolutions": {
-        "basic-ftp": "5.2.0",
+        "basic-ftp": "5.3.0",
         "minimatch": "9.0.7",
         "tar": "7.5.11",
         "immutable": "3.8.3"

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -5288,10 +5288,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:5.2.0":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10/f5a15d789aa98859af4da9e976154b2aeae19052e1762dc68d259d2bce631dafa40c667aa06d7346cd630aa6f9cc9a26f515b468e0bd24243fbae2149c7d01ad
+"basic-ftp@npm:5.3.0":
+  version: 5.3.0
+  resolution: "basic-ftp@npm:5.3.0"
+  checksum: 10/08eef717642f32d92936e02f516ab6426ecc61084e4a75b542cd202dd84dddff2520dda321db1be34b7e49860cf1b2aed67ab275dc3e53b185949df311241396
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hva

Bumper `basic-ftp` fra `5.2.0` til `5.3.0` i `resolutions` (yarn.lock).

## Hvorfor

Patcher **CVE-2026-41324** — DoS-sårbarhet i `Client.list()` som kan føre til ubegrenset minnebruk.

`basic-ftp` er ikke en direkte avhengighet, men en transitiv via:
```
pac-proxy-agent → get-uri → basic-ftp
```
Pakken er allerede pinnset via `resolutions` i rot-`package.json`; eneste nødvendige endring er å bumpe versjonen der.

## For reviewer

- Én linje endret i `package.json`, resten er lockfile-oppdatering.
- `basic-ftp` brukes ikke direkte i frontend-koden — ingen funksjonelle endringer.