### PR TITLE
🔐 Dropper å eksponere location til `tavla-visning`

### DIFF
--- a/tavla/app/api/board/route.ts
+++ b/tavla/app/api/board/route.ts
@@ -40,8 +40,10 @@ async function fetchBoardById(boardId: BoardDB['id']): Promise<BoardDB | null> {
     if (!boardDoc.exists) {
         return null
     }
+    const board = { id: boardId, ...boardDoc.data() } as BoardDB
 
-    return { id: boardId, ...boardDoc.data() } as BoardDB
+    const { location: _, ...meta } = board.meta
+    return { ...board, meta }
 }
 
 async function fetchFolderLogo(boardId: BoardDB['id']): Promise<string | null> {


### PR DESCRIPTION
### 🥅 Bakgrunn
Som en utvikler
Ønsker jeg at location på et board ikke eksponeres til tavla visning
Slik at vi ikke eksponerer unødvendig informasjon og tar vare på personvernet til brukerne

### ✨ Løsning

- Filtrere borde location-feltet i route.ts  GET-endepunktet