### PR TITLE
📈 Sender med "isAnonymousTable" for nye tavler lages uten bruker

### DIFF
--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -23,6 +23,7 @@ export async function publishBoard(board: BoardDB): Promise<string> {
                 created: now,
                 dateModified: now,
             },
+            isAnonymousBoard: true,
         })
     return doc.id
 }

--- a/tavla/src/types/db-types/boards.ts
+++ b/tavla/src/types/db-types/boards.ts
@@ -106,15 +106,14 @@ export const BoardDBSchema = z.object({
     id: z.string(),
     meta: boardMetaSchema,
     tiles: z.array(boardTileSchema),
-
     isCombinedTiles: z.boolean(),
     theme: boardThemeSchema.optional(),
     footer: boardFooterSchema.optional(),
     transportPalette: transportPaletteSchema.optional(),
     hideLogo: z.boolean().optional(),
     hideClock: z.boolean().optional(),
-
     customUrl: z.string().optional(),
+    isAnonymousBoard: z.boolean().default(false),
 })
 
 export type BoardDB = z.infer<typeof BoardDBSchema>

--- a/tavla/src/types/db-types/boards.ts
+++ b/tavla/src/types/db-types/boards.ts
@@ -113,7 +113,7 @@ export const BoardDBSchema = z.object({
     hideLogo: z.boolean().optional(),
     hideClock: z.boolean().optional(),
     customUrl: z.string().optional(),
-    isAnonymousBoard: z.boolean().default(false),
+    isAnonymousBoard: z.boolean().optional(),
 })
 
 export type BoardDB = z.infer<typeof BoardDBSchema>


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi ønsker å lett kunne tracke hvilke tavler som er opprettet uten bruker, både for statistikk og enkel opprydning i senere tid (en tavle som er uten bruker og ikke har vært aktiv på lang tid kan slettes)

### ✨ Løsning

- legger til isAnonymousBoard-felt på nye tavler uten bruker. Feltet vil være true for anonyme tavler, og undefined ellers. Se [minidiskusjon på slack om optional/ikke-optional](https://entur.slack.com/archives/C071E0QN7ST/p1778142783675499).
- Feltet brukes ikke i frontendvisningen, kun som en tag i db


