### PR TITLE
🔒 Oppdater protobufjs til 7.5.8 for å fikse sikkerhetssårbarheter

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -91,6 +91,7 @@
         "basic-ftp": "5.3.0",
         "minimatch": "9.0.7",
         "tar": "7.5.11",
-        "immutable": "3.8.3"
+        "immutable": "3.8.3",
+        "protobufjs": "7.5.8"
     }
 }

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -3777,10 +3777,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/codegen@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@protobufjs/codegen@npm:2.0.4"
-  checksum: 10/c6ee5fa172a8464f5253174d3c2353ea520c2573ad7b6476983d9b1346f4d8f2b44aa29feb17a949b83c1816bc35286a5ea265ed9d8fdd2865acfa09668c0447
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10/290335fa114f26202abc0695f279d53e2fd516b01cfd8298923591e0bda011295ff40e3582a1cda0a0f27cbc5039a0292082d5ad08872bb5d6243a614ac15c88
   languageName: node
   linkType: hard
 
@@ -3815,6 +3815,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/inquire@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/inquire@npm:1.1.1"
+  checksum: 10/504740e8ac348f70b33bcf6a20c83d5b9679901654c1a96b18c0491ec2f2f7ac580e74019b6d1bce16113bfb9746bc6e7dfd4e12a717deed699675b7f230ce9e
+  languageName: node
+  linkType: hard
+
 "@protobufjs/path@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/path@npm:1.1.2"
@@ -3829,10 +3836,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/utf8@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/utf8@npm:1.1.0"
-  checksum: 10/131e289c57534c1d73a0e55782d6751dd821db1583cb2f7f7e017c9d6747addaebe79f28120b2e0185395d990aad347fb14ffa73ef4096fa38508d61a0e64602
+"@protobufjs/utf8@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/utf8@npm:1.1.1"
+  checksum: 10/ed0c3f9ff1afd602a0aed54c4c03a0b8f641686a5587d8949e088dcac653fb2019d15691ed92eef23dfdf9f4293249532d0508ecd15cef810acf026917719a19
   languageName: node
   linkType: hard
 
@@ -10756,23 +10763,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.2, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.0, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
-  version: 7.5.5
-  resolution: "protobufjs@npm:7.5.5"
+"protobufjs@npm:7.5.8":
+  version: 7.5.8
+  resolution: "protobufjs@npm:7.5.8"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/codegen": "npm:^2.0.5"
     "@protobufjs/eventemitter": "npm:^1.1.0"
     "@protobufjs/fetch": "npm:^1.1.0"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/inquire": "npm:^1.1.1"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
+  checksum: 10/2beb69b88a5c0a8420d0d5934f2358d417ecd6446f4c0d7c8a9ba5fc0e62ec1631938c0ab083258c14f15b87d39d559b49b398779638df57b2f3a3238cc0be1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🥅 Bakgrunn

7 Dependabot-varsler (4 høy, 3 moderat) ble åpnet for `protobufjs` i `tavla/yarn.lock`:

- **Høy:** Kodegenererings-gadget etter prototype-forurensning (#430)
- **Høy:** Kode-injeksjon via bytes-felts standardverdier i generert `toObject`-kode (#432)
- **Høy:** Prosessomfattende tjenestenekt via usikre alternativstier (#429)
- **Høy:** Tjenestenekt via ubegrenset protobuf-rekursjon (#428)
- **Moderat:** Tjenestenekt fra bearbeidede feltnavn i generert kode (#433)
- **Moderat:** Prototype-injeksjon i genererte meldingskonstruktører (#431)
- **Moderat:** Overlangt UTF-8-dekoding (#427)

`protobufjs` er ikke en direkte avhengighet — den hentes inn transitivt av `@google-cloud/firestore`, `firebase-functions`, `@grpc/proto-loader` m.fl.

### ✨ Løsning

- Legger til `"protobufjs": "7.5.8"` i `resolutions`-blokken i `package.json`, som allerede brukes for andre sikkerhetspinner
- Oppdaterer `yarn.lock` slik at alle `^7.x.x`-versjonsintervaller løses til `7.5.8` (var `7.5.5`)



### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
