### PR TITLE
🪵 Legg til logging av inn- og utgående kall

### DIFF
--- a/tavla/app/(innlogget)/actions.ts
+++ b/tavla/app/(innlogget)/actions.ts
@@ -18,6 +18,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function getFirebaseClientConfig() {
+    await logToGcp('info', 'action:getFirebaseClientConfig invoked')
     const env = process.env.GOOGLE_PROJECT_ID
     if (env === 'ent-tavla-prd') return FIREBASE_PRD_CONFIG
     return FIREBASE_DEV_CONFIG
@@ -28,6 +29,7 @@ function userInFolder(uid?: UserDB['uid'], folder?: FolderDB) {
 }
 
 export async function getFolderIfUserHasAccess(folderid?: FolderDB['id']) {
+    await logToGcp('info', 'action:getFolderIfUserHasAccess invoked')
     if (!folderid) return undefined
 
     const folder = await getFolder(folderid)
@@ -44,6 +46,7 @@ export async function getFolderIfUserHasAccess(folderid?: FolderDB['id']) {
 }
 
 export async function getFoldersForUser(): Promise<Folder[]> {
+    await logToGcp('info', 'action:getFoldersForUser invoked')
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 
@@ -129,6 +132,7 @@ export async function getFoldersForUser(): Promise<Folder[]> {
 }
 
 export async function getBoardsForFolder(folderid: FolderDB['id']) {
+    await logToGcp('info', 'action:getBoardsForFolder invoked')
     const folder = await getFolderIfUserHasAccess(folderid)
     if (!folder) return redirect('/')
 
@@ -183,6 +187,7 @@ export async function getBoardsForFolder(folderid: FolderDB['id']) {
 }
 
 export async function getBoards(ids?: BoardDB['id'][]) {
+    await logToGcp('info', 'action:getBoards invoked')
     if (!ids) return []
 
     const batches = chunk(ids, 20)
@@ -228,6 +233,7 @@ export async function getBoards(ids?: BoardDB['id'][]) {
 }
 
 export async function getPrivateBoardsForUser(folders: FolderDB[]) {
+    await logToGcp('info', 'action:getPrivateBoardsForUser invoked')
     const userWithBoards = await getUserWithBoardIds()
     if (!userWithBoards?.uid) return []
 

--- a/tavla/app/(innlogget)/actions.ts
+++ b/tavla/app/(innlogget)/actions.ts
@@ -206,12 +206,18 @@ export async function getBoards(ids?: BoardDB['id'][]) {
                 const parsedBoard = BoardDBSchema.safeParse(boardData)
 
                 if (!parsedBoard.success) {
+                    logToGcp(
+                        'warning',
+                        `Board data validation failed: ${parsedBoard.error.message}`,
+                        { bid: doc.id },
+                    )
+
                     Sentry.captureMessage(
                         'Board data validation failed in getBoards',
                         {
                             level: 'warning',
                             extra: {
-                                error: parsedBoard.error.flatten(),
+                                error: parsedBoard.error.message,
                                 boardId: doc.id,
                             },
                         },
@@ -233,9 +239,12 @@ export async function getBoards(ids?: BoardDB['id'][]) {
 }
 
 export async function getPrivateBoardsForUser(folders: FolderDB[]) {
-    await logToGcp('info', 'action:getPrivateBoardsForUser invoked')
     const userWithBoards = await getUserWithBoardIds()
     if (!userWithBoards?.uid) return []
+
+    await logToGcp('info', 'action:getPrivateBoardsForUser invoked', {
+        uid: userWithBoards.uid,
+    })
 
     const rawOwner = userWithBoards.owner ?? []
 

--- a/tavla/app/(innlogget)/actions.ts
+++ b/tavla/app/(innlogget)/actions.ts
@@ -18,7 +18,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function getFirebaseClientConfig() {
-    await logToGcp('info', 'action:getFirebaseClientConfig invoked')
+    logToGcp('info', 'action:getFirebaseClientConfig invoked')
     const env = process.env.GOOGLE_PROJECT_ID
     if (env === 'ent-tavla-prd') return FIREBASE_PRD_CONFIG
     return FIREBASE_DEV_CONFIG
@@ -29,7 +29,7 @@ function userInFolder(uid?: UserDB['uid'], folder?: FolderDB) {
 }
 
 export async function getFolderIfUserHasAccess(folderid?: FolderDB['id']) {
-    await logToGcp('info', 'action:getFolderIfUserHasAccess invoked')
+    logToGcp('info', 'action:getFolderIfUserHasAccess invoked')
     if (!folderid) return undefined
 
     const folder = await getFolder(folderid)
@@ -46,7 +46,7 @@ export async function getFolderIfUserHasAccess(folderid?: FolderDB['id']) {
 }
 
 export async function getFoldersForUser(): Promise<Folder[]> {
-    await logToGcp('info', 'action:getFoldersForUser invoked')
+    logToGcp('info', 'action:getFoldersForUser invoked')
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 
@@ -120,9 +120,9 @@ export async function getFoldersForUser(): Promise<Folder[]> {
             }
         })
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to fetch folders for user ${user.uid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to fetch folders: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureMessage(
             'Error while fetching folders for user with id ' + user.uid,
@@ -132,7 +132,7 @@ export async function getFoldersForUser(): Promise<Folder[]> {
 }
 
 export async function getBoardsForFolder(folderid: FolderDB['id']) {
-    await logToGcp('info', 'action:getBoardsForFolder invoked')
+    logToGcp('info', 'action:getBoardsForFolder invoked')
     const folder = await getFolderIfUserHasAccess(folderid)
     if (!folder) return redirect('/')
 
@@ -175,7 +175,7 @@ export async function getBoardsForFolder(folderid: FolderDB['id']) {
             }),
         )
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to fetch boards for folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -187,7 +187,7 @@ export async function getBoardsForFolder(folderid: FolderDB['id']) {
 }
 
 export async function getBoards(ids?: BoardDB['id'][]) {
-    await logToGcp('info', 'action:getBoards invoked')
+    logToGcp('info', 'action:getBoards invoked')
     if (!ids) return []
 
     const batches = chunk(ids, 20)
@@ -229,7 +229,7 @@ export async function getBoards(ids?: BoardDB['id'][]) {
             }),
         )
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to fetch boards [${ids}]: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -242,9 +242,7 @@ export async function getPrivateBoardsForUser(folders: FolderDB[]) {
     const userWithBoards = await getUserWithBoardIds()
     if (!userWithBoards?.uid) return []
 
-    await logToGcp('info', 'action:getPrivateBoardsForUser invoked', {
-        uid: userWithBoards.uid,
-    })
+    logToGcp('info', 'action:getPrivateBoardsForUser invoked')
 
     const rawOwner = userWithBoards.owner ?? []
 

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -19,6 +19,7 @@ export async function createBoard(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    await logToGcp('info', 'action:createBoard invoked')
     const name = data.get('name') as string
     if (!name) return getFormFeedbackForError('board/name-missing')
 

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -26,7 +26,7 @@ export async function createBoard(
 
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
-    await logToGcp('info', 'action:createBoard invoked', { uid: user.uid })
+    logToGcp('info', 'action:createBoard invoked')
 
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 
@@ -55,9 +55,9 @@ export async function createBoard(
                     admin.firestore.FieldValue.arrayUnion(createdBoard.id),
             })
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to create board for user ${user.uid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to create board: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -19,7 +19,6 @@ export async function createBoard(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
-    await logToGcp('info', 'action:createBoard invoked')
     const name = data.get('name') as string
     if (!name) return getFormFeedbackForError('board/name-missing')
 
@@ -27,6 +26,7 @@ export async function createBoard(
 
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
+    await logToGcp('info', 'action:createBoard invoked', { uid: user.uid })
 
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 

--- a/tavla/app/(innlogget)/components/CreateFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateFolder/actions.ts
@@ -20,6 +20,7 @@ export async function createFolder(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    await logToGcp('info', 'action:createFolder invoked')
     const name = data.get('name')?.toString() ?? ''
 
     if (!name || /^\s*$/.test(name))

--- a/tavla/app/(innlogget)/components/CreateFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateFolder/actions.ts
@@ -28,7 +28,7 @@ export async function createFolder(
     const user = await getUserFromSessionCookie()
 
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
-    await logToGcp('info', 'action:createFolder invoked', { uid: user.uid })
+    logToGcp('info', 'action:createFolder invoked')
 
     let folder: FirebaseFirestore.DocumentReference | undefined
 
@@ -40,7 +40,7 @@ export async function createFolder(
         })
         if (!folder || !folder.id) return getFormFeedbackForError()
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to create folder: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/(innlogget)/components/CreateFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateFolder/actions.ts
@@ -20,7 +20,6 @@ export async function createFolder(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
-    await logToGcp('info', 'action:createFolder invoked')
     const name = data.get('name')?.toString() ?? ''
 
     if (!name || /^\s*$/.test(name))
@@ -29,6 +28,7 @@ export async function createFolder(
     const user = await getUserFromSessionCookie()
 
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
+    await logToGcp('info', 'action:createFolder invoked', { uid: user.uid })
 
     let folder: FirebaseFirestore.DocumentReference | undefined
 

--- a/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
@@ -16,11 +16,11 @@ import { logToGcp } from 'src/utils/logging'
 import { logout } from '../Login/actions'
 
 export async function deleteAccount(data: FormData) {
-    await logToGcp('info', 'action:deleteAccount invoked')
     const user = await getUserFromSessionCookie()
     if (!user || !user.uid) {
         return getFormFeedbackForError('auth/operation-not-allowed')
     }
+    await logToGcp('info', 'action:deleteAccount invoked', { uid: user.uid })
 
     const userObject = await auth().getUser(user.uid)
     const confirmEmail = data.get('confirmEmail') as string

--- a/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
@@ -16,6 +16,7 @@ import { logToGcp } from 'src/utils/logging'
 import { logout } from '../Login/actions'
 
 export async function deleteAccount(data: FormData) {
+    await logToGcp('info', 'action:deleteAccount invoked')
     const user = await getUserFromSessionCookie()
     if (!user || !user.uid) {
         return getFormFeedbackForError('auth/operation-not-allowed')

--- a/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
@@ -20,7 +20,7 @@ export async function deleteAccount(data: FormData) {
     if (!user || !user.uid) {
         return getFormFeedbackForError('auth/operation-not-allowed')
     }
-    await logToGcp('info', 'action:deleteAccount invoked', { uid: user.uid })
+    logToGcp('info', 'action:deleteAccount invoked')
 
     const userObject = await auth().getUser(user.uid)
     const confirmEmail = data.get('confirmEmail') as string
@@ -35,9 +35,9 @@ export async function deleteAccount(data: FormData) {
         await deleteUserFromFirestore()
         await deleteUserFromFirebaseAuth()
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to delete account for user ${user.uid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to delete account for user: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/components/DeleteFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteFolder/actions.ts
@@ -19,9 +19,7 @@ export async function deleteFolderAction(
     const user = await getUserFromSessionCookie()
 
     if (!user) redirect('/')
-    await logToGcp('info', 'action:deleteFolderAction invoked', {
-        uid: user.uid,
-    })
+    logToGcp('info', 'action:deleteFolderAction invoked')
 
     const folderid = data.get('folderid') as FolderDB['id']
     if (!folderid) return getFormFeedbackForError('general')
@@ -36,10 +34,10 @@ export async function deleteFolderAction(
         await deleteFolder(folderid)
         revalidatePath('/')
     } catch (e) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to delete folder: ${e instanceof Error ? e.message : String(e)}`,
-            { uid: user.uid, folderId: folderid },
+            { folderId: folderid },
         )
         return handleError(e)
     }

--- a/tavla/app/(innlogget)/components/DeleteFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteFolder/actions.ts
@@ -16,6 +16,7 @@ export async function deleteFolderAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    await logToGcp('info', 'action:deleteFolderAction invoked')
     const user = await getUserFromSessionCookie()
 
     if (!user) redirect('/')

--- a/tavla/app/(innlogget)/components/DeleteFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteFolder/actions.ts
@@ -16,10 +16,12 @@ export async function deleteFolderAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
-    await logToGcp('info', 'action:deleteFolderAction invoked')
     const user = await getUserFromSessionCookie()
 
     if (!user) redirect('/')
+    await logToGcp('info', 'action:deleteFolderAction invoked', {
+        uid: user.uid,
+    })
 
     const folderid = data.get('folderid') as FolderDB['id']
     if (!folderid) return getFormFeedbackForError('general')
@@ -36,7 +38,8 @@ export async function deleteFolderAction(
     } catch (e) {
         await logToGcp(
             'error',
-            `Failed to delete folder ${folderid}: ${e instanceof Error ? e.message : String(e)}`,
+            `Failed to delete folder: ${e instanceof Error ? e.message : String(e)}`,
+            { uid: user.uid, folderId: folderid },
         )
         return handleError(e)
     }

--- a/tavla/app/(innlogget)/components/Login/actions.ts
+++ b/tavla/app/(innlogget)/components/Login/actions.ts
@@ -43,7 +43,7 @@ export async function login(token: string) {
 }
 
 export async function create(uid: UserDB['uid']) {
-    await logToGcp('info', 'action:createUser invoked')
+    await logToGcp('info', 'action:createUser invoked', { uid })
     try {
         await firestore().collection('users').doc(uid).create({})
     } catch (error) {

--- a/tavla/app/(innlogget)/components/Login/actions.ts
+++ b/tavla/app/(innlogget)/components/Login/actions.ts
@@ -14,7 +14,7 @@ import { logToGcp } from 'src/utils/logging'
 initializeAdminApp()
 
 export async function logout() {
-    await logToGcp('info', 'action:logout invoked')
+    logToGcp('info', 'action:logout invoked')
     revokeUserTokenOnLogout()
     ;(await cookies()).delete('session')
     revalidatePath('/')
@@ -22,7 +22,7 @@ export async function logout() {
 }
 
 export async function login(token: string) {
-    await logToGcp('info', 'action:login invoked')
+    logToGcp('info', 'action:login invoked')
     const expiresIn = 60 * 60 * 24 * 10 // Ten days in seconds
     const sessionCookie = await admin.auth().createSessionCookie(token, {
         expiresIn: expiresIn * 1000, // Firebase expects the number in milliseconds
@@ -43,14 +43,13 @@ export async function login(token: string) {
 }
 
 export async function create(uid: UserDB['uid']) {
-    await logToGcp('info', 'action:createUser invoked', { uid })
+    logToGcp('info', 'action:createUser invoked')
     try {
         await firestore().collection('users').doc(uid).create({})
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to create user: ${error instanceof Error ? error.message : String(error)}`,
-            { uid },
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/components/Login/actions.ts
+++ b/tavla/app/(innlogget)/components/Login/actions.ts
@@ -14,6 +14,7 @@ import { logToGcp } from 'src/utils/logging'
 initializeAdminApp()
 
 export async function logout() {
+    await logToGcp('info', 'action:logout invoked')
     revokeUserTokenOnLogout()
     ;(await cookies()).delete('session')
     revalidatePath('/')
@@ -21,6 +22,7 @@ export async function logout() {
 }
 
 export async function login(token: string) {
+    await logToGcp('info', 'action:login invoked')
     const expiresIn = 60 * 60 * 24 * 10 // Ten days in seconds
     const sessionCookie = await admin.auth().createSessionCookie(token, {
         expiresIn: expiresIn * 1000, // Firebase expects the number in milliseconds
@@ -41,6 +43,7 @@ export async function login(token: string) {
 }
 
 export async function create(uid: UserDB['uid']) {
+    await logToGcp('info', 'action:createUser invoked')
     try {
         await firestore().collection('users').doc(uid).create({})
     } catch (error) {

--- a/tavla/app/(innlogget)/components/Login/actions.ts
+++ b/tavla/app/(innlogget)/components/Login/actions.ts
@@ -49,7 +49,8 @@ export async function create(uid: UserDB['uid']) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to create user ${uid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to create user: ${error instanceof Error ? error.message : String(error)}`,
+            { uid },
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
@@ -19,6 +19,7 @@ export async function removeUserAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    await logToGcp('info', 'action:removeUserAction invoked')
     const folderId = data.get('folderid')?.toString() ?? ''
     const uid = data.get('uid')?.toString() ?? ''
 
@@ -48,6 +49,7 @@ export async function inviteUserAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    await logToGcp('info', 'action:inviteUserAction invoked')
     const folderid = data.get('folderid')?.toString() ?? ''
 
     const email = data.get('email')?.toString()

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
@@ -14,15 +14,16 @@ import admin, { auth, firestore } from 'firebase-admin'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { logToGcp } from 'src/utils/logging'
+import { getUserFromSessionCookie } from '../../../utils/server'
 
 export async function removeUserAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
-    await logToGcp('info', 'action:removeUserAction invoked')
     const folderId = data.get('folderid')?.toString() ?? ''
     const uid = data.get('uid')?.toString() ?? ''
 
+    await logToGcp('info', 'action:removeUserAction invoked', { uid, folderId })
     const access = await userCanEditFolder(folderId)
     if (!access) return redirect('/')
 
@@ -32,7 +33,8 @@ export async function removeUserAction(
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to remove user ${uid} from folder ${folderId}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to remove user from folder: ${error instanceof Error ? error.message : String(error)}`,
+            { uid, folderId },
         )
         Sentry.captureException(error, {
             extra: {
@@ -49,8 +51,10 @@ export async function inviteUserAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
-    await logToGcp('info', 'action:inviteUserAction invoked')
     const folderid = data.get('folderid')?.toString() ?? ''
+    await logToGcp('info', 'action:inviteUserAction invoked', {
+        folderId: folderid,
+    })
 
     const email = data.get('email')?.toString()
     if (!email) return getFormFeedbackForError('auth/invalid-email')
@@ -80,9 +84,15 @@ export async function inviteUserAction(
             })
         revalidatePath('/')
     } catch (error) {
+        const user = await getUserFromSessionCookie()
+
         await logToGcp(
             'error',
-            `Failed to invite user ${invitee.uid} to folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to invite user ${invitee.uid} to folder: ${error instanceof Error ? error.message : String(error)}`,
+            {
+                uid: user?.uid ?? 'invalid user / unauthorized',
+                folderId: folder.id,
+            },
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
@@ -23,7 +23,7 @@ export async function removeUserAction(
     const folderId = data.get('folderid')?.toString() ?? ''
     const uid = data.get('uid')?.toString() ?? ''
 
-    await logToGcp('info', 'action:removeUserAction invoked', { uid, folderId })
+    logToGcp('info', 'action:removeUserAction invoked', { folderId })
     const access = await userCanEditFolder(folderId)
     if (!access) return redirect('/')
 
@@ -31,10 +31,10 @@ export async function removeUserAction(
         await removeUserFromFolder(folderId, uid)
         revalidatePath('/')
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to remove user from folder: ${error instanceof Error ? error.message : String(error)}`,
-            { uid, folderId },
+            { folderId },
         )
         Sentry.captureException(error, {
             extra: {
@@ -52,7 +52,7 @@ export async function inviteUserAction(
     data: FormData,
 ) {
     const folderid = data.get('folderid')?.toString() ?? ''
-    await logToGcp('info', 'action:inviteUserAction invoked', {
+    logToGcp('info', 'action:inviteUserAction invoked', {
         folderId: folderid,
     })
 
@@ -86,11 +86,10 @@ export async function inviteUserAction(
     } catch (error) {
         const user = await getUserFromSessionCookie()
 
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to invite user ${invitee.uid} to folder: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to invite user to folder: ${error instanceof Error ? error.message : String(error)}`,
             {
-                uid: user?.uid ?? 'invalid user / unauthorized',
                 folderId: folder.id,
             },
         )

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
@@ -21,10 +21,10 @@ export async function remove(
     folderid?: FolderDB['id'],
     logo?: FolderDB['logo'],
 ) {
-    await logToGcp('info', 'action:removeLogo invoked')
     if (!folderid || !logo)
         return getFormFeedbackForError('auth/operation-not-allowed')
 
+    await logToGcp('info', 'action:removeLogo invoked', { folderId: folderid })
     const file = getFilename(logo)
 
     if (!file) return getFormFeedbackForError()

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
@@ -21,6 +21,7 @@ export async function remove(
     folderid?: FolderDB['id'],
     logo?: FolderDB['logo'],
 ) {
+    await logToGcp('info', 'action:removeLogo invoked')
     if (!folderid || !logo)
         return getFormFeedbackForError('auth/operation-not-allowed')
 

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
@@ -24,7 +24,7 @@ export async function remove(
     if (!folderid || !logo)
         return getFormFeedbackForError('auth/operation-not-allowed')
 
-    await logToGcp('info', 'action:removeLogo invoked', { folderId: folderid })
+    logToGcp('info', 'action:removeLogo invoked', { folderId: folderid })
     const file = getFilename(logo)
 
     if (!file) return getFormFeedbackForError()
@@ -44,7 +44,7 @@ export async function remove(
 
         revalidatePath('/')
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to remove logo from folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -11,6 +11,7 @@ initializeAdminApp()
 export async function saveBoardToFirebaseForUser(
     board: BoardDB,
 ): Promise<string> {
+    await logToGcp('info', 'action:saveBoardToFirebaseForUser invoked')
     const user = await getUserFromSessionCookie()
     if (!user) {
         throw new Error('Not authenticated')

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -15,9 +15,7 @@ export async function saveBoardToFirebaseForUser(
     if (!user) {
         throw new Error('Not authenticated')
     }
-    await logToGcp('info', 'action:saveBoardToFirebaseForUser invoked', {
-        uid: user.uid,
-    })
+    logToGcp('info', 'action:saveBoardToFirebaseForUser invoked')
 
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
     const now = Date.now()
@@ -43,9 +41,9 @@ export async function saveBoardToFirebaseForUser(
 
         return doc.id
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to save board from localStorage for user ${user.uid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save board from localStorage: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -11,11 +11,13 @@ initializeAdminApp()
 export async function saveBoardToFirebaseForUser(
     board: BoardDB,
 ): Promise<string> {
-    await logToGcp('info', 'action:saveBoardToFirebaseForUser invoked')
     const user = await getUserFromSessionCookie()
     if (!user) {
         throw new Error('Not authenticated')
     }
+    await logToGcp('info', 'action:saveBoardToFirebaseForUser invoked', {
+        uid: user.uid,
+    })
 
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
     const now = Date.now()

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -27,7 +27,8 @@ export async function deleteBoardAction(
     } catch (e) {
         await logToGcp(
             'error',
-            `Failed to delete board ${bid}: ${e instanceof Error ? e.message : String(e)}`,
+            `Failed to delete board: ${e instanceof Error ? e.message : String(e)}`,
+            { bid },
         )
         return handleError(e)
     }

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -17,6 +17,7 @@ export async function deleteBoardAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
+    await logToGcp('info', 'action:deleteBoardAction invoked')
     const bid = data.get('bid') as BoardDB['id']
     const folder = await getFolderForBoard(bid)
 
@@ -54,6 +55,7 @@ export async function countAllBoards(folders: FolderDB[], boards: BoardDB[]) {
 }
 
 export async function moveBoardAction(data: FormData) {
+    await logToGcp('info', 'action:moveBoardAction invoked')
     const bid = data.get('bid') as BoardDB['id']
     const newFolderID = data.get('newOid') as FolderDB['id'] | undefined
     const oldFolder = await getFolderForBoard(bid)

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -17,8 +17,8 @@ export async function deleteBoardAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
-    await logToGcp('info', 'action:deleteBoardAction invoked')
     const bid = data.get('bid') as BoardDB['id']
+    await logToGcp('info', 'action:deleteBoardAction invoked', { bid })
     const folder = await getFolderForBoard(bid)
 
     try {
@@ -55,8 +55,8 @@ export async function countAllBoards(folders: FolderDB[], boards: BoardDB[]) {
 }
 
 export async function moveBoardAction(data: FormData) {
-    await logToGcp('info', 'action:moveBoardAction invoked')
     const bid = data.get('bid') as BoardDB['id']
+    await logToGcp('info', 'action:moveBoardAction invoked', { bid })
     const newFolderID = data.get('newOid') as FolderDB['id'] | undefined
     const oldFolder = await getFolderForBoard(bid)
     try {

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -18,14 +18,14 @@ export async function deleteBoardAction(
     data: FormData,
 ) {
     const bid = data.get('bid') as BoardDB['id']
-    await logToGcp('info', 'action:deleteBoardAction invoked', { bid })
+    logToGcp('info', 'action:deleteBoardAction invoked', { bid })
     const folder = await getFolderForBoard(bid)
 
     try {
         await deleteBoard(bid)
         revalidatePath('/')
     } catch (e) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to delete board: ${e instanceof Error ? e.message : String(e)}`,
             { bid },
@@ -57,14 +57,14 @@ export async function countAllBoards(folders: FolderDB[], boards: BoardDB[]) {
 
 export async function moveBoardAction(data: FormData) {
     const bid = data.get('bid') as BoardDB['id']
-    await logToGcp('info', 'action:moveBoardAction invoked', { bid })
+    logToGcp('info', 'action:moveBoardAction invoked', { bid })
     const newFolderID = data.get('newOid') as FolderDB['id'] | undefined
     const oldFolder = await getFolderForBoard(bid)
     try {
         await moveBoard(bid, newFolderID, oldFolder?.id)
         revalidatePath('/')
     } catch (e) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to move board ${bid}: ${e instanceof Error ? e.message : String(e)}`,
         )

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -24,6 +24,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
+    await logToGcp('info', 'action:addTiles invoked')
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -63,6 +64,7 @@ export async function getWalkingDistanceTile(
     tile: BoardTileDB,
     location: LocationDB,
 ): Promise<BoardTileDB> {
+    await logToGcp('info', 'action:getWalkingDistanceTile invoked')
     const fromCoordinates = await getStopPlaceCoordinates(tile.stopPlaceId)
     const toCoordinates = location.coordinate
 
@@ -88,6 +90,7 @@ export async function saveUpdatedTileOrder(
     bid: BoardDB['id'],
     tiles: BoardTileDB[],
 ) {
+    await logToGcp('info', 'action:saveUpdatedTileOrder invoked')
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -117,6 +120,7 @@ export async function saveCustomUrl(
     bid: BoardDB['id'],
     customUrl: string,
 ): Promise<{ error?: string }> {
+    await logToGcp('info', 'action:saveCustomUrl invoked')
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -24,7 +24,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
-    await logToGcp('info', 'action:addTiles invoked', { bid })
+    logToGcp('info', 'action:addTiles invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -49,7 +49,7 @@ export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
 
         await db.collection('boards').doc(bid).update(updateData)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save tile to board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -64,7 +64,7 @@ export async function getWalkingDistanceTile(
     tile: BoardTileDB,
     location: LocationDB,
 ): Promise<BoardTileDB> {
-    await logToGcp('info', 'action:getWalkingDistanceTile invoked')
+    logToGcp('info', 'action:getWalkingDistanceTile invoked')
     const fromCoordinates = await getStopPlaceCoordinates(tile.stopPlaceId)
     const toCoordinates = location.coordinate
 
@@ -90,7 +90,7 @@ export async function saveUpdatedTileOrder(
     bid: BoardDB['id'],
     tiles: BoardTileDB[],
 ) {
-    await logToGcp('info', 'action:saveUpdatedTileOrder invoked', { bid })
+    logToGcp('info', 'action:saveUpdatedTileOrder invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -101,7 +101,7 @@ export async function saveUpdatedTileOrder(
         })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save tile order for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -120,7 +120,7 @@ export async function saveCustomUrl(
     bid: BoardDB['id'],
     customUrl: string,
 ): Promise<{ error?: string }> {
-    await logToGcp('info', 'action:saveCustomUrl invoked', { bid })
+    logToGcp('info', 'action:saveCustomUrl invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -162,7 +162,7 @@ export async function saveCustomUrl(
         revalidatePath(`/tavler/${bid}/rediger`)
         return {}
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save custom URL for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -24,7 +24,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
-    await logToGcp('info', 'action:addTiles invoked')
+    await logToGcp('info', 'action:addTiles invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -90,7 +90,7 @@ export async function saveUpdatedTileOrder(
     bid: BoardDB['id'],
     tiles: BoardTileDB[],
 ) {
-    await logToGcp('info', 'action:saveUpdatedTileOrder invoked')
+    await logToGcp('info', 'action:saveUpdatedTileOrder invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -120,7 +120,7 @@ export async function saveCustomUrl(
     bid: BoardDB['id'],
     customUrl: string,
 ): Promise<{ error?: string }> {
-    await logToGcp('info', 'action:saveCustomUrl invoked')
+    await logToGcp('info', 'action:saveCustomUrl invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -15,9 +15,9 @@ export async function duplicateBoard(
     board: Omit<BoardDB, 'id'>,
     folderid?: FolderDB['id'],
 ) {
-    await logToGcp('info', 'action:duplicateBoard invoked')
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
+    await logToGcp('info', 'action:duplicateBoard invoked', { uid: user.uid })
 
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -15,6 +15,7 @@ export async function duplicateBoard(
     board: Omit<BoardDB, 'id'>,
     folderid?: FolderDB['id'],
 ) {
+    await logToGcp('info', 'action:duplicateBoard invoked')
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -17,8 +17,7 @@ export async function duplicateBoard(
 ) {
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
-    await logToGcp('info', 'action:duplicateBoard invoked', {
-        uid: user.uid,
+    logToGcp('info', 'action:duplicateBoard invoked', {
         folderId: folderid,
     })
 
@@ -48,7 +47,7 @@ export async function duplicateBoard(
                     admin.firestore.FieldValue.arrayUnion(createdBoard.id),
             })
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to duplicate board: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -17,7 +17,10 @@ export async function duplicateBoard(
 ) {
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
-    await logToGcp('info', 'action:duplicateBoard invoked', { uid: user.uid })
+    await logToGcp('info', 'action:duplicateBoard invoked', {
+        uid: user.uid,
+        folderId: folderid,
+    })
 
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
@@ -7,7 +7,7 @@ import { logToGcp } from 'src/utils/logging'
 import { getBackendUrl } from 'utils/backendUrl'
 
 export async function refreshBoard(board: BoardDB) {
-    await logToGcp('info', 'action:refreshBoard invoked')
+    await logToGcp('info', 'action:refreshBoard invoked', { bid: board.id })
     const access = await userCanEditBoard(board.id)
     if (!access) return redirect('/')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
@@ -20,7 +20,8 @@ export async function refreshBoard(board: BoardDB) {
                 Authorization: `Bearer ${process.env.BACKEND_API_KEY}`,
                 'Content-Type': 'application/json',
             },
-    })
+        },
+    )
     logToGcp(
         res.ok ? 'info' : 'warning',
         `POST /refresh/${board.id}: status=${res.status}`,

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
@@ -7,7 +7,7 @@ import { logToGcp } from 'src/utils/logging'
 import { getBackendUrl } from 'utils/backendUrl'
 
 export async function refreshBoard(board: BoardDB) {
-    await logToGcp('info', 'action:refreshBoard invoked', { bid: board.id })
+    logToGcp('info', 'action:refreshBoard invoked', { bid: board.id })
     const access = await userCanEditBoard(board.id)
     if (!access) return redirect('/')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
@@ -7,6 +7,7 @@ import { logToGcp } from 'src/utils/logging'
 import { getBackendUrl } from 'utils/backendUrl'
 
 export async function refreshBoard(board: BoardDB) {
+    await logToGcp('info', 'action:refreshBoard invoked')
     const access = await userCanEditBoard(board.id)
     if (!access) return redirect('/')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/actions.ts
@@ -3,6 +3,7 @@
 import { userCanEditBoard } from 'app/(innlogget)/utils/firebase'
 import { redirect } from 'next/navigation'
 import type { BoardDB } from 'src/types/db-types/boards'
+import { logToGcp } from 'src/utils/logging'
 import { getBackendUrl } from 'utils/backendUrl'
 
 export async function refreshBoard(board: BoardDB) {
@@ -18,7 +19,10 @@ export async function refreshBoard(board: BoardDB) {
                 Authorization: `Bearer ${process.env.BACKEND_API_KEY}`,
                 'Content-Type': 'application/json',
             },
-        },
+    })
+    logToGcp(
+        res.ok ? 'info' : 'warning',
+        `POST /refresh/${board.id}: status=${res.status}`,
     )
     return res.ok
 }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -43,9 +43,9 @@ async function userHasAccessToEditBoard(bid: string) {
 }
 
 export async function saveSettings(data: FormData) {
-    await logToGcp('info', 'action:saveSettings invoked')
     const title = data.get('title') as string
     const bid = data.get('bid') as BoardDB['id']
+    await logToGcp('info', 'action:saveSettings invoked', { bid })
     const viewType = data.get('viewType') as string
     const theme = data.get('theme') as BoardTheme
     const font = data.get('font') as BoardFontSize
@@ -284,7 +284,7 @@ export async function moveBoard(
     toFolder?: FolderDB['id'],
     fromFolder?: FolderDB['id'],
 ) {
-    await logToGcp('info', 'action:moveBoard invoked')
+    await logToGcp('info', 'action:moveBoard invoked', { bid })
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -60,7 +60,7 @@ export async function saveSettings(data: FormData) {
         'newLocation',
     ) as string
 
-    await logToGcp('info', 'action:saveSettings invoked', { bid })
+    logToGcp('info', 'action:saveSettings invoked', { bid })
 
     if (location) {
         location = JSON.parse(location) as LocationDB
@@ -106,7 +106,7 @@ export async function saveSettings(data: FormData) {
             redirect('/')
         }
 
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save settings for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -130,7 +130,7 @@ async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
         })
         revalidatePath(`tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to set footer for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },
@@ -157,7 +157,7 @@ async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
 
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to set theme for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },
@@ -187,7 +187,7 @@ async function setViewType(board: BoardDB, viewType: string) {
 
         revalidatePath(`/tavler/${board.id}/rediger`)
     } catch (e) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to set view type for board: ${e instanceof Error ? e.message : String(e)}`,
             { bid: board.id },
@@ -207,7 +207,7 @@ async function saveTitle(bid: BoardDB['id'], title: string) {
             })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save title for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },
@@ -230,7 +230,7 @@ async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
             .update({ 'meta.fontSize': font, 'meta.dateModified': Date.now() })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save font for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },
@@ -257,7 +257,7 @@ async function saveLocation(board: BoardDB, location?: LocationDB) {
             })
         revalidatePath(`/tavler/${board.id}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save location for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid: board.id },
@@ -294,7 +294,7 @@ export async function moveBoard(
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 
-    await logToGcp('info', 'action:moveBoard invoked', { uid: user.uid, bid })
+    logToGcp('info', 'action:moveBoard invoked', { bid })
 
     if (fromFolder) {
         const canEdit = await userCanEditFolder(fromFolder)
@@ -329,10 +329,10 @@ export async function moveBoard(
                 .doc(user.uid)
                 .update({ owner: FieldValue.arrayUnion(bid) })
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to move board: ${error instanceof Error ? error.message : String(error)}`,
-            { uid: user.uid, bid },
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -361,7 +361,7 @@ async function setTransportPalette(
 
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to set transport palette for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },
@@ -391,7 +391,7 @@ async function setElements(
 
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to set elements for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -45,7 +45,6 @@ async function userHasAccessToEditBoard(bid: string) {
 export async function saveSettings(data: FormData) {
     const title = data.get('title') as string
     const bid = data.get('bid') as BoardDB['id']
-    await logToGcp('info', 'action:saveSettings invoked', { bid })
     const viewType = data.get('viewType') as string
     const theme = data.get('theme') as BoardTheme
     const font = data.get('font') as BoardFontSize
@@ -60,6 +59,8 @@ export async function saveSettings(data: FormData) {
     let location: LocationDB | undefined | string = data.get(
         'newLocation',
     ) as string
+
+    await logToGcp('info', 'action:saveSettings invoked', { bid })
 
     if (location) {
         location = JSON.parse(location) as LocationDB
@@ -131,7 +132,8 @@ async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to set footer for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to set footer for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -157,7 +159,8 @@ async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to set theme for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to set theme for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -186,7 +189,8 @@ async function setViewType(board: BoardDB, viewType: string) {
     } catch (e) {
         await logToGcp(
             'error',
-            `Failed to set view type for board ${board.id}: ${e instanceof Error ? e.message : String(e)}`,
+            `Failed to set view type for board: ${e instanceof Error ? e.message : String(e)}`,
+            { bid: board.id },
         )
         handleError(e)
     }
@@ -205,7 +209,8 @@ async function saveTitle(bid: BoardDB['id'], title: string) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to save title for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save title for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -227,7 +232,8 @@ async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to save font for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save font for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -253,7 +259,8 @@ async function saveLocation(board: BoardDB, location?: LocationDB) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to save location for board ${board.id}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save location for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid: board.id },
         )
         Sentry.captureException(error, {
             extra: {
@@ -284,9 +291,10 @@ export async function moveBoard(
     toFolder?: FolderDB['id'],
     fromFolder?: FolderDB['id'],
 ) {
-    await logToGcp('info', 'action:moveBoard invoked', { bid })
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
+
+    await logToGcp('info', 'action:moveBoard invoked', { uid: user.uid, bid })
 
     if (fromFolder) {
         const canEdit = await userCanEditFolder(fromFolder)
@@ -323,7 +331,8 @@ export async function moveBoard(
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to move board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to move board: ${error instanceof Error ? error.message : String(error)}`,
+            { uid: user.uid, bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -354,7 +363,8 @@ async function setTransportPalette(
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to set transport palette for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to set transport palette for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -383,7 +393,8 @@ async function setElements(
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to set elements for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to set elements for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -43,6 +43,7 @@ async function userHasAccessToEditBoard(bid: string) {
 }
 
 export async function saveSettings(data: FormData) {
+    await logToGcp('info', 'action:saveSettings invoked')
     const title = data.get('title') as string
     const bid = data.get('bid') as BoardDB['id']
     const viewType = data.get('viewType') as string
@@ -283,6 +284,7 @@ export async function moveBoard(
     toFolder?: FolderDB['id'],
     fromFolder?: FolderDB['id'],
 ) {
+    await logToGcp('info', 'action:moveBoard invoked')
     const user = await getUserFromSessionCookie()
     if (!user) return redirect('/')
 

--- a/tavla/app/(innlogget)/utils/firebase.ts
+++ b/tavla/app/(innlogget)/utils/firebase.ts
@@ -110,7 +110,7 @@ export async function deleteBoard(bid: BoardDB['id']) {
                 })
         }
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to delete board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -154,7 +154,7 @@ export async function deleteFolderBoard(
     try {
         return firestore().collection('boards').doc(bid).delete()
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to delete board ${bid} in folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -174,9 +174,9 @@ export async function removeUserFromFolder(folderid: string, uid: string) {
                 owners: admin.firestore.FieldValue.arrayRemove(uid),
             })
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to remove user ${uid} from folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to remove user from folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureMessage(
             'Error while removing user ' + uid + ' from folder ' + folderid,
@@ -193,9 +193,9 @@ export async function deleteUserFromFirebaseAuth() {
     try {
         await auth().deleteUser(user.uid)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to delete user ${user?.uid} from Firebase Auth: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to delete user from Firebase Auth: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureMessage(
             'Error while deleting user ' + user?.uid + ' from firebase auth',
@@ -212,9 +212,9 @@ export async function deleteUserFromFirestore() {
     try {
         await firestore().collection('users').doc(user.uid).delete()
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
-            `Failed to delete user ${user?.uid} from Firestore: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to delete user from Firestore: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureMessage(
             'Error while deleting user ' + user?.uid + ' from firestore',

--- a/tavla/app/_components/TileCard/actions.ts
+++ b/tavla/app/_components/TileCard/actions.ts
@@ -17,7 +17,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function deleteTile(boardId: string, tile: BoardTileDB) {
-    await logToGcp('info', 'action:deleteTile invoked')
+    await logToGcp('info', 'action:deleteTile invoked', { bid: boardId })
     const access = await userCanEditBoard(boardId)
     if (!access) return redirect('/')
 
@@ -74,7 +74,7 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
 }
 
 export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
-    await logToGcp('info', 'action:saveTile invoked')
+    await logToGcp('info', 'action:saveTile invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 

--- a/tavla/app/_components/TileCard/actions.ts
+++ b/tavla/app/_components/TileCard/actions.ts
@@ -61,7 +61,8 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to delete tile from board ${boardId}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to delete tile from board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid: boardId },
         )
         Sentry.captureException(error, {
             extra: {
@@ -105,7 +106,8 @@ export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
     } catch (error) {
         await logToGcp(
             'error',
-            `Failed to save tile for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save tile for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/_components/TileCard/actions.ts
+++ b/tavla/app/_components/TileCard/actions.ts
@@ -17,7 +17,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function deleteTile(boardId: string, tile: BoardTileDB) {
-    await logToGcp('info', 'action:deleteTile invoked', { bid: boardId })
+    logToGcp('info', 'action:deleteTile invoked', { bid: boardId })
     const access = await userCanEditBoard(boardId)
     if (!access) return redirect('/')
 
@@ -59,7 +59,7 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
         await db.collection('boards').doc(boardId).update(updatePayload)
         revalidatePath(`/tavler/${boardId}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to delete tile from board: ${error instanceof Error ? error.message : String(error)}`,
             { bid: boardId },
@@ -75,7 +75,7 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
 }
 
 export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
-    await logToGcp('info', 'action:saveTile invoked', { bid })
+    logToGcp('info', 'action:saveTile invoked', { bid })
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
@@ -104,7 +104,7 @@ export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
 
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to save tile for board: ${error instanceof Error ? error.message : String(error)}`,
             { bid },

--- a/tavla/app/_components/TileCard/actions.ts
+++ b/tavla/app/_components/TileCard/actions.ts
@@ -17,6 +17,7 @@ initializeAdminApp()
 const db = getFirestore()
 
 export async function deleteTile(boardId: string, tile: BoardTileDB) {
+    await logToGcp('info', 'action:deleteTile invoked')
     const access = await userCanEditBoard(boardId)
     if (!access) return redirect('/')
 
@@ -73,6 +74,7 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
 }
 
 export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
+    await logToGcp('info', 'action:saveTile invoked')
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 

--- a/tavla/app/_components/TileSelector/utils.ts
+++ b/tavla/app/_components/TileSelector/utils.ts
@@ -69,7 +69,7 @@ export async function getWalkingDistance(
         })
         return response.trip.tripPatterns[0]?.duration ?? undefined
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to get walking distance from ${JSON.stringify(from)} to ${JSON.stringify(to)}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -95,7 +95,7 @@ export async function getStopPlaceCoordinates(
             lng: response.stopPlace?.longitude ?? 0,
         }
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to get stop place coordinates for ${stopPlaceId}: ${error instanceof Error ? error.message : String(error)}`,
         )
@@ -116,7 +116,7 @@ export async function getQuayCoordinates(quayId?: string): Promise<Coordinate> {
             lng: response.quay?.longitude ?? 0,
         }
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to get quay coordinates for ${quayId}: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/_components/actions.ts
+++ b/tavla/app/_components/actions.ts
@@ -11,7 +11,7 @@ import { validEmail } from 'src/utils/email'
 import { logToGcp } from 'src/utils/logging'
 
 async function postForm(_prevState: TFormFeedback | undefined, data: FormData) {
-    await logToGcp('info', 'action:postForm invoked')
+    logToGcp('info', 'action:postForm invoked')
     const email = data.get('email') as string
     const message = data.get('message') as string
     const disabledEmail = data.get('disabledEmail') as string
@@ -102,7 +102,7 @@ async function postForm(_prevState: TFormFeedback | undefined, data: FormData) {
     try {
         const url = process.env.SLACK_WEBHOOK_URL
         if (!url) throw Error('Could not find url')
-        await logToGcp('info', 'Outgoing: POST Slack webhook (contact form)')
+        logToGcp('info', 'Outgoing: POST Slack webhook (contact form)')
         const response = await fetch(url, {
             method: 'POST',
             headers: {
@@ -110,7 +110,7 @@ async function postForm(_prevState: TFormFeedback | undefined, data: FormData) {
             },
             body: JSON.stringify(payload),
         })
-        await logToGcp(
+        logToGcp(
             response.ok ? 'info' : 'error',
             `Outgoing response: Slack webhook status=${response.status}`,
         )
@@ -119,7 +119,7 @@ async function postForm(_prevState: TFormFeedback | undefined, data: FormData) {
             throw Error('Error in request')
         }
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to submit contact form: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/_components/actions.ts
+++ b/tavla/app/_components/actions.ts
@@ -11,6 +11,7 @@ import { validEmail } from 'src/utils/email'
 import { logToGcp } from 'src/utils/logging'
 
 async function postForm(_prevState: TFormFeedback | undefined, data: FormData) {
+    await logToGcp('info', 'action:postForm invoked')
     const email = data.get('email') as string
     const message = data.get('message') as string
     const disabledEmail = data.get('disabledEmail') as string

--- a/tavla/app/api/board/route.ts
+++ b/tavla/app/api/board/route.ts
@@ -106,17 +106,14 @@ export async function GET(request: NextRequest) {
             (await fetchBoardByCustomUrl(boardId))
 
         if (!boardData) {
-            await logToGcp(
-                'warning',
-                `GET /api/board: boardId=${boardId} status=404`,
-            )
+            logToGcp('warning', `GET /api/board: boardId=${boardId} status=404`)
             return createErrorResponse(request, 'Board not found', 404)
         }
 
         const folderLogo = await fetchFolderLogo(boardData.id)
 
         const origin = request.headers.get('origin') ?? 'unknown'
-        await logToGcp(
+        logToGcp(
             'info',
             `GET /api/board: boardId=${boardId} status=200 origin=${origin}`,
         )
@@ -128,7 +125,7 @@ export async function GET(request: NextRequest) {
             { headers: getCorsHeaders(request) },
         )
     } catch (error) {
-        await logToGcp(
+        logToGcp(
             'error',
             `Failed to fetch board ${boardId}: ${error instanceof Error ? error.message : String(error)}`,
         )

--- a/tavla/app/api/board/route.ts
+++ b/tavla/app/api/board/route.ts
@@ -106,11 +106,20 @@ export async function GET(request: NextRequest) {
             (await fetchBoardByCustomUrl(boardId))
 
         if (!boardData) {
+            await logToGcp(
+                'warning',
+                `GET /api/board: boardId=${boardId} status=404`,
+            )
             return createErrorResponse(request, 'Board not found', 404)
         }
 
         const folderLogo = await fetchFolderLogo(boardData.id)
 
+        const origin = request.headers.get('origin') ?? 'unknown'
+        await logToGcp(
+            'info',
+            `GET /api/board: boardId=${boardId} status=200 origin=${origin}`,
+        )
         return NextResponse.json(
             {
                 board: boardData,

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -14,6 +14,7 @@ import { nanoid } from 'nanoid'
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
 import type { FolderDB } from 'src/types/db-types/folders'
+import { logToGcp } from 'src/utils/logging'
 import rateLimit from 'src/utils/rateLimit'
 
 initializeAdminApp()
@@ -29,6 +30,10 @@ export async function POST(request: NextRequest) {
     const response = new Response()
     response.headers.set('Content-Type', 'application/json')
     if (!user || !user.uid) {
+        await logToGcp(
+            'warning',
+            'POST /api/upload: status=401 reason=invalid-token',
+        )
         return new Response(JSON.stringify({ error: 'Invalid token' }), {
             status: 401,
             headers: response.headers,
@@ -39,6 +44,10 @@ export async function POST(request: NextRequest) {
         await rateLimiter.check(response, 5, user.uid)
     } catch {
         response.headers.set('Content-Type', 'application/json')
+        await logToGcp(
+            'warning',
+            `POST /api/upload: status=429 uid=${user.uid}`,
+        )
         return new Response(JSON.stringify({ error: 'Too Many Requests' }), {
             headers: response.headers,
             status: 429,
@@ -49,25 +58,39 @@ export async function POST(request: NextRequest) {
 
     const logo = data.get('logo') as File
 
-    if (!logo || !folderid)
+    if (!logo || !folderid) {
+        await logToGcp(
+            'warning',
+            `POST /api/upload: status=400 uid=${user.uid} reason=missing-values`,
+        )
         return new Response(JSON.stringify({ error: 'Missing values' }), {
             headers: response.headers,
             status: 400,
         })
+    }
 
     try {
         await userCanEditFolder(folderid)
     } catch {
+        await logToGcp(
+            'warning',
+            `POST /api/upload: status=403 uid=${user.uid} folderid=${folderid}`,
+        )
         return new Response(JSON.stringify({ error: 'Unauthorized' }), {
             headers: response.headers,
             status: 403,
         })
     }
-    if (logo.size > 10_000_000)
+    if (logo.size > 10_000_000) {
+        await logToGcp(
+            'warning',
+            `POST /api/upload: status=413 uid=${user.uid} size=${logo.size}`,
+        )
         return new Response(JSON.stringify({ error: 'File size too big' }), {
             headers: response.headers,
             status: 413,
         })
+    }
 
     const allowedFileTypes = [
         'image/apng',
@@ -78,6 +101,10 @@ export async function POST(request: NextRequest) {
         'image/webp',
     ]
     if (!allowedFileTypes.includes(logo.type)) {
+        await logToGcp(
+            'warning',
+            `POST /api/upload: status=415 uid=${user.uid} type=${logo.type}`,
+        )
         return new Response(
             JSON.stringify({ error: 'Unsupported file type' }),
             {
@@ -108,7 +135,11 @@ export async function POST(request: NextRequest) {
 
     const logoUrl = await getDownloadURL(file)
 
-    if (!logoUrl)
+    if (!logoUrl) {
+        await logToGcp(
+            'error',
+            `POST /api/upload: status=500 uid=${user.uid} reason=no-logo-url`,
+        )
         return new Response(
             JSON.stringify({ error: 'Failed to get logo url' }),
             {
@@ -116,11 +147,16 @@ export async function POST(request: NextRequest) {
                 status: 500,
             },
         )
+    }
 
     await db.collection('folders').doc(folderid).update({
         logo: logoUrl,
     })
     revalidatePath(`/mapper/${folderid}`)
+    await logToGcp(
+        'info',
+        `POST /api/upload: status=200 uid=${user.uid} folderid=${folderid}`,
+    )
     return new Response(
         JSON.stringify({ message: 'Logo uploaded successfully' }),
         {

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -30,10 +30,7 @@ export async function POST(request: NextRequest) {
     const response = new Response()
     response.headers.set('Content-Type', 'application/json')
     if (!user || !user.uid) {
-        await logToGcp(
-            'warning',
-            'POST /api/upload: status=401 reason=invalid-token',
-        )
+        logToGcp('warning', 'POST /api/upload: status=401 reason=invalid-token')
         return new Response(JSON.stringify({ error: 'Invalid token' }), {
             status: 401,
             headers: response.headers,
@@ -44,10 +41,7 @@ export async function POST(request: NextRequest) {
         await rateLimiter.check(response, 5, user.uid)
     } catch {
         response.headers.set('Content-Type', 'application/json')
-        await logToGcp(
-            'warning',
-            `POST /api/upload: status=429 uid=${user.uid}`,
-        )
+        logToGcp('warning', `POST /api/upload: status=429`)
         return new Response(JSON.stringify({ error: 'Too Many Requests' }), {
             headers: response.headers,
             status: 429,
@@ -59,9 +53,9 @@ export async function POST(request: NextRequest) {
     const logo = data.get('logo') as File
 
     if (!logo || !folderid) {
-        await logToGcp(
+        logToGcp(
             'warning',
-            `POST /api/upload: status=400 uid=${user.uid} reason=missing-values`,
+            `POST /api/upload: status=400 reason=missing-values`,
         )
         return new Response(JSON.stringify({ error: 'Missing values' }), {
             headers: response.headers,
@@ -72,20 +66,14 @@ export async function POST(request: NextRequest) {
     try {
         await userCanEditFolder(folderid)
     } catch {
-        await logToGcp(
-            'warning',
-            `POST /api/upload: status=403 uid=${user.uid} folderid=${folderid}`,
-        )
+        logToGcp('warning', `POST /api/upload: status=403 folderid=${folderid}`)
         return new Response(JSON.stringify({ error: 'Unauthorized' }), {
             headers: response.headers,
             status: 403,
         })
     }
     if (logo.size > 10_000_000) {
-        await logToGcp(
-            'warning',
-            `POST /api/upload: status=413 uid=${user.uid} size=${logo.size}`,
-        )
+        logToGcp('warning', `POST /api/upload: status=413 size=${logo.size}`)
         return new Response(JSON.stringify({ error: 'File size too big' }), {
             headers: response.headers,
             status: 413,
@@ -101,10 +89,7 @@ export async function POST(request: NextRequest) {
         'image/webp',
     ]
     if (!allowedFileTypes.includes(logo.type)) {
-        await logToGcp(
-            'warning',
-            `POST /api/upload: status=415 uid=${user.uid} type=${logo.type}`,
-        )
+        logToGcp('warning', `POST /api/upload: status=415 type=${logo.type}`)
         return new Response(
             JSON.stringify({ error: 'Unsupported file type' }),
             {
@@ -136,10 +121,7 @@ export async function POST(request: NextRequest) {
     const logoUrl = await getDownloadURL(file)
 
     if (!logoUrl) {
-        await logToGcp(
-            'error',
-            `POST /api/upload: status=500 uid=${user.uid} reason=no-logo-url`,
-        )
+        logToGcp('error', `POST /api/upload: status=500 reason=no-logo-url`)
         return new Response(
             JSON.stringify({ error: 'Failed to get logo url' }),
             {
@@ -153,10 +135,7 @@ export async function POST(request: NextRequest) {
         logo: logoUrl,
     })
     revalidatePath(`/mapper/${folderid}`)
-    await logToGcp(
-        'info',
-        `POST /api/upload: status=200 uid=${user.uid} folderid=${folderid}`,
-    )
+    logToGcp('info', `POST /api/upload: status=200 folderid=${folderid}`)
     return new Response(
         JSON.stringify({ message: 'Logo uploaded successfully' }),
         {

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -12,7 +12,7 @@ import { logToGcp } from 'src/utils/logging'
 initializeAdminApp()
 
 export async function publishBoard(board: BoardDB): Promise<string> {
-    await logToGcp('info', 'action:publishBoard invoked')
+    logToGcp('info', 'action:publishBoard invoked')
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
     const now = Date.now()

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -7,10 +7,12 @@ import type {
     BoardTileDB,
     LocationDB,
 } from 'src/types/db-types/boards'
+import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
 
 export async function publishBoard(board: BoardDB): Promise<string> {
+    await logToGcp('info', 'action:publishBoard invoked')
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
     const now = Date.now()

--- a/tavla/next.config.js
+++ b/tavla/next.config.js
@@ -44,7 +44,7 @@ const cspHeaderTavlevisning = `
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
-    serverExternalPackages: [],
+    serverExternalPackages: ['@google-cloud/logging'],
     transpilePackages: [
         'swr',
         'tailwindcss',

--- a/tavla/proxy.ts
+++ b/tavla/proxy.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export function proxy(request: NextRequest) {
+    return NextResponse.next({
+        request: {
+            headers: new Headers({
+                ...Object.fromEntries(request.headers),
+                'x-pathname': request.nextUrl.pathname,
+            }),
+        },
+    })
+}
+
+export const config = {
+    matcher: ['/((?!api|_next/static|_next/image|favicon|.*\\..*).*)'],
+}

--- a/tavla/src/graphql/utils.ts
+++ b/tavla/src/graphql/utils.ts
@@ -66,7 +66,14 @@ export async function fetcher<Data, Variables>([
         method: 'POST',
     })
 
-    await logToGcp('info', `GraphQL ${endpointName}: status=${response.status}`)
+    await logToGcp(
+        response.status >= 500
+            ? 'error'
+            : response.status >= 400
+              ? 'warning'
+              : 'info',
+        `GraphQL ${endpointName}: status=${response.status}`,
+    )
 
     const res = await response.json()
 

--- a/tavla/src/graphql/utils.ts
+++ b/tavla/src/graphql/utils.ts
@@ -66,7 +66,7 @@ export async function fetcher<Data, Variables>([
         method: 'POST',
     })
 
-    await logToGcp(
+    logToGcp(
         response.status >= 500
             ? 'error'
             : response.status >= 400
@@ -79,10 +79,7 @@ export async function fetcher<Data, Variables>([
 
     if (res.errors && res.errors.length > 0) {
         const errorMessage = res.errors[0]?.message || 'Unknown GraphQL error'
-        await logToGcp(
-            'warning',
-            `GraphQL ${endpointName} error: ${errorMessage}`,
-        )
+        logToGcp('warning', `GraphQL ${endpointName} error: ${errorMessage}`)
         Sentry.captureMessage(`GraphQL error: ${errorMessage}`, {
             level: 'warning',
             extra: {

--- a/tavla/src/graphql/utils.ts
+++ b/tavla/src/graphql/utils.ts
@@ -4,6 +4,7 @@ import {
     GRAPHQL_ENDPOINTS,
     type TEndpointNames,
 } from 'src/assets/env'
+import { logToGcp } from 'src/utils/logging'
 import { addMinutesToDate, formatDateToISO } from 'src/utils/time'
 import type { TypedDocumentString } from './index'
 
@@ -65,10 +66,16 @@ export async function fetcher<Data, Variables>([
         method: 'POST',
     })
 
+    await logToGcp('info', `GraphQL ${endpointName}: status=${response.status}`)
+
     const res = await response.json()
 
     if (res.errors && res.errors.length > 0) {
         const errorMessage = res.errors[0]?.message || 'Unknown GraphQL error'
+        await logToGcp(
+            'warning',
+            `GraphQL ${endpointName} error: ${errorMessage}`,
+        )
         Sentry.captureMessage(`GraphQL error: ${errorMessage}`, {
             level: 'warning',
             extra: {

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -3,9 +3,15 @@ import { Logging } from '@google-cloud/logging'
 
 export type LogLevel = 'debug' | 'info' | 'warning' | 'error'
 
-const logging = new Logging({ projectId: process.env.GOOGLE_PROJECT_ID })
-const log_name = 'tavla_admin'
-const log = logging.log(log_name)
+let _log: ReturnType<InstanceType<typeof Logging>['log']> | null = null
+
+function getLog() {
+    if (_log) return _log
+    const projectId = process.env.GOOGLE_PROJECT_ID
+    if (!projectId) return null
+    _log = new Logging({ projectId }).log('tavla_admin')
+    return _log
+}
 
 function sanitizeForLog(value: unknown): string {
     return (
@@ -22,7 +28,7 @@ export async function logToGcp(level: LogLevel, message: string) {
     const safeMessage = sanitizeForLog(message)
 
     if (process.env.NODE_ENV === 'development') {
-        // biome-ignore lint/suspicious/noConsole: If using development environment (local), skip logging to GCP and print out to console.
+        // biome-ignore lint/suspicious/noConsole: local dev mirror of GCP log entry
         console.log({
             source: 'GCP log',
             level: safeLevel,
@@ -31,15 +37,16 @@ export async function logToGcp(level: LogLevel, message: string) {
         })
     }
 
-    try {
-        const metadata = {
-            resource: { type: 'global' },
-            severity: safeLevel.toUpperCase(),
-        }
-        const entry = log.entry(metadata, { message: safeMessage })
-        await log.write(entry)
-    } catch (error) {
-        // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
-        console.error('GCP logging failed:', error)
+    const log = getLog()
+    if (!log) return
+
+    const metadata = {
+        resource: { type: 'global' },
+        severity: safeLevel.toUpperCase(),
     }
+    const entry = log.entry(metadata, { message: safeMessage })
+    // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
+    log.write(entry).catch((error) =>
+        console.error('GCP logging failed:', error),
+    )
 }

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -29,8 +29,6 @@ export async function logToGcp(level: LogLevel, message: string) {
             timestamp: new Date().toISOString(),
             message: safeMessage,
         })
-
-        return
     }
 
     try {

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -1,6 +1,17 @@
 'use server'
+import { Logging } from '@google-cloud/logging'
 
 export type LogLevel = 'debug' | 'info' | 'warning' | 'error'
+
+let _log: ReturnType<InstanceType<typeof Logging>['log']> | null = null
+
+function getLog() {
+    if (_log) return _log
+    const projectId = process.env.GOOGLE_PROJECT_ID
+    if (!projectId) return null
+    _log = new Logging({ projectId }).log('tavla_admin')
+    return _log
+}
 
 function sanitizeForLog(value: unknown): string {
     return (
@@ -26,12 +37,15 @@ export async function logToGcp(level: LogLevel, message: string) {
         return
     }
 
-    // Fluentbit reads stdout from the pod and forwards structured JSON to Cloud Logging
-    // biome-ignore lint/suspicious/noConsole: structured logging for GCP log ingestion
-    console.log(
-        JSON.stringify({
-            severity: safeLevel.toUpperCase(),
-            message: safeMessage,
-        }),
+    const log = getLog()
+    if (!log) return
+
+    const entry = log.entry(
+        { resource: { type: 'global' }, severity: safeLevel.toUpperCase() },
+        { message: safeMessage },
+    )
+    // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
+    log.write(entry).catch((error) =>
+        console.error('GCP logging failed:', error),
     )
 }

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -13,7 +13,7 @@ function getLog() {
     return _log
 }
 
-type LogExtra = { bid?: string; uid?: string }
+type LogExtra = { bid?: string; uid?: string; folderId?: string }
 
 type LogPayload = {
     message: string
@@ -24,6 +24,7 @@ type LogPayload = {
     status?: number
     bid?: string
     uid?: string
+    folderId?: string
 }
 
 function buildPayload(message: string, extra?: LogExtra): LogPayload {
@@ -82,12 +83,20 @@ export async function logToGcp(
     const safeLevel = sanitizeForLog(level) as LogLevel
     const safeMessage = sanitizeForLog(message)
 
+    const safeExtra: LogExtra | undefined = extra
+        ? {
+              uid: sanitizeForLog(extra?.uid),
+              bid: sanitizeForLog(extra?.bid),
+              folderId: sanitizeForLog(extra?.folderId),
+          }
+        : undefined
+
     if (process.env.NODE_ENV === 'development') {
         // biome-ignore lint/suspicious/noConsole: local dev output
         console.log({
             severity: safeLevel.toUpperCase(),
             timestamp: new Date().toISOString(),
-            ...buildPayload(safeMessage, extra),
+            ...buildPayload(safeMessage, safeExtra),
         })
         return
     }

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -13,6 +13,46 @@ function getLog() {
     return _log
 }
 
+type LogPayload = {
+    message: string
+    type?: 'server-action' | 'http' | 'graphql'
+    action?: string
+    method?: string
+    endpoint?: string
+    status?: number
+}
+
+function buildPayload(message: string): LogPayload {
+    const actionMatch = message.match(/^action:(\w+)/)
+    if (actionMatch) {
+        return { message, type: 'server-action', action: actionMatch[1] }
+    }
+
+    const httpMatch = message.match(/^(GET|POST|PUT|DELETE|PATCH) /)
+    if (httpMatch) {
+        const status = message.match(/status=(\d+)/)?.[1]
+        return {
+            message,
+            type: 'http',
+            method: httpMatch[1],
+            ...(status ? { status: Number(status) } : {}),
+        }
+    }
+
+    const graphqlMatch = message.match(/^GraphQL ([\w-]+)/)
+    if (graphqlMatch) {
+        const status = message.match(/status=(\d+)/)?.[1]
+        return {
+            message,
+            type: 'graphql',
+            endpoint: graphqlMatch[1],
+            ...(status ? { status: Number(status) } : {}),
+        }
+    }
+
+    return { message }
+}
+
 function sanitizeForLog(value: unknown): string {
     return (
         String(value)
@@ -32,7 +72,7 @@ export async function logToGcp(level: LogLevel, message: string) {
         console.log({
             severity: safeLevel.toUpperCase(),
             timestamp: new Date().toISOString(),
-            message: safeMessage,
+            ...buildPayload(safeMessage),
         })
         return
     }
@@ -42,7 +82,7 @@ export async function logToGcp(level: LogLevel, message: string) {
 
     const entry = log.entry(
         { resource: { type: 'global' }, severity: safeLevel.toUpperCase() },
-        { message: safeMessage },
+        buildPayload(safeMessage),
     )
     // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
     log.write(entry).catch((error) =>

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -13,7 +13,7 @@ function getLog() {
     return _log
 }
 
-type LogExtra = { bid?: string; uid?: string; folderId?: string }
+type LogExtra = { bid?: string; folderId?: string }
 
 type LogPayload = {
     message: string
@@ -23,7 +23,6 @@ type LogPayload = {
     endpoint?: string
     status?: number
     bid?: string
-    uid?: string
     folderId?: string
 }
 
@@ -85,7 +84,6 @@ export async function logToGcp(
 
     const safeExtra: LogExtra | undefined = extra
         ? {
-              uid: sanitizeForLog(extra?.uid),
               bid: sanitizeForLog(extra?.bid),
               folderId: sanitizeForLog(extra?.folderId),
           }
@@ -108,8 +106,10 @@ export async function logToGcp(
         { resource: { type: 'global' }, severity: safeLevel.toUpperCase() },
         buildPayload(safeMessage, extra),
     )
-    // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
-    log.write(entry).catch((error) =>
-        console.error('GCP logging failed:', error),
-    )
+    log.write(entry).catch((error) => {
+        if (process.env.NODE_ENV === 'development') {
+            // biome-ignore lint/suspicious/noConsole: Local logging in dev for why logging failed. Fail silently in prod.
+            console.error('GCP logging failed:', error)
+        }
+    })
 }

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -1,17 +1,6 @@
 'use server'
-import { Logging } from '@google-cloud/logging'
 
 export type LogLevel = 'debug' | 'info' | 'warning' | 'error'
-
-let _log: ReturnType<InstanceType<typeof Logging>['log']> | null = null
-
-function getLog() {
-    if (_log) return _log
-    const projectId = process.env.GOOGLE_PROJECT_ID
-    if (!projectId) return null
-    _log = new Logging({ projectId }).log('tavla_admin')
-    return _log
-}
 
 function sanitizeForLog(value: unknown): string {
     return (
@@ -28,25 +17,21 @@ export async function logToGcp(level: LogLevel, message: string) {
     const safeMessage = sanitizeForLog(message)
 
     if (process.env.NODE_ENV === 'development') {
-        // biome-ignore lint/suspicious/noConsole: local dev mirror of GCP log entry
+        // biome-ignore lint/suspicious/noConsole: local dev output
         console.log({
-            source: 'GCP log',
-            level: safeLevel,
+            severity: safeLevel.toUpperCase(),
             timestamp: new Date().toISOString(),
             message: safeMessage,
         })
+        return
     }
 
-    const log = getLog()
-    if (!log) return
-
-    const metadata = {
-        resource: { type: 'global' },
-        severity: safeLevel.toUpperCase(),
-    }
-    const entry = log.entry(metadata, { message: safeMessage })
-    // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
-    log.write(entry).catch((error) =>
-        console.error('GCP logging failed:', error),
+    // Fluentbit reads stdout from the pod and forwards structured JSON to Cloud Logging
+    // biome-ignore lint/suspicious/noConsole: structured logging for GCP log ingestion
+    console.log(
+        JSON.stringify({
+            severity: safeLevel.toUpperCase(),
+            message: safeMessage,
+        }),
     )
 }

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -13,6 +13,8 @@ function getLog() {
     return _log
 }
 
+type LogExtra = { bid?: string; uid?: string }
+
 type LogPayload = {
     message: string
     type?: 'server-action' | 'http' | 'graphql'
@@ -20,12 +22,19 @@ type LogPayload = {
     method?: string
     endpoint?: string
     status?: number
+    bid?: string
+    uid?: string
 }
 
-function buildPayload(message: string): LogPayload {
+function buildPayload(message: string, extra?: LogExtra): LogPayload {
     const actionMatch = message.match(/^action:(\w+)/)
     if (actionMatch) {
-        return { message, type: 'server-action', action: actionMatch[1] }
+        return {
+            message,
+            type: 'server-action',
+            action: actionMatch[1],
+            ...extra,
+        }
     }
 
     const httpMatch = message.match(/^(GET|POST|PUT|DELETE|PATCH) /)
@@ -36,6 +45,7 @@ function buildPayload(message: string): LogPayload {
             type: 'http',
             method: httpMatch[1],
             ...(status ? { status: Number(status) } : {}),
+            ...extra,
         }
     }
 
@@ -47,10 +57,11 @@ function buildPayload(message: string): LogPayload {
             type: 'graphql',
             endpoint: graphqlMatch[1],
             ...(status ? { status: Number(status) } : {}),
+            ...extra,
         }
     }
 
-    return { message }
+    return { message, ...extra }
 }
 
 function sanitizeForLog(value: unknown): string {
@@ -63,7 +74,11 @@ function sanitizeForLog(value: unknown): string {
     )
 }
 
-export async function logToGcp(level: LogLevel, message: string) {
+export async function logToGcp(
+    level: LogLevel,
+    message: string,
+    extra?: LogExtra,
+) {
     const safeLevel = sanitizeForLog(level) as LogLevel
     const safeMessage = sanitizeForLog(message)
 
@@ -72,7 +87,7 @@ export async function logToGcp(level: LogLevel, message: string) {
         console.log({
             severity: safeLevel.toUpperCase(),
             timestamp: new Date().toISOString(),
-            ...buildPayload(safeMessage),
+            ...buildPayload(safeMessage, extra),
         })
         return
     }
@@ -82,7 +97,7 @@ export async function logToGcp(level: LogLevel, message: string) {
 
     const entry = log.entry(
         { resource: { type: 'global' }, severity: safeLevel.toUpperCase() },
-        buildPayload(safeMessage),
+        buildPayload(safeMessage, extra),
     )
     // biome-ignore lint/suspicious/noConsole: surface GCP logging errors
     log.write(entry).catch((error) =>


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi hadde ingen synlighet i hvilke server actions som ble kalt, hvilke API-kall
som kom inn mot routeren fra tavlevisningen, eller hvilke utgående kall vi
gjorde mot Enturs GraphQL-API. Dette gjør det vanskelig å feilsøke problemer i
produksjon.

### ✨ Løsning
- Legger til `logToGcp` på alle 30+ eksporterte server actions (invocation-
- Fullstendig HTTP-statuskode-logging på `POST /api/upload (401/400/403/413/415/429/500/
- GraphQL-fetcher bruker nå riktig loggnivå basert på HTTP-status (warning, 5xx → 
- Strukturerte `jsonPayload`-felt for enkel filtrering i GCP Log  (`type`, `action`, `method`, `endpoint`, `status`, `bid`, `uid`)
- Fikser rotårsak til gRPC-feil: `@google-cloud/logging` ble bundlet webpack, noe som brøt dynamiske requires i gRPC-klienten — løst med `serverExternalPackages


**Filtrering i GCP Log Viewer:**

```
jsonPayload.type="server-action"
jsonPayload.type="http" AND jsonPayload.status=404
jsonPayload.type="graphql"
jsonPayload.action="deleteAccount" AND jsonPayload.uid="abc123"
jsonPayload.bid="<board id>"
```