### PR TITLE
🐛 Fiks at walking distance ikke fungerte

### DIFF
--- a/tavla/app/_components/TableSettings/WalkingDistance.tsx
+++ b/tavla/app/_components/TableSettings/WalkingDistance.tsx
@@ -23,13 +23,14 @@ function WalkingDistance({
     const isFirstRender = useRef(true)
 
     //Wait until selectedPoint is set before calling onChange to ensure the form is updated correctly
+    // biome-ignore lint/correctness/useExhaustiveDependencies: selectedPoint triggers onChange intentionally
     useEffect(() => {
         if (isFirstRender.current) {
             isFirstRender.current = false
             return
         }
         onChange()
-    }, [onChange])
+    }, [onChange, selectedPoint])
 
     return (
         <div className="flex flex-col">


### PR DESCRIPTION
### 🥅 Bakgrunn
Oppdaget at man ikke fikk satt adresse for gangavstand, den ble kun lagret dersom man gjorde andre endringer på innstillinger. 

### ✨ Løsning
Fant ut at `onChange` ikke ble trigget når `selectedPoint` endret seg - hadde blitt fjernet fra dependency array. Fiks: Legge til `selectedPoint` i dependency array igjen og så be `biome` om å ignorere


### ✅ Sjekkliste

- [x] Testet i Chrome
