### PR TITLE
🐛 Legg til en sjekk for customUrl-lenker som starter med "preview"

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/actions.ts
@@ -118,6 +118,12 @@ export async function saveCustomUrl(
         }
     }
 
+    if (trimmed && /^preview/i.test(trimmed)) {
+        return {
+            error: 'Denne lenken kan ikke brukes.',
+        }
+    }
+
     try {
         if (trimmed) {
             const existing = await db


### PR DESCRIPTION
### 🥅 Bakgrunn
`preview`-lenker er en spesiell case og det er umulig å få opp en egendefinert tavle med denne lenken. Vi må fjerne muligheten for å lage disse.