### PR TITLE
🧹 Fjerne demo page logging innenfor rediger

### DIFF
--- a/tavla/app/(admin)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/page.tsx
@@ -131,9 +131,7 @@ export default async function EditPage(props: TProps) {
                     </div>
                     <TileSelector
                         action={addTilesAction}
-                        trackingLocation={
-                            board.id === 'demo' ? 'demo_page' : 'board_page'
-                        }
+                        trackingLocation="board_page"
                     />
                     <TileList board={board} />
                     <section


### PR DESCRIPTION
### 🥅 Bakgrunn

Location tracking av demo_page ville aldri bli trigget innenfor rediger-siden for innloggede brukere. 

### ✨ Løsning

Sette tracking til statisk "board_page"


