### PR TITLE
🔒 Legger til encodeURIComponent for board.id-input 

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
@@ -9,13 +9,16 @@ export async function refreshBoard(board: BoardDB) {
     const access = await userCanEditBoard(board.id)
     if (!access) return redirect('/')
 
-    const res = await fetch(`${getBackendUrl()}/refresh/${board.id}`, {
-        method: 'POST',
-        body: JSON.stringify(board),
-        headers: {
-            Authorization: `Bearer ${process.env.BACKEND_API_KEY}`,
-            'Content-Type': 'application/json',
+    const res = await fetch(
+        `${getBackendUrl()}/refresh/${encodeURIComponent(board.id)}`,
+        {
+            method: 'POST',
+            body: JSON.stringify(board),
+            headers: {
+                Authorization: `Bearer ${process.env.BACKEND_API_KEY}`,
+                'Content-Type': 'application/json',
+            },
         },
-    })
+    )
     return res.ok
 }


### PR DESCRIPTION
- > som anbefalt av claude sin sikkerhetsgjennomgang

### 🥅 Bakgrunn
Fra CodeQL og Claude:

> CodeQL mener board.id er bruker-kontrollert og inngår i URL-en. Men: getBackendUrl() returnerer en hardkodet streng — enten 'https://tavla-api.entur.no' eller 'https://tavla-api.dev.entur.no' basert på process.env.COMMON_ENV. Angriperen kan aldri endre hosten — dette er ikke SSRF i tradisjonell forstand.
> 
> Det som teknisk sett er mulig er path traversal: en ondsinnet klient kunne sende board.id = "../../noe". Men funksjonen kaller userCanEditBoard(board.id) først — som sjekker mot Firestore at en ekte sak med den IDen finnes. Firestore-genererte IDer er alfanumeriske, og ingen sak med ID ../../noe vil finnes → redirect('/') returneres.
> 
> Anbefaling: Ikke dismiss uten å notere. CodeQL-flagget kan elimineres ved å legge til encodeURIComponent(board.id) eller en enkel format-validering på board.id. Reell risiko: svært lav.


### ✨ Løsning

- Som nevnt i Slack innfører vi løsningen som er foreslått i **Bakgrunn**. 

> Som med det meste ang. sikkerhet: for mye er på det verste bare overflødig. For lite kan være katastrofe

