### PR TITLE
👷 Bump gha-docker til @v1

### DIFF
--- a/.github/workflows/cd-backend-dev.yml
+++ b/.github/workflows/cd-backend-dev.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docker-push:
-    uses: entur/gha-docker/.github/workflows/push.yml@v1.2.3
+    uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
       environment: prd
       context: backend

--- a/.github/workflows/cd-backend-dev.yml
+++ b/.github/workflows/cd-backend-dev.yml
@@ -4,12 +4,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  docker-build:
+    uses: entur/gha-docker/.github/workflows/build.yml@v1
+    with:
+      context: backend
+      dockerfile: backend/Dockerfile
+      image_name: tavla-backend
+
   docker-push:
+    needs: [docker-build]
     uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
-      environment: prd
-      context: backend
-      image_name: tavla/backend
+      image_name: tavla-backend
 
   helm-deploy-dev:
     needs: [docker-push]
@@ -19,4 +25,3 @@ jobs:
       chart: backend/helm/backend
       image: ${{ needs.docker-push.outputs.image_name }}:${{ needs.docker-push.outputs.image_tag}}
       release_name: backend
-

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -9,12 +9,18 @@ on:
       - "backend/**"
 
 jobs:
+  docker-build:
+    uses: entur/gha-docker/.github/workflows/build.yml@v1
+    with:
+      context: backend
+      dockerfile: backend/Dockerfile
+      image_name: tavla-backend
+
   docker-push:
+    needs: [docker-build]
     uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
-      environment: prd
-      context: backend
-      image_name: tavla/backend
+      image_name: tavla-backend
 
   helm-deploy-dev:
     needs: [docker-push]
@@ -24,7 +30,6 @@ jobs:
       chart: backend/helm/backend
       image: ${{ needs.docker-push.outputs.image_name }}:${{ needs.docker-push.outputs.image_tag}}
       release_name: backend
-
 
   helm-deploy-prd:
     needs: [docker-push]

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docker-push:
-    uses: entur/gha-docker/.github/workflows/push.yml@v1.2.3
+    uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
       environment: prd
       context: backend

--- a/.github/workflows/cd-frontend-dev.yml
+++ b/.github/workflows/cd-frontend-dev.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docker-push:
-    uses: entur/gha-docker/.github/workflows/push.yml@v1.2.3
+    uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
       context: tavla
       image_name: tavla/frontend

--- a/.github/workflows/cd-frontend-dev.yml
+++ b/.github/workflows/cd-frontend-dev.yml
@@ -4,10 +4,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker-push:
-    uses: entur/gha-docker/.github/workflows/push.yml@v1
+  docker-build:
+    uses: entur/gha-docker/.github/workflows/build.yml@v1
     with:
       context: tavla
+      image_name: tavla/frontend
+
+  docker-push:
+    needs: [docker-build]
+    uses: entur/gha-docker/.github/workflows/push.yml@v1
+    with:
       image_name: tavla/frontend
 
   helm-deploy-dev:

--- a/.github/workflows/cd-frontend-dev.yml
+++ b/.github/workflows/cd-frontend-dev.yml
@@ -9,13 +9,13 @@ jobs:
     with:
       context: tavla
       dockerfile: tavla/Dockerfile
-      image_name: tavla/frontend
+      image_name: tavla-frontend
 
   docker-push:
     needs: [docker-build]
     uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
-      image_name: tavla/frontend
+      image_name: tavla-frontend
 
   helm-deploy-dev:
     needs: [docker-push]

--- a/.github/workflows/cd-frontend-dev.yml
+++ b/.github/workflows/cd-frontend-dev.yml
@@ -8,6 +8,7 @@ jobs:
     uses: entur/gha-docker/.github/workflows/build.yml@v1
     with:
       context: tavla
+      dockerfile: tavla/Dockerfile
       image_name: tavla/frontend
 
   docker-push:

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -9,11 +9,18 @@ on:
       - "tavla/**"
 
 jobs:
-  docker-push:
-    uses: entur/gha-docker/.github/workflows/push.yml@v1
+  docker-build:
+    uses: entur/gha-docker/.github/workflows/build.yml@v1
     with:
       context: tavla
-      image_name: tavla/frontend
+      dockerfile: tavla/Dockerfile
+      image_name: tavla-frontend
+
+  docker-push:
+    needs: [docker-build]
+    uses: entur/gha-docker/.github/workflows/push.yml@v1
+    with:
+      image_name: tavla-frontend
 
   helm-deploy-dev:
     needs: [docker-push]

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docker-push:
-    uses: entur/gha-docker/.github/workflows/push.yml@v1.2.3
+    uses: entur/gha-docker/.github/workflows/push.yml@v1
     with:
       context: tavla
       image_name: tavla/frontend


### PR DESCRIPTION
### 🥅 Bakgrunn

Fikk følgende feil ved deploy som kan være relatert til at vi bruker gammel versjon av entur/gha-docker. 

> `Permission 'artifactregistry.repositories.uploadArtifacts' denied on resource (or it may not exist)`

Plattformteamet bekreftet at løsningen er å bumpe til `@v1`.

### ✨ Løsning

- Oppdaterer `entur/gha-docker/.github/workflows/push.yml` fra `@v1.2.3` til `@v1` i alle fire CD-workflows:
  - `cd-frontend-dev.yml`
  - `cd-frontend.yml`
  - `cd-backend-dev.yml`
  - `cd-backend.yml`

