### PR TITLE
✨ Add custom url as board id on open board

### DIFF
--- a/tavla/app/(admin)/oversikt/components/Column/Actions.tsx
+++ b/tavla/app/(admin)/oversikt/components/Column/Actions.tsx
@@ -19,7 +19,7 @@ function TableActions({ data }: { data: TableItem }) {
                     />
                     <Open
                         board={data.board}
-                        bid={data.board.id}
+                        bid={data.board.customUrl ?? data.board.id}
                         trackingLocation="admin_table"
                     />
                     <Move board={data.board} />

--- a/tavla/app/(admin)/tavler/[id]/rediger/components/ActionsMenu.tsx
+++ b/tavla/app/(admin)/tavler/[id]/rediger/components/ActionsMenu.tsx
@@ -31,7 +31,11 @@ function ActionsMenuDesktop({
 }) {
     return (
         <div className="hidden flex-row gap-4 sm:flex md:items-center">
-            <Open bid={board.id} type="button" trackingLocation="board_page" />
+            <Open
+                bid={board.customUrl ?? board.id}
+                type="button"
+                trackingLocation="board_page"
+            />
             <RefreshButton board={board} />
             <DeleteBoard
                 board={board}
@@ -60,7 +64,7 @@ function ActionsMenuPhone({
         <div className="hidden flex-row max-sm:flex md:hidden">
             <div className="flex flex-row gap-1">
                 <Open
-                    bid={board.id}
+                    bid={board.customUrl ?? board.id}
                     type="button"
                     trackingLocation="board_page"
                 />


### PR DESCRIPTION
### 🥅 Bakgrunn

Selv om det blir satt egendefinert url er det fortsatt id-urlen som blir valgt når bruker trykker "Åpne tavle" 


### ✨ Løsning

Sette custom-url som første prioritet i open, og velge boardid hvis urlen ikke er egendefinert!


### ✅ Sjekkliste

- [x] Testet i Chrome
