### PR TITLE
🐛 Fiks at endringer på tile ikke trigget ny lenke på /lag-tavle

### DIFF
--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -95,7 +95,10 @@ function CreateBoardLocally() {
                 />
                 <TileList
                     board={board}
-                    setTilesDemoBoard={setTiles}
+                    setTilesDemoBoard={(tiles) => {
+                        setTiles(tiles)
+                        resetPublishedBoard()
+                    }}
                     bid="demo"
                 />
                 <section


### PR DESCRIPTION
### 🥅 Bakgrunn
Når man sletter eller endrer linjer på et stoppested blir ikke lenken resatt så endringene er ikke med

### ✨ Løsning
- kall `resetPublishedBoard` når tiles endres

