### PR TITLE
🧹Fjerner knapp som ikke skal være der for tavle uten bruker

### DIFF
--- a/tavla/app/components/CreateBoardButton.tsx
+++ b/tavla/app/components/CreateBoardButton.tsx
@@ -1,34 +1,11 @@
 'use client'
 import { Button } from '@entur/button'
 import { ForwardIcon } from '@entur/icons'
-import { CreateUserButton } from 'app/components/CreateUserButton'
-import { FeatureFlags } from 'app/posthog/featureFlags'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import Link from 'next/link'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 
 function CreateBoardButton() {
     const posthog = usePosthogTracking()
-
-    const isCreateBoardWithoutUserEnabled = useFeatureFlagEnabled(
-        FeatureFlags.CreateBoardWithoutUser,
-    )
-
-    if (isCreateBoardWithoutUserEnabled) {
-        return (
-            <>
-                <CreateUserButton variant="secondary" />
-                <Button
-                    variant="primary"
-                    size="medium"
-                    as={Link}
-                    href="lag-tavle"
-                >
-                    Lag en tavle <ForwardIcon aria-hidden />
-                </Button>
-            </>
-        )
-    }
 
     return (
         <Button

--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -95,7 +95,10 @@ function CreateBoardLocally() {
                 />
                 <TileList
                     board={board}
-                    setTilesDemoBoard={setTiles}
+                    setTilesDemoBoard={(tiles) => {
+                        setTiles(tiles)
+                        resetPublishedBoard()
+                    }}
                     bid="demo"
                 />
                 <section

--- a/tavla/app/page.tsx
+++ b/tavla/app/page.tsx
@@ -71,9 +71,7 @@ async function Landing() {
                             {loggedIn ? (
                                 <NavigateToOversiktButton />
                             ) : (
-                                <div className="flex w-full flex-col gap-4 md:flex-row">
-                                    <CreateBoardButton />
-                                </div>
+                                <CreateBoardButton />
                             )}
                         </div>
                     </div>


### PR DESCRIPTION
### 🥅 Bakgrunn
Lå igjen en knapp som ikke skulle være der på forsiden, inngangen til /lag-tavle blir bare gjennom `Entry`

### ✨ Løsning
- Fjerner sjekk og egen return for `isCreateBoardWithoutUserEnabled` på forsiden



### ✅ Sjekkliste

- [x] Testet i Chrome