### PR TITLE
📝 Legg til design system-referanse i CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ No unit test framework is configured — CI only runs `yarn lint` and `yarn type
 
 Dev URLs: App at `http://localhost:3000`, Firebase Emulator UI at `http://127.0.0.1:4000/`
 
+## Design system
+
+When working with Entur components, branding, or accessibility, read and follow:
+https://raw.githubusercontent.com/entur/design-system/main/skills/entur-linje/SKILL.md
+
 ## Backend Commands (`backend/` directory)
 
 ```bash


### PR DESCRIPTION
### 🥅 Bakgrunn

For å gi Claude Code bedre kontekst ved arbeid med Entur-komponenter og tilgjengelighet, legges det til en referanse til Entur sitt design system (Linje) i CLAUDE.md.

### ✨ Løsning

- Lagt til en ny `## Design system`-seksjon i CLAUDE.md som peker til Entur Linje-skillen på GitHub
- Skillen (linje-skills) er fortsatt under arbeid (work in progress)

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| bilde | bilde |

### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)