### PR TITLE
🐛 Fiks for unhandledRejection på userHasAccessToEditBoard

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -85,6 +85,8 @@ export async function saveSettings(data: FormData) {
             return errors
         }
 
+        await userHasAccessToEditBoard(board.id ?? '')
+
         await saveTitle(bid, boardTitle)
         await moveBoard(bid, newFolder, oldFolder)
         await saveLocation(board, location)
@@ -107,8 +109,6 @@ export async function saveSettings(data: FormData) {
 }
 
 async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
-    await userHasAccessToEditBoard(bid)
-
     const footerContainsText =
         footer && !isOnlyWhiteSpace(footer) && footer.trim() !== ''
 
@@ -134,8 +134,6 @@ async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
 }
 
 async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
-    await userHasAccessToEditBoard(bid)
-
     try {
         await db
             .collection('boards')
@@ -159,8 +157,6 @@ async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
 }
 
 async function setViewType(board: BoardDB, viewType: string) {
-    await userHasAccessToEditBoard(board.id ?? '')
-
     const isSeparateTiles = viewType === 'separate'
 
     try {
@@ -179,8 +175,6 @@ async function setViewType(board: BoardDB, viewType: string) {
 }
 
 async function saveTitle(bid: BoardDB['id'], title: string) {
-    await userHasAccessToEditBoard(bid)
-
     try {
         await db
             .collection('boards')
@@ -202,8 +196,6 @@ async function saveTitle(bid: BoardDB['id'], title: string) {
 }
 
 async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
-    await userHasAccessToEditBoard(bid)
-
     try {
         await db
             .collection('boards')
@@ -222,8 +214,6 @@ async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
 }
 
 async function saveLocation(board: BoardDB, location?: LocationDB) {
-    await userHasAccessToEditBoard(board.id ?? '')
-
     try {
         await db
             .collection('boards')
@@ -266,8 +256,6 @@ export async function moveBoard(
 ) {
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
-
-    await userHasAccessToEditBoard(bid)
 
     if (fromFolder) {
         const canEdit = await userCanEditFolder(fromFolder)
@@ -318,8 +306,6 @@ async function setTransportPalette(
     bid: BoardDB['id'],
     transportPalette?: TransportPalette,
 ) {
-    await userHasAccessToEditBoard(bid)
-
     try {
         await db
             .collection('boards')
@@ -347,8 +333,6 @@ async function setElements(
     hideClock: boolean,
     hideLogo: boolean,
 ) {
-    await userHasAccessToEditBoard(bid)
-
     try {
         await db.collection('boards').doc(bid).update({
             hideClock: hideClock,

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -107,7 +107,7 @@ export async function saveSettings(data: FormData) {
 }
 
 async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     const footerContainsText =
         footer && !isOnlyWhiteSpace(footer) && footer.trim() !== ''
@@ -134,7 +134,7 @@ async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
 }
 
 async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     try {
         await db
@@ -159,7 +159,7 @@ async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
 }
 
 async function setViewType(board: BoardDB, viewType: string) {
-    userHasAccessToEditBoard(board.id ?? '')
+    await userHasAccessToEditBoard(board.id ?? '')
 
     const isSeparateTiles = viewType === 'separate'
 
@@ -179,7 +179,7 @@ async function setViewType(board: BoardDB, viewType: string) {
 }
 
 async function saveTitle(bid: BoardDB['id'], title: string) {
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     try {
         await db
@@ -202,7 +202,7 @@ async function saveTitle(bid: BoardDB['id'], title: string) {
 }
 
 async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     try {
         await db
@@ -222,7 +222,7 @@ async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
 }
 
 async function saveLocation(board: BoardDB, location?: LocationDB) {
-    userHasAccessToEditBoard(board.id ?? '')
+    await userHasAccessToEditBoard(board.id ?? '')
 
     try {
         await db
@@ -267,7 +267,7 @@ export async function moveBoard(
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     if (fromFolder) {
         const canEdit = await userCanEditFolder(fromFolder)
@@ -318,7 +318,7 @@ async function setTransportPalette(
     bid: BoardDB['id'],
     transportPalette?: TransportPalette,
 ) {
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     try {
         await db
@@ -347,7 +347,7 @@ async function setElements(
     hideClock: boolean,
     hideLogo: boolean,
 ) {
-    userHasAccessToEditBoard(bid)
+    await userHasAccessToEditBoard(bid)
 
     try {
         await db.collection('boards').doc(bid).update({


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi har blitt plaget en god del av `NEXT_REDIRECT`-problemer som har dukket opp i Sentry. Dette har også skjedd lokalt:

```bash
  [1] ⨯ unhandledRejection:  Error: NEXT_REDIRECT
  [1]     at userHasAccessToEditBoard
  (app/(admin)/tavler/[id]/rediger/components/Settings/actions.ts:41:33)
  [1]   39 | async function userHasAccessToEditBoard(bid: string) {
  [1]   40 |     const access = await userCanEditBoard(bid)
  [1] > 41 |     if (!access) return redirect('/')
  [1]      |                                 ^
  [1]   42 | }
  [1]   43 |
  [1]   44 | export async function saveSettings(data: FormData) { {
  [1]   digest: 'NEXT_REDIRECT;push;/;307;'
  [1] }
```

### ✨ Løsning
- Legge til `await`s på calls til `userhasAccessToEditBoard()`. Slik jeg forstår det: resultatet (og da en `rejection`) mistes inne i den `async` funksjonen, siden vi ikke venter svaret fra den. Den kjøres ikke sekvensielt, og på `return` skjer det da en feil siden ingenting venter på svaret (den blir rejected), og det er ikke håndtert. Med en `await` så venter vi på svaret, og da vil vi også vente på å bli redirected, ellers skjer ingenting og alt går som før.

Forklaring av claudern:
> The root cause is clear: userHasAccessToEditBoard(bid) is called without await
  in every helper function (lines 110, 137, 162, 182, 205, 225, 270, 321, 350).
  Since redirect() works by throwing a special error, throwing inside an
  un-awaited promise produces an unhandled rejection instead of propagating up
  the call stack.
 > 
 > Without await, the promise from
  userHasAccessToEditBoard was fire-and-forget — the redirect() throw inside it
  never propagated to the caller, causing the unhandled rejection. With await,
  the thrown redirect error propagates normally and is caught by the try/catch in
   saveSettings (which already has isRedirectError handling).


Har testet rundt en god del, har ikke fått opp noen redirect-problemer.
