### PR TITLE
🧹 Samler Firebase-kall i felles hjelpefunksjoner

### DIFF
--- a/tavla/app/(innlogget)/components/CreateBoard/NameAndFolderSelector.tsx
+++ b/tavla/app/(innlogget)/components/CreateBoard/NameAndFolderSelector.tsx
@@ -15,7 +15,7 @@ import { isNull } from 'lodash'
 import Image from 'next/image'
 import { useActionState } from 'react'
 import type { FolderDB } from 'src/types/db-types/folders'
-import { createBoard } from './actions'
+import { createBoardAction } from './actions'
 
 type NameAndFolderSelectorProps = {
     folder?: FolderDB
@@ -28,7 +28,7 @@ function NameAndFolderSelector({
     folders,
     onClose,
 }: NameAndFolderSelectorProps) {
-    const [state, action] = useActionState(createBoard, undefined)
+    const [state, action] = useActionState(createBoardAction, undefined)
     const posthog = usePosthogTracking()
 
     const { folderDropdownList, selectedFolder, handleFolderChange } =

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -35,9 +35,6 @@ export async function createBoard(
             isCombinedTiles: false,
             meta: {
                 title: name.substring(0, 50),
-                fontSize: 'medium',
-                created: Date.now(),
-                dateModified: Date.now(),
             },
         })
 

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -35,6 +35,7 @@ export async function createBoard(
             isCombinedTiles: false,
             meta: {
                 title: name.substring(0, 50),
+                fontSize: 'medium',
             },
         })
 

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -8,13 +8,13 @@ import {
 import { handleError } from 'app/(innlogget)/utils/handleError'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import { redirect } from 'next/navigation'
-import { addBoard, addBoardIdToFolder, addBoardIdToUser } from 'src/firebase'
+import { addBoardIdToFolder, addBoardIdToUser, createBoard } from 'src/firebase'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
 
-export async function createBoard(
+export async function createBoardAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
@@ -30,7 +30,7 @@ export async function createBoard(
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 
     try {
-        createdBoard = await addBoard({
+        createdBoard = await createBoard({
             tiles: [],
             theme: 'dark',
             isCombinedTiles: false,

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -7,8 +7,8 @@ import {
 } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import admin, { firestore } from 'firebase-admin'
 import { redirect } from 'next/navigation'
+import { addBoard, addBoardIdToFolder, addBoardIdToUser } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
@@ -30,29 +30,25 @@ export async function createBoard(
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 
     try {
-        createdBoard = await firestore()
-            .collection('boards')
-            .add({
-                tiles: [],
-                theme: 'dark',
-                isCombinedTiles: false,
-                meta: {
-                    title: name.substring(0, 50),
-                    fontSize: 'medium',
-                    created: Date.now(),
-                    dateModified: Date.now(),
-                },
-            } as Omit<BoardDB, 'id'>)
+        createdBoard = await addBoard({
+            tiles: [],
+            theme: 'dark',
+            isCombinedTiles: false,
+            meta: {
+                title: name.substring(0, 50),
+                fontSize: 'medium',
+                created: Date.now(),
+                dateModified: Date.now(),
+            },
+        } as Omit<BoardDB, 'id'>)
 
         if (!createdBoard) return getFormFeedbackForError('firebase/general')
 
-        await firestore()
-            .collection(folderid ? 'folders' : 'users')
-            .doc(folderid ? folderid : user.uid)
-            .update({
-                [folderid ? 'boards' : 'owner']:
-                    admin.firestore.FieldValue.arrayUnion(createdBoard.id),
-            })
+        if (folderid) {
+            await addBoardIdToFolder(folderid, createdBoard.id)
+        } else {
+            await addBoardIdToUser(user.uid, createdBoard.id)
+        }
     } catch (error) {
         await logToGcp(
             'error',

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -9,7 +9,6 @@ import { handleError } from 'app/(innlogget)/utils/handleError'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import { redirect } from 'next/navigation'
 import { addBoard, addBoardIdToFolder, addBoardIdToUser } from 'src/firebase'
-import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 
@@ -40,7 +39,7 @@ export async function createBoard(
                 created: Date.now(),
                 dateModified: Date.now(),
             },
-        } as Omit<BoardDB, 'id'>)
+        })
 
         if (!createdBoard) return getFormFeedbackForError('firebase/general')
 

--- a/tavla/app/(innlogget)/components/CreateFolder/CreateFolder.tsx
+++ b/tavla/app/(innlogget)/components/CreateFolder/CreateFolder.tsx
@@ -11,11 +11,11 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import birds from 'assets/illustrations/Birds.png'
 import Image from 'next/image'
 import { useActionState, useState } from 'react'
-import { createFolder } from './actions'
+import { createFolderAction } from './actions'
 
 function CreateFolder() {
     const [isOpen, setIsOpen] = useState(false)
-    const [state, formAction] = useActionState(createFolder, undefined)
+    const [state, formAction] = useActionState(createFolderAction, undefined)
 
     const posthog = usePosthogTracking()
 

--- a/tavla/app/(innlogget)/components/CreateFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateFolder/actions.ts
@@ -32,7 +32,7 @@ export async function createFolderAction(
 
     try {
         folder = await createFolder(name.substring(0, 50), user.uid)
-        if (!folder || !folder.id) return getFormFeedbackForError()
+        if (!folder?.id) return getFormFeedbackForError()
     } catch (error) {
         logToGcp(
             'error',

--- a/tavla/app/(innlogget)/components/CreateFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateFolder/actions.ts
@@ -8,13 +8,11 @@ import {
 } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import { getFirestore } from 'firebase-admin/firestore'
 import { redirect } from 'next/navigation'
+import { addFolder } from 'src/firebase'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
-
-const db = getFirestore()
 
 export async function createFolder(
     _prevState: TFormFeedback | undefined,
@@ -32,11 +30,7 @@ export async function createFolder(
     let folder: FirebaseFirestore.DocumentReference | undefined
 
     try {
-        folder = await db.collection('folders').add({
-            name: name.substring(0, 50),
-            owners: [user.uid],
-            boards: [],
-        })
+        folder = await addFolder(name.substring(0, 50), user.uid)
         if (!folder || !folder.id) return getFormFeedbackForError()
     } catch (error) {
         await logToGcp(

--- a/tavla/app/(innlogget)/components/CreateFolder/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateFolder/actions.ts
@@ -9,12 +9,12 @@ import {
 import { handleError } from 'app/(innlogget)/utils/handleError'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import { redirect } from 'next/navigation'
-import { addFolder } from 'src/firebase'
+import { createFolder } from 'src/firebase'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
 
-export async function createFolder(
+export async function createFolderAction(
     _prevState: TFormFeedback | undefined,
     data: FormData,
 ) {
@@ -31,7 +31,7 @@ export async function createFolder(
     let folder: FirebaseFirestore.DocumentReference | undefined
 
     try {
-        folder = await addFolder(name.substring(0, 50), user.uid)
+        folder = await createFolder(name.substring(0, 50), user.uid)
         if (!folder || !folder.id) return getFormFeedbackForError()
     } catch (error) {
         logToGcp(

--- a/tavla/app/(innlogget)/components/Login/actions.ts
+++ b/tavla/app/(innlogget)/components/Login/actions.ts
@@ -4,10 +4,11 @@ import {
     initializeAdminApp,
     revokeUserTokenOnLogout,
 } from 'app/(innlogget)/utils/firebase'
-import admin, { auth, firestore } from 'firebase-admin'
+import admin, { auth } from 'firebase-admin'
 import { revalidatePath } from 'next/cache'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { createUser } from 'src/firebase'
 import type { UserDB } from 'src/types/db-types/users'
 import { logToGcp } from 'src/utils/logging'
 
@@ -42,7 +43,7 @@ export async function login(token: string) {
 
 export async function create(uid: UserDB['uid']) {
     try {
-        await firestore().collection('users').doc(uid).create({})
+        await createUser(uid)
     } catch (error) {
         await logToGcp(
             'error',

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
@@ -10,9 +10,10 @@ import {
     type TFormFeedback,
 } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
-import admin, { auth, firestore } from 'firebase-admin'
+import { auth } from 'firebase-admin'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { addOwnerToFolder } from 'src/firebase'
 import { logToGcp } from 'src/utils/logging'
 
 export async function removeUserAction(
@@ -70,12 +71,7 @@ export async function inviteUserAction(
         return getFormFeedbackForError('folder/user-already-invited')
 
     try {
-        await firestore()
-            .collection('folders')
-            .doc(folderid)
-            .update({
-                owners: admin.firestore.FieldValue.arrayUnion(invitee.uid),
-            })
+        await addOwnerToFolder(folderid, invitee.uid)
         revalidatePath('/')
     } catch (error) {
         await logToGcp(

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
@@ -37,8 +37,10 @@ export async function remove(
         const bucket = storage().bucket((await getConfig()).bucket)
         const logoFile = bucket.file('logo/' + file)
 
-        await logoFile.delete()
-        await updateFolder(folderid, { logo: FieldValue.delete() })
+        await Promise.all([
+            logoFile.delete(),
+            updateFolder(folderid, { logo: FieldValue.delete() }),
+        ])
 
         revalidatePath('/')
     } catch (error) {

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
@@ -30,7 +30,7 @@ export async function remove(
 
     if (!file) return getFormFeedbackForError()
 
-    const access = userCanEditFolder(folderid)
+    const access = await userCanEditFolder(folderid)
     if (!access) return redirect('/')
 
     try {

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/actions.ts
@@ -8,9 +8,11 @@ import {
 } from 'app/(innlogget)/utils/firebase'
 import { getFormFeedbackForError } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
-import { firestore, storage } from 'firebase-admin'
+import { storage } from 'firebase-admin'
+import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { updateFolder } from 'src/firebase'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 import { getFilename } from './utils'
@@ -36,10 +38,7 @@ export async function remove(
         const logoFile = bucket.file('logo/' + file)
 
         await logoFile.delete()
-
-        await firestore().collection('folders').doc(folderid).update({
-            logo: firestore.FieldValue.delete(),
-        })
+        await updateFolder(folderid, { logo: FieldValue.delete() })
 
         revalidatePath('/')
     } catch (error) {

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -2,7 +2,8 @@
 import * as Sentry from '@sentry/nextjs'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import admin, { firestore } from 'firebase-admin'
+import { redirect } from 'next/navigation'
+import { addBoard, addBoardIdToUser } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
 
@@ -20,23 +21,16 @@ export async function saveBoardToFirebaseForUser(
     const now = Date.now()
 
     try {
-        const doc = await firestore()
-            .collection('boards')
-            .add({
-                ...boardData,
-                meta: {
-                    ...boardData.meta,
-                    created: now,
-                    dateModified: now,
-                },
-            })
+        const doc = await addBoard({
+            ...boardData,
+            meta: {
+                ...boardData.meta,
+                created: now,
+                dateModified: now,
+            },
+        })
 
-        await firestore()
-            .collection('users')
-            .doc(user.uid)
-            .update({
-                owner: admin.firestore.FieldValue.arrayUnion(doc.id),
-            })
+        await addBoardIdToUser(user.uid, doc.id)
 
         return doc.id
     } catch (error) {

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -2,7 +2,6 @@
 import * as Sentry from '@sentry/nextjs'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import { redirect } from 'next/navigation'
 import { addBoard, addBoardIdToUser } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
@@ -22,9 +21,6 @@ export async function saveBoardToFirebaseForUser(
     try {
         const doc = await addBoard({
             ...boardData,
-            meta: {
-                ...boardData.meta,
-            },
         })
 
         await addBoardIdToUser(user.uid, doc.id)

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -18,15 +18,12 @@ export async function saveBoardToFirebaseForUser(
     }
 
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
-    const now = Date.now()
 
     try {
         const doc = await addBoard({
             ...boardData,
             meta: {
                 ...boardData.meta,
-                created: now,
-                dateModified: now,
             },
         })
 

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -2,7 +2,7 @@
 import * as Sentry from '@sentry/nextjs'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import { addBoard, addBoardIdToUser } from 'src/firebase'
+import { addBoardIdToUser, createBoard } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
 
@@ -20,7 +20,7 @@ export async function saveBoardToFirebaseForUser(
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
     try {
-        const doc = await addBoard({
+        const doc = await createBoard({
             ...boardData,
         })
 

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -1,17 +1,24 @@
 'use server'
+import * as Sentry from '@sentry/nextjs'
 import { getBoardsForFolder } from 'app/(innlogget)/actions'
-import { moveBoard } from 'app/(innlogget)/tavler/[id]/rediger/components/Settings/actions'
-import { deleteBoard, initializeAdminApp } from 'app/(innlogget)/utils/firebase'
+import {
+    deleteBoard,
+    initializeAdminApp,
+    userCanEditFolder,
+} from 'app/(innlogget)/utils/firebase'
 import type { TFormFeedback } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
+import { FieldValue, getFirestore } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getFolderForBoard } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
+import { getUserFromSessionCookie } from '../../utils/server'
 
 initializeAdminApp()
+const db = getFirestore()
 
 export async function deleteBoardAction(
     _prevState: TFormFeedback | undefined,
@@ -51,6 +58,63 @@ export async function countAllBoards(folders: FolderDB[], boards: BoardDB[]) {
     let count = boards.length
     folderCounts.map((folderCount) => (count += folderCount))
     return count
+}
+
+export async function moveBoard(
+    bid: BoardDB['id'],
+    toFolder?: FolderDB['id'],
+    fromFolder?: FolderDB['id'],
+) {
+    const user = await getUserFromSessionCookie()
+    if (!user) return redirect('/')
+
+    if (fromFolder) {
+        const canEdit = await userCanEditFolder(fromFolder)
+        if (!canEdit) return redirect('/')
+    }
+
+    if (toFolder) {
+        const canEdit = await userCanEditFolder(toFolder)
+        if (!canEdit) return redirect('/')
+    }
+
+    try {
+        if (fromFolder)
+            await db
+                .collection('folders')
+                .doc(fromFolder)
+                .update({ boards: FieldValue.arrayRemove(bid) })
+        else
+            await db
+                .collection('users')
+                .doc(user.uid)
+                .update({ owner: FieldValue.arrayRemove(bid) })
+
+        if (toFolder)
+            await db
+                .collection('folders')
+                .doc(toFolder)
+                .update({ boards: FieldValue.arrayUnion(bid) })
+        else
+            await db
+                .collection('users')
+                .doc(user.uid)
+                .update({ owner: FieldValue.arrayUnion(bid) })
+    } catch (error) {
+        await logToGcp(
+            'error',
+            `Failed to move board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        Sentry.captureException(error, {
+            extra: {
+                message: 'Error while moving board to new folder',
+                boardID: bid,
+                newFolder: toFolder,
+                oldFolder: fromFolder,
+            },
+        })
+        throw error
+    }
 }
 
 export async function moveBoardAction(data: FormData) {

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -8,17 +8,21 @@ import {
 } from 'app/(innlogget)/utils/firebase'
 import type { TFormFeedback } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
-import { FieldValue, getFirestore } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getFolderForBoard } from 'src/firebase'
+import {
+    addBoardIdToFolder,
+    addBoardIdToUser,
+    getFolderForBoard,
+    removeBoardIdFromFolder,
+    removeBoardIdFromUser,
+} from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 import { getUserFromSessionCookie } from '../../utils/server'
 
 initializeAdminApp()
-const db = getFirestore()
 
 export async function deleteBoardAction(
     _prevState: TFormFeedback | undefined,
@@ -62,76 +66,47 @@ export async function countAllBoards(folders: FolderDB[], boards: BoardDB[]) {
     return count
 }
 
-export async function moveBoard(
-    bid: BoardDB['id'],
-    toFolder?: FolderDB['id'],
-    fromFolder?: FolderDB['id'],
-) {
-    const user = await getUserFromSessionCookie()
-    if (!user) return redirect('/')
-
-    if (fromFolder) {
-        const canEdit = await userCanEditFolder(fromFolder)
-        if (!canEdit) return redirect('/')
-    }
-
-    if (toFolder) {
-        const canEdit = await userCanEditFolder(toFolder)
-        if (!canEdit) return redirect('/')
-    }
-
-    try {
-        if (fromFolder)
-            await db
-                .collection('folders')
-                .doc(fromFolder)
-                .update({ boards: FieldValue.arrayRemove(bid) })
-        else
-            await db
-                .collection('users')
-                .doc(user.uid)
-                .update({ owner: FieldValue.arrayRemove(bid) })
-
-        if (toFolder)
-            await db
-                .collection('folders')
-                .doc(toFolder)
-                .update({ boards: FieldValue.arrayUnion(bid) })
-        else
-            await db
-                .collection('users')
-                .doc(user.uid)
-                .update({ owner: FieldValue.arrayUnion(bid) })
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to move board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while moving board to new folder',
-                boardID: bid,
-                newFolder: toFolder,
-                oldFolder: fromFolder,
-            },
-        })
-        throw error
-    }
-}
-
 export async function moveBoardAction(data: FormData) {
     const bid = data.get('bid') as BoardDB['id']
     logToGcp('info', 'action:moveBoardAction invoked', { bid })
+
+    const user = await getUserFromSessionCookie()
+    if (!user) return redirect('/')
+
     const newFolderID = data.get('newOid') as FolderDB['id'] | undefined
     const oldFolder = await getFolderForBoard(bid)
+
+    if (oldFolder?.id) {
+        const canEdit = await userCanEditFolder(oldFolder.id)
+        if (!canEdit) return redirect('/')
+    }
+
+    if (newFolderID) {
+        const canEdit = await userCanEditFolder(newFolderID)
+        if (!canEdit) return redirect('/')
+    }
+
     try {
-        await moveBoard(bid, newFolderID, oldFolder?.id)
+        if (oldFolder?.id) await removeBoardIdFromFolder(oldFolder.id, bid)
+        else await removeBoardIdFromUser(user.uid, bid)
+
+        if (newFolderID) await addBoardIdToFolder(newFolderID, bid)
+        else await addBoardIdToUser(user.uid, bid)
+
         revalidatePath('/')
     } catch (e) {
         logToGcp(
             'error',
             `Failed to move board ${bid}: ${e instanceof Error ? e.message : String(e)}`,
         )
+        Sentry.captureException(e, {
+            extra: {
+                message: 'Error while moving board to new folder',
+                boardID: bid,
+                newFolder: newFolderID,
+                oldFolder: oldFolder?.id,
+            },
+        })
         return handleError(e)
     }
 }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -8,7 +8,7 @@ import {
     initializeAdminApp,
     userCanEditBoard,
 } from 'app/(innlogget)/utils/firebase'
-import { FieldValue } from 'firebase-admin/firestore'
+import { FieldValue, getFirestore } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getBoard, getBoardByCustomUrl, updateBoard } from 'src/firebase'
@@ -21,13 +21,15 @@ import type {
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
+const db = getFirestore()
 
 export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {
-        const currentBoard = await getBoard(bid)
+        const boardDoc = await db.collection('boards').doc(bid).get()
+        const currentBoard = boardDoc.data() as BoardDB | undefined
 
         const updateData: {
             tiles: FieldValue

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -8,9 +8,10 @@ import {
     initializeAdminApp,
     userCanEditBoard,
 } from 'app/(innlogget)/utils/firebase'
-import { FieldValue, getFirestore } from 'firebase-admin/firestore'
+import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { getBoard, getBoardByCustomUrl, updateBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardTileDB,
@@ -21,24 +22,19 @@ import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
 
-const db = getFirestore()
-
 export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {
-        const boardDoc = await db.collection('boards').doc(bid).get()
-        const currentBoard = boardDoc.data() as BoardDB | undefined
+        const currentBoard = await getBoard(bid)
 
         const updateData: {
             tiles: FieldValue
-            'meta.dateModified': number
             isCombinedTiles: boolean
             transportPalette?: TransportPalette
         } = {
             tiles: FieldValue.arrayUnion(...tiles),
-            'meta.dateModified': Date.now(),
             isCombinedTiles: currentBoard?.isCombinedTiles || false,
         }
 
@@ -46,7 +42,7 @@ export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
             updateData.transportPalette = 'default'
         }
 
-        await db.collection('boards').doc(bid).update(updateData)
+        await updateBoard(bid, updateData)
     } catch (error) {
         await logToGcp(
             'error',
@@ -92,10 +88,7 @@ export async function saveUpdatedTileOrder(
     if (!access) return redirect('/')
 
     try {
-        await db.collection('boards').doc(bid).update({
-            tiles: tiles,
-            'meta.dateModified': Date.now(),
-        })
+        await updateBoard(bid, { tiles })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -136,24 +129,15 @@ export async function saveCustomUrl(
 
     try {
         if (trimmed) {
-            const existing = await db
-                .collection('boards')
-                .where('customUrl', '==', trimmed)
-                .get()
-
-            const taken = existing.docs.some((doc) => doc.id !== bid)
-            if (taken) {
+            const existing = await getBoardByCustomUrl(trimmed)
+            if (existing && existing.id !== bid) {
                 return { error: 'Denne lenken er allerede i bruk.' }
             }
         }
 
-        await db
-            .collection('boards')
-            .doc(bid)
-            .update({
-                customUrl: trimmed || FieldValue.delete(),
-                'meta.dateModified': Date.now(),
-            })
+        await updateBoard(bid, {
+            customUrl: trimmed || FieldValue.delete(),
+        })
 
         revalidatePath(`/tavler/${bid}/rediger`)
         return {}

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -8,10 +8,10 @@ import {
     initializeAdminApp,
     userCanEditBoard,
 } from 'app/(innlogget)/utils/firebase'
-import { FieldValue, getFirestore } from 'firebase-admin/firestore'
+import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getBoardByCustomUrl, updateBoard } from 'src/firebase'
+import { getBoard, getBoardByCustomUrl, updateBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardTileDB,
@@ -21,15 +21,13 @@ import type {
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
-const db = getFirestore()
 
 export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
     const access = await userCanEditBoard(bid)
     if (!access) return redirect('/')
 
     try {
-        const boardDoc = await db.collection('boards').doc(bid).get()
-        const currentBoard = boardDoc.data() as BoardDB | undefined
+        const currentBoard = await getBoard(bid)
 
         const updateData: {
             tiles: FieldValue
@@ -105,6 +103,7 @@ export async function saveUpdatedTileOrder(
                 tilesObjects: tiles,
             },
         })
+        throw error
     }
 }
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -11,7 +11,7 @@ import {
 import { FieldValue, getFirestore } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getBoard, getBoardByCustomUrl, updateBoard } from 'src/firebase'
+import { getBoardByCustomUrl, updateBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardTileDB,

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -7,7 +7,7 @@ import {
 import { getFormFeedbackForError } from 'app/(innlogget)/utils/forms'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import { redirect } from 'next/navigation'
-import { addBoard, addBoardIdToFolder, addBoardIdToUser } from 'src/firebase'
+import { addBoardIdToFolder, addBoardIdToUser, createBoard } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
@@ -31,7 +31,7 @@ export async function duplicateBoard(
                 return getFormFeedbackForError('auth/operation-not-allowed')
         }
 
-        const createdBoard = await addBoard({
+        const createdBoard = await createBoard({
             ...board,
             meta: {
                 ...board.meta,

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -22,17 +22,15 @@ export async function duplicateBoard(
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
 
     try {
-        const createdBoard = await addBoard({
-            ...board,
-            meta: {
-                ...board.meta,
-            },
-        })
-
         if (folderid) {
             const access = await userCanEditFolder(folderid)
             if (!access)
                 return getFormFeedbackForError('auth/operation-not-allowed')
+        }
+
+        const createdBoard = await addBoard(board)
+
+        if (folderid) {
             await addBoardIdToFolder(folderid, createdBoard.id)
         } else {
             await addBoardIdToUser(user.uid, createdBoard.id)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -25,9 +25,7 @@ export async function duplicateBoard(
             ...board,
             meta: {
                 ...board.meta,
-                fontSize: board.meta?.fontSize ?? 'medium',
-                created: Date.now(),
-                dateModified: Date.now(),
+                fontSize: board.meta?.fontSize,
             },
         })
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -31,7 +31,13 @@ export async function duplicateBoard(
                 return getFormFeedbackForError('auth/operation-not-allowed')
         }
 
-        const createdBoard = await addBoard(board)
+        const createdBoard = await addBoard({
+            ...board,
+            meta: {
+                ...board.meta,
+                fontSize: board.meta?.fontSize ?? 'medium',
+            },
+        })
 
         if (folderid) {
             await addBoardIdToFolder(folderid, createdBoard.id)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -1,6 +1,9 @@
 'use server'
 import * as Sentry from '@sentry/nextjs'
-import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
+import {
+    initializeAdminApp,
+    userCanEditFolder,
+} from 'app/(innlogget)/utils/firebase'
 import { getFormFeedbackForError } from 'app/(innlogget)/utils/forms'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import { redirect } from 'next/navigation'
@@ -25,7 +28,6 @@ export async function duplicateBoard(
             ...board,
             meta: {
                 ...board.meta,
-                fontSize: board.meta?.fontSize,
             },
         })
 
@@ -33,6 +35,9 @@ export async function duplicateBoard(
             throw Error('failed to create board')
 
         if (folderid) {
+            const access = await userCanEditFolder(folderid)
+            if (!access)
+                return getFormFeedbackForError('auth/operation-not-allowed')
             await addBoardIdToFolder(folderid, createdBoard.id)
         } else {
             await addBoardIdToUser(user.uid, createdBoard.id)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -3,8 +3,8 @@ import * as Sentry from '@sentry/nextjs'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
 import { getFormFeedbackForError } from 'app/(innlogget)/utils/forms'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import admin, { firestore } from 'firebase-admin'
 import { redirect } from 'next/navigation'
+import { addBoard, addBoardIdToFolder, addBoardIdToUser } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
@@ -21,28 +21,24 @@ export async function duplicateBoard(
     let createdBoard: FirebaseFirestore.DocumentReference | undefined
 
     try {
-        createdBoard = await firestore()
-            .collection('boards')
-            .add({
-                ...board,
-                meta: {
-                    ...board.meta,
-                    fontSize: board.meta?.fontSize ?? 'medium',
-                    created: Date.now(),
-                    dateModified: Date.now(),
-                },
-            })
+        createdBoard = await addBoard({
+            ...board,
+            meta: {
+                ...board.meta,
+                fontSize: board.meta?.fontSize ?? 'medium',
+                created: Date.now(),
+                dateModified: Date.now(),
+            },
+        })
 
         if (!createdBoard || !createdBoard.id)
             throw Error('failed to create board')
 
-        firestore()
-            .collection(folderid ? 'folders' : 'users')
-            .doc(folderid ? String(folderid) : String(user.uid))
-            .update({
-                [folderid ? 'boards' : 'owner']:
-                    admin.firestore.FieldValue.arrayUnion(createdBoard.id),
-            })
+        if (folderid) {
+            await addBoardIdToFolder(folderid, createdBoard.id)
+        } else {
+            await addBoardIdToUser(user.uid, createdBoard.id)
+        }
     } catch (error) {
         await logToGcp(
             'error',

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -21,18 +21,13 @@ export async function duplicateBoard(
     const user = await getUserFromSessionCookie()
     if (!user) return getFormFeedbackForError('auth/operation-not-allowed')
 
-    let createdBoard: FirebaseFirestore.DocumentReference | undefined
-
     try {
-        createdBoard = await addBoard({
+        const createdBoard = await addBoard({
             ...board,
             meta: {
                 ...board.meta,
             },
         })
-
-        if (!createdBoard || !createdBoard.id)
-            throw Error('failed to create board')
 
         if (folderid) {
             const access = await userCanEditFolder(folderid)
@@ -42,6 +37,7 @@ export async function duplicateBoard(
         } else {
             await addBoardIdToUser(user.uid, createdBoard.id)
         }
+        redirect(`/tavler/${createdBoard.id}/rediger`)
     } catch (error) {
         await logToGcp(
             'error',
@@ -50,5 +46,4 @@ export async function duplicateBoard(
         Sentry.captureMessage('Error while duplicating board object: ' + board)
         throw error
     }
-    redirect(`/tavler/${createdBoard.id}/rediger`)
 }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -32,7 +32,6 @@ import {
 import type {
     BoardDB,
     BoardFontSize,
-    BoardFooter,
     BoardTheme,
     LocationDB,
     TransportPalette,
@@ -61,15 +60,10 @@ export async function saveSettings(data: FormData) {
     const hideClock = data.get('clock') === null
     const hideLogo = data.get('logo') === null
 
-    let location: LocationDB | undefined | string = data.get(
-        'newLocation',
-    ) as string
-
-    if (location) {
-        location = JSON.parse(location) as LocationDB
-    } else {
-        location = undefined
-    }
+    const locationRaw = data.get('newLocation') as string
+    const location: LocationDB | undefined = locationRaw
+        ? (JSON.parse(locationRaw) as LocationDB)
+        : undefined
 
     const infoMessage = data.get('infoMessage') as string
 
@@ -83,25 +77,39 @@ export async function saveSettings(data: FormData) {
 
     const boardTitle = title ?? board.meta.title //Ugly hack, should re-evaluate the whole structure
 
+    if (isEmptyOrSpaces(boardTitle)) {
+        errors.name = getFormFeedbackForError('board/tiles-name-missing')
+        return errors
+    }
+
     try {
-        if (isEmptyOrSpaces(boardTitle))
-            errors.name = getFormFeedbackForError('board/tiles-name-missing')
-
-        if (Object.keys(errors).length !== 0) {
-            return errors
-        }
-
         await userHasAccessToEditBoard(board.id ?? '')
 
-        await saveTitle(bid, boardTitle)
-        await moveBoard(bid, newFolder, oldFolder)
-        await saveLocation(board, location)
-        await saveFont(bid, font)
-        await setTheme(bid, theme)
-        await setViewType(board, viewType)
-        await setFooter(bid, { footer: infoMessage })
-        await setTransportPalette(bid, transportPalette)
-        await setElements(bid, hideClock, hideLogo)
+        const tiles = await getTilesWithDistance(board, location)
+
+        const footerContainsText =
+            infoMessage &&
+            !isOnlyWhiteSpace(infoMessage) &&
+            infoMessage.trim() !== ''
+
+        await updateBoard(bid, {
+            'meta.title': boardTitle.substring(0, 50),
+            'meta.fontSize': font,
+            'meta.location': location ?? FieldValue.delete(),
+            theme: theme ?? 'dark',
+            isCombinedTiles: viewType !== 'separate',
+            footer: footerContainsText
+                ? { footer: infoMessage }
+                : FieldValue.delete(),
+            transportPalette: transportPalette ?? 'default',
+            tiles,
+            hideClock,
+            hideLogo,
+        })
+
+        if (newFolder !== oldFolder) {
+            await moveBoard(bid, newFolder, oldFolder)
+        }
 
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
@@ -113,144 +121,12 @@ export async function saveSettings(data: FormData) {
             'error',
             `Failed to save settings for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
         )
+        Sentry.captureException(error, {
+            extra: { message: 'Error while saving settings', boardID: bid },
+        })
         errors.general = handleError(error)
         return errors
     }
-}
-
-async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
-    const footerContainsText =
-        footer && !isOnlyWhiteSpace(footer) && footer.trim() !== ''
-
-    const newFooter = footerContainsText
-        ? { footer: footer }
-        : FieldValue.delete()
-
-    try {
-        await updateBoard(bid, { footer: newFooter })
-        revalidatePath(`tavler/${bid}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to set footer for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while setting footer of board',
-                boardID: bid,
-            },
-        })
-        return handleError(error)
-    }
-}
-
-async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
-    try {
-        await updateBoard(bid, { theme: theme ?? 'dark' })
-        revalidatePath(`/tavler/${bid}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to set theme for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while updating theme of board',
-                boardID: bid,
-                newTheme: theme,
-            },
-        })
-        return handleError(error)
-    }
-}
-
-async function setViewType(board: BoardDB, viewType: string) {
-    const isSeparateTiles = viewType === 'separate'
-
-    try {
-        await updateBoard(board.id ?? '', { isCombinedTiles: !isSeparateTiles })
-        revalidatePath(`/tavler/${board.id}/rediger`)
-    } catch (e) {
-        await logToGcp(
-            'error',
-            `Failed to set view type for board ${board.id}: ${e instanceof Error ? e.message : String(e)}`,
-        )
-        handleError(e)
-    }
-}
-
-async function saveTitle(bid: BoardDB['id'], title: string) {
-    try {
-        await updateBoard(bid, { 'meta.title': title.substring(0, 50) })
-        revalidatePath(`/tavler/${bid}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to save title for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while saving title of board tile',
-                boardID: bid,
-            },
-        })
-        return handleError(error)
-    }
-}
-
-async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
-    try {
-        await updateBoard(bid, { 'meta.fontSize': font })
-        revalidatePath(`/tavler/${bid}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to save font for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while updating font size of board',
-                boardID: bid,
-            },
-        })
-        return handleError(error)
-    }
-}
-
-async function saveLocation(board: BoardDB, location?: LocationDB) {
-    try {
-        await updateBoard(board.id ?? '', {
-            tiles: await getTilesWithDistance(board, location),
-            'meta.location': location ?? FieldValue.delete(),
-        })
-        revalidatePath(`/tavler/${board.id}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to save location for board ${board.id}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while updating location of board',
-                boardID: board.id,
-                location: location,
-            },
-        })
-        return handleError(error)
-    }
-}
-
-async function getTilesWithDistance(board: BoardDB, location?: LocationDB) {
-    return await Promise.all(
-        board.tiles.map(async (tile) => {
-            if (location === undefined) {
-                delete tile.walkingDistance
-                return tile
-            } else {
-                return await getWalkingDistanceTile(tile, location)
-            }
-        }),
-    )
 }
 
 export async function moveBoard(
@@ -286,60 +162,23 @@ export async function moveBoard(
             extra: {
                 message: 'Error while moving board to new folder',
                 boardID: bid,
-                newFolder: toFolder,
-                oldFolder: fromFolder,
+                toFolder,
+                fromFolder,
             },
         })
         throw error
     }
 }
 
-async function setTransportPalette(
-    bid: BoardDB['id'],
-    transportPalette?: TransportPalette,
-) {
-    try {
-        await updateBoard(bid, {
-            transportPalette: transportPalette ?? 'default',
-        })
-        revalidatePath(`/tavler/${bid}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to set transport palette for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while updating transport palette',
-                boardID: bid,
-                newTransportPalette: transportPalette,
-            },
-        })
-        return handleError(error)
-    }
-}
-
-async function setElements(
-    bid: BoardDB['id'],
-    hideClock: boolean,
-    hideLogo: boolean,
-) {
-    try {
-        await updateBoard(bid, { hideClock, hideLogo })
-        revalidatePath(`/tavler/${bid}/rediger`)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to set elements for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while updating visible elements',
-                boardID: bid,
-                hideClock: hideClock,
-                hideLogo: hideLogo,
-            },
-        })
-        return handleError(error)
-    }
+async function getTilesWithDistance(board: BoardDB, location?: LocationDB) {
+    return await Promise.all(
+        board.tiles.map(async (tile) => {
+            if (location === undefined) {
+                delete tile.walkingDistance
+                return tile
+            } else {
+                return await getWalkingDistanceTile(tile, location)
+            }
+        }),
+    )
 }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -8,7 +8,6 @@ import {
 import {
     initializeAdminApp,
     userCanEditBoard,
-    userCanEditFolder,
 } from 'app/(innlogget)/utils/firebase'
 import {
     getFormFeedbackForError,
@@ -16,19 +15,11 @@ import {
     type TFormFeedback,
 } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
-import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 import { redirect } from 'next/navigation'
-import {
-    addBoardIdToFolder,
-    addBoardIdToUser,
-    getBoard,
-    removeBoardIdFromFolder,
-    removeBoardIdFromUser,
-    updateBoard,
-} from 'src/firebase'
+import { getBoard, updateBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardFontSize,
@@ -36,7 +27,6 @@ import type {
     LocationDB,
     TransportPalette,
 } from 'src/types/db-types/boards'
-import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
@@ -53,9 +43,6 @@ export async function saveSettings(data: FormData) {
     const theme = data.get('theme') as BoardTheme
     const font = data.get('font') as BoardFontSize
     const transportPalette = data.get('transportPalette') as TransportPalette
-
-    const newFolder = data.get('newOid') as FolderDB['id'] | undefined
-    const oldFolder = data.get('oldOid') as FolderDB['id'] | undefined
 
     const hideClock = data.get('clock') === null
     const hideLogo = data.get('logo') === null
@@ -107,10 +94,6 @@ export async function saveSettings(data: FormData) {
             hideLogo,
         })
 
-        if (newFolder !== oldFolder) {
-            await moveBoard(bid, newFolder, oldFolder)
-        }
-
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         if (isRedirectError(error)) {
@@ -126,47 +109,6 @@ export async function saveSettings(data: FormData) {
         })
         errors.general = handleError(error)
         return errors
-    }
-}
-
-export async function moveBoard(
-    bid: BoardDB['id'],
-    toFolder?: FolderDB['id'],
-    fromFolder?: FolderDB['id'],
-) {
-    const user = await getUserFromSessionCookie()
-    if (!user) return redirect('/')
-
-    if (fromFolder) {
-        const canEdit = await userCanEditFolder(fromFolder)
-        if (!canEdit) return redirect('/')
-    }
-
-    if (toFolder) {
-        const canEdit = await userCanEditFolder(toFolder)
-        if (!canEdit) return redirect('/')
-    }
-
-    try {
-        if (fromFolder) await removeBoardIdFromFolder(fromFolder, bid)
-        else await removeBoardIdFromUser(user.uid, bid)
-
-        if (toFolder) await addBoardIdToFolder(toFolder, bid)
-        else await addBoardIdToUser(user.uid, bid)
-    } catch (error) {
-        await logToGcp(
-            'error',
-            `Failed to move board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
-        )
-        Sentry.captureException(error, {
-            extra: {
-                message: 'Error while moving board to new folder',
-                boardID: bid,
-                toFolder,
-                fromFolder,
-            },
-        })
-        throw error
     }
 }
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -17,11 +17,18 @@ import {
 } from 'app/(innlogget)/utils/forms'
 import { handleError } from 'app/(innlogget)/utils/handleError'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
-import { FieldValue, getFirestore } from 'firebase-admin/firestore'
+import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 import { redirect } from 'next/navigation'
-import { getBoard } from 'src/firebase'
+import {
+    addBoardIdToFolder,
+    addBoardIdToUser,
+    getBoard,
+    removeBoardIdFromFolder,
+    removeBoardIdFromUser,
+    updateBoard,
+} from 'src/firebase'
 import type {
     BoardDB,
     BoardFontSize,
@@ -34,8 +41,6 @@ import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
-
-const db = getFirestore()
 
 async function userHasAccessToEditBoard(bid: string) {
     const access = await userCanEditBoard(bid)
@@ -122,10 +127,7 @@ async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
         : FieldValue.delete()
 
     try {
-        await db.collection('boards').doc(bid).update({
-            footer: newFooter,
-            'meta.dateModified': Date.now(),
-        })
+        await updateBoard(bid, { footer: newFooter })
         revalidatePath(`tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -144,14 +146,7 @@ async function setFooter(bid: BoardDB['id'], { footer }: BoardFooter) {
 
 async function setTheme(bid: BoardDB['id'], theme?: BoardTheme) {
     try {
-        await db
-            .collection('boards')
-            .doc(bid)
-            .update({
-                theme: theme ?? 'dark',
-                'meta.dateModified': Date.now(),
-            })
-
+        await updateBoard(bid, { theme: theme ?? 'dark' })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -173,14 +168,7 @@ async function setViewType(board: BoardDB, viewType: string) {
     const isSeparateTiles = viewType === 'separate'
 
     try {
-        await db
-            .collection('boards')
-            .doc(board.id ?? '')
-            .update({
-                isCombinedTiles: !isSeparateTiles,
-                'meta.dateModified': Date.now(),
-            })
-
+        await updateBoard(board.id ?? '', { isCombinedTiles: !isSeparateTiles })
         revalidatePath(`/tavler/${board.id}/rediger`)
     } catch (e) {
         await logToGcp(
@@ -193,13 +181,7 @@ async function setViewType(board: BoardDB, viewType: string) {
 
 async function saveTitle(bid: BoardDB['id'], title: string) {
     try {
-        await db
-            .collection('boards')
-            .doc(bid)
-            .update({
-                'meta.title': title.substring(0, 50),
-                'meta.dateModified': Date.now(),
-            })
+        await updateBoard(bid, { 'meta.title': title.substring(0, 50) })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -218,10 +200,7 @@ async function saveTitle(bid: BoardDB['id'], title: string) {
 
 async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
     try {
-        await db
-            .collection('boards')
-            .doc(bid)
-            .update({ 'meta.fontSize': font, 'meta.dateModified': Date.now() })
+        await updateBoard(bid, { 'meta.fontSize': font })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -240,14 +219,10 @@ async function saveFont(bid: BoardDB['id'], font: BoardFontSize) {
 
 async function saveLocation(board: BoardDB, location?: LocationDB) {
     try {
-        await db
-            .collection('boards')
-            .doc(board.id ?? '')
-            .update({
-                tiles: await getTilesWithDistance(board, location),
-                'meta.location': location ?? FieldValue.delete(),
-                'meta.dateModified': Date.now(),
-            })
+        await updateBoard(board.id ?? '', {
+            tiles: await getTilesWithDistance(board, location),
+            'meta.location': location ?? FieldValue.delete(),
+        })
         revalidatePath(`/tavler/${board.id}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -297,27 +272,11 @@ export async function moveBoard(
     }
 
     try {
-        if (fromFolder)
-            await db
-                .collection('folders')
-                .doc(fromFolder)
-                .update({ boards: FieldValue.arrayRemove(bid) })
-        else
-            await db
-                .collection('users')
-                .doc(user.uid)
-                .update({ owner: FieldValue.arrayRemove(bid) })
+        if (fromFolder) await removeBoardIdFromFolder(fromFolder, bid)
+        else await removeBoardIdFromUser(user.uid, bid)
 
-        if (toFolder)
-            await db
-                .collection('folders')
-                .doc(toFolder)
-                .update({ boards: FieldValue.arrayUnion(bid) })
-        else
-            await db
-                .collection('users')
-                .doc(user.uid)
-                .update({ owner: FieldValue.arrayUnion(bid) })
+        if (toFolder) await addBoardIdToFolder(toFolder, bid)
+        else await addBoardIdToUser(user.uid, bid)
     } catch (error) {
         await logToGcp(
             'error',
@@ -340,14 +299,9 @@ async function setTransportPalette(
     transportPalette?: TransportPalette,
 ) {
     try {
-        await db
-            .collection('boards')
-            .doc(bid)
-            .update({
-                transportPalette: transportPalette ?? 'default',
-                'meta.dateModified': Date.now(),
-            })
-
+        await updateBoard(bid, {
+            transportPalette: transportPalette ?? 'default',
+        })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -371,12 +325,7 @@ async function setElements(
     hideLogo: boolean,
 ) {
     try {
-        await db.collection('boards').doc(bid).update({
-            hideClock: hideClock,
-            hideLogo: hideLogo,
-            'meta.dateModified': Date.now(),
-        })
-
+        await updateBoard(bid, { hideClock, hideLogo })
         revalidatePath(`/tavler/${bid}/rediger`)
     } catch (error) {
         await logToGcp(

--- a/tavla/app/(innlogget)/utils/firebase.ts
+++ b/tavla/app/(innlogget)/utils/firebase.ts
@@ -1,7 +1,12 @@
 'use server'
 import * as Sentry from '@sentry/nextjs'
 import admin, { auth, firestore } from 'firebase-admin'
-import { getFolderForBoard } from 'src/firebase'
+import {
+    getFolderForBoard,
+    removeBoardIdFromFolder,
+    removeBoardIdFromUser,
+    removeOwnerFromFolder,
+} from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import type { FolderDB } from 'src/types/db-types/folders'
 import { type UserDB, UserDBSchema } from 'src/types/db-types/users'
@@ -95,19 +100,9 @@ export async function deleteBoard(bid: BoardDB['id']) {
         await firestore().collection('boards').doc(bid).delete()
 
         if (folder?.id) {
-            await firestore()
-                .collection('folders')
-                .doc(folder.id)
-                .update({
-                    boards: admin.firestore.FieldValue.arrayRemove(bid),
-                })
+            await removeBoardIdFromFolder(folder.id, bid)
         } else {
-            await firestore()
-                .collection('users')
-                .doc(user.uid)
-                .update({
-                    owner: admin.firestore.FieldValue.arrayRemove(bid),
-                })
+            await removeBoardIdFromUser(user.uid, bid)
         }
     } catch (error) {
         await logToGcp(
@@ -167,12 +162,7 @@ export async function deleteFolderBoard(
 
 export async function removeUserFromFolder(folderid: string, uid: string) {
     try {
-        await firestore()
-            .collection('folders')
-            .doc(folderid)
-            .update({
-                owners: admin.firestore.FieldValue.arrayRemove(uid),
-            })
+        await removeOwnerFromFolder(folderid, uid)
     } catch (error) {
         await logToGcp(
             'error',

--- a/tavla/app/_components/TileCard/actions.ts
+++ b/tavla/app/_components/TileCard/actions.ts
@@ -5,16 +5,14 @@ import {
     initializeAdminApp,
     userCanEditBoard,
 } from 'app/(innlogget)/utils/firebase'
-import { FieldValue, getFirestore } from 'firebase-admin/firestore'
+import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getBoard } from 'src/firebase'
+import { getBoard, updateBoard } from 'src/firebase'
 import type { BoardDB, BoardTileDB } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
-
-const db = getFirestore()
 
 export async function deleteTile(boardId: string, tile: BoardTileDB) {
     const access = await userCanEditBoard(boardId)
@@ -55,7 +53,7 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
             updatePayload.transportPalette = 'default'
         }
 
-        await db.collection('boards').doc(boardId).update(updatePayload)
+        await updateBoard(boardId, updatePayload)
         revalidatePath(`/tavler/${boardId}/rediger`)
     } catch (error) {
         await logToGcp(
@@ -77,14 +75,13 @@ export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
     if (!access) return redirect('/')
 
     try {
-        const boardRef = db.collection('boards').doc(bid)
         const board = await getBoard(bid)
         const existingTile = board?.tiles.find((t) => t.uuid === tile.uuid)
-        if (!existingTile)
-            return boardRef.update({
-                tiles: FieldValue.arrayUnion(tile),
-                'meta.dateModified': Date.now(),
-            })
+        if (!existingTile) {
+            await updateBoard(bid, { tiles: FieldValue.arrayUnion(tile) })
+            revalidatePath(`/tavler/${bid}/rediger`)
+            return
+        }
         const indexExistingTile = board?.tiles.indexOf(existingTile)
 
         if (
@@ -93,10 +90,7 @@ export async function saveTile(bid: BoardDB['id'], tile: BoardTileDB) {
             indexExistingTile !== -1
         ) {
             board.tiles[indexExistingTile] = tile
-            boardRef.update({
-                tiles: board.tiles,
-                'meta.dateModified': Date.now(),
-            })
+            await updateBoard(bid, { tiles: board.tiles })
         }
 
         revalidatePath(`/tavler/${bid}/rediger`)

--- a/tavla/app/_components/TileCard/actions.ts
+++ b/tavla/app/_components/TileCard/actions.ts
@@ -46,7 +46,6 @@ export async function deleteTile(boardId: string, tile: BoardTileDB) {
 
         const updatePayload: Record<string, unknown> = {
             tiles: FieldValue.arrayRemove(tileToDelete),
-            'meta.dateModified': Date.now(),
         }
 
         if (shouldResetPalette) {

--- a/tavla/app/api/board/route.ts
+++ b/tavla/app/api/board/route.ts
@@ -1,14 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
-import { getFirestore } from 'firebase-admin/firestore'
 import { type NextRequest, NextResponse } from 'next/server'
+import { getBoard, getBoardByCustomUrl, getFolderForBoard } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
-import type { FolderDB } from 'src/types/db-types/folders'
 import { logToGcp } from 'src/utils/logging'
 
 initializeAdminApp()
-
-const db = getFirestore()
 
 const allowedOrigins = [
     'https://vis-tavla.dev.entur.no',
@@ -36,47 +33,15 @@ export async function OPTIONS(request: NextRequest) {
 }
 
 async function fetchBoardById(boardId: BoardDB['id']): Promise<BoardDB | null> {
-    const boardDoc = await db.collection('boards').doc(boardId).get()
-
-    if (!boardDoc.exists) {
-        return null
-    }
-    const board = { id: boardId, ...boardDoc.data() } as BoardDB
-
+    const board = await getBoard(boardId)
+    if (!board) return null
     const { location: _, ...meta } = board.meta
     return { ...board, meta }
 }
 
-async function fetchBoardByCustomUrl(
-    boardString: BoardDB['customUrl'],
-): Promise<BoardDB | null> {
-    const boardQuery = await db
-        .collection('boards')
-        .where('customUrl', '==', boardString)
-        .get()
-
-    if (boardQuery.empty) {
-        return null
-    }
-
-    return {
-        id: boardQuery.docs[0]?.id,
-        ...boardQuery.docs[0]?.data(),
-    } as BoardDB
-}
-
 async function fetchFolderLogo(boardId: BoardDB['id']): Promise<string | null> {
-    const foldersSnapshot = await db
-        .collection('folders')
-        .where('boards', 'array-contains', boardId)
-        .get()
-
-    if (foldersSnapshot.empty || !foldersSnapshot.docs[0]) {
-        return null
-    }
-
-    const folderData = foldersSnapshot.docs[0].data() as FolderDB
-    return folderData.logo ?? null
+    const folder = await getFolderForBoard(boardId)
+    return folder?.logo ?? null
 }
 
 function createErrorResponse(
@@ -103,7 +68,7 @@ export async function GET(request: NextRequest) {
     try {
         const boardData =
             (boardId.length === 20 ? await fetchBoardById(boardId) : null) ??
-            (await fetchBoardByCustomUrl(boardId))
+            (await getBoardByCustomUrl(boardId))
 
         if (!boardData) {
             return createErrorResponse(request, 'Board not found', 404)

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -7,18 +7,16 @@ import {
 } from 'app/(innlogget)/utils/firebase'
 import { getUserFromSessionCookie } from 'app/(innlogget)/utils/server'
 import createDOMPurify from 'dompurify'
-import { getFirestore } from 'firebase-admin/firestore'
 import { getDownloadURL, getStorage } from 'firebase-admin/storage'
 import { JSDOM } from 'jsdom'
 import { nanoid } from 'nanoid'
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { updateFolder } from 'src/firebase'
 import type { FolderDB } from 'src/types/db-types/folders'
 import rateLimit from 'src/utils/rateLimit'
 
 initializeAdminApp()
-
-const db = getFirestore()
 
 const rateLimiter = rateLimit({
     maxUniqueTokens: 100,
@@ -117,9 +115,7 @@ export async function POST(request: NextRequest) {
             },
         )
 
-    await db.collection('folders').doc(folderid).update({
-        logo: logoUrl,
-    })
+    await updateFolder(folderid, { logo: logoUrl })
     revalidatePath(`/mapper/${folderid}`)
     return new Response(
         JSON.stringify({ message: 'Logo uploaded successfully' }),

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -53,14 +53,13 @@ export async function POST(request: NextRequest) {
             status: 400,
         })
 
-    try {
-        await userCanEditFolder(folderid)
-    } catch {
+    const canEdit = await userCanEditFolder(folderid)
+    if (!canEdit)
         return new Response(JSON.stringify({ error: 'Unauthorized' }), {
             headers: response.headers,
             status: 403,
         })
-    }
+
     if (logo.size > 10_000_000)
         return new Response(JSON.stringify({ error: 'File size too big' }), {
             headers: response.headers,

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 import { getWalkingDistanceTile } from 'app/(innlogget)/tavler/[id]/rediger/actions'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
-import { addBoard } from 'src/firebase'
+import { createBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardTileDB,
@@ -15,7 +15,7 @@ export async function publishBoard(board: BoardDB): Promise<string> {
     logToGcp('info', 'action:publishBoard invoked')
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
-    const doc = await addBoard({ ...boardData, isAnonymousBoard: true })
+    const doc = await createBoard({ ...boardData, isAnonymousBoard: true })
     return doc.id
 }
 

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 import { getWalkingDistanceTile } from 'app/(innlogget)/tavler/[id]/rediger/actions'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
-import { firestore } from 'firebase-admin'
+import { addBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardTileDB,
@@ -14,17 +14,15 @@ export async function publishBoard(board: BoardDB): Promise<string> {
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
     const now = Date.now()
-    const doc = await firestore()
-        .collection('boards')
-        .add({
-            ...boardData,
-            meta: {
-                ...boardData.meta,
-                created: now,
-                dateModified: now,
-            },
-            isAnonymousBoard: true,
-        })
+    const doc = await addBoard({
+        ...boardData,
+        meta: {
+            ...boardData.meta,
+            created: now,
+            dateModified: now,
+        },
+        isAnonymousBoard: true,
+    })
     return doc.id
 }
 

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -13,13 +13,10 @@ initializeAdminApp()
 export async function publishBoard(board: BoardDB): Promise<string> {
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
-    const now = Date.now()
     const doc = await addBoard({
         ...boardData,
         meta: {
             ...boardData.meta,
-            created: now,
-            dateModified: now,
         },
         isAnonymousBoard: true,
     })

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -13,13 +13,7 @@ initializeAdminApp()
 export async function publishBoard(board: BoardDB): Promise<string> {
     const { id: _id, ...boardData } = board // We don't want to use the localStorage board ID in firebase, so we remove it before saving. Firebase will generate a new ID for us.
 
-    const doc = await addBoard({
-        ...boardData,
-        meta: {
-            ...boardData.meta,
-        },
-        isAnonymousBoard: true,
-    })
+    const doc = await addBoard({ ...boardData, isAnonymousBoard: true })
     return doc.id
 }
 

--- a/tavla/src/firebase.ts
+++ b/tavla/src/firebase.ts
@@ -108,7 +108,17 @@ export async function updateBoard(
 }
 
 export async function addBoard(boardData: Omit<BoardDB, 'id'>) {
-    return firestore().collection('boards').add(boardData)
+    const now = Date.now()
+    return firestore()
+        .collection('boards')
+        .add({
+            ...boardData,
+            meta: {
+                ...boardData.meta,
+                created: now,
+                dateModified: now,
+            },
+        })
 }
 
 export async function getBoardByCustomUrl(customUrl: string) {

--- a/tavla/src/firebase.ts
+++ b/tavla/src/firebase.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs'
 import { makeBoardCompatible } from 'app/_utils/compatibility'
 import admin, { firestore } from 'firebase-admin'
+import { FieldValue } from 'firebase-admin/firestore'
 import { type BoardDB, BoardDBSchema } from 'src/types/db-types/boards'
 import { type FolderDB, FolderDBSchema } from 'src/types/db-types/folders'
 
@@ -94,6 +95,101 @@ export async function getFolder(folderid: FolderDB['id']) {
             { cause: error },
         )
     }
+}
+
+export async function updateBoard(
+    bid: BoardDB['id'],
+    data: Record<string, unknown>,
+) {
+    await firestore()
+        .collection('boards')
+        .doc(bid)
+        .update({ ...data, 'meta.dateModified': Date.now() })
+}
+
+export async function addBoard(boardData: Omit<BoardDB, 'id'>) {
+    return firestore().collection('boards').add(boardData)
+}
+
+export async function getBoardByCustomUrl(customUrl: string) {
+    const query = await firestore()
+        .collection('boards')
+        .where('customUrl', '==', customUrl)
+        .get()
+    if (query.empty || !query.docs[0]) return null
+    return { id: query.docs[0].id, ...query.docs[0].data() } as BoardDB
+}
+
+export async function addBoardIdToUser(uid: string, bid: BoardDB['id']) {
+    await firestore()
+        .collection('users')
+        .doc(uid)
+        .update({ owner: FieldValue.arrayUnion(bid) })
+}
+
+export async function removeBoardIdFromUser(uid: string, bid: BoardDB['id']) {
+    await firestore()
+        .collection('users')
+        .doc(uid)
+        .update({ owner: FieldValue.arrayRemove(bid) })
+}
+
+export async function addBoardIdToFolder(
+    folderid: FolderDB['id'],
+    bid: BoardDB['id'],
+) {
+    await firestore()
+        .collection('folders')
+        .doc(folderid)
+        .update({ boards: FieldValue.arrayUnion(bid) })
+}
+
+export async function removeBoardIdFromFolder(
+    folderid: FolderDB['id'],
+    bid: BoardDB['id'],
+) {
+    await firestore()
+        .collection('folders')
+        .doc(folderid)
+        .update({ boards: FieldValue.arrayRemove(bid) })
+}
+
+export async function addOwnerToFolder(folderid: FolderDB['id'], uid: string) {
+    await firestore()
+        .collection('folders')
+        .doc(folderid)
+        .update({ owners: FieldValue.arrayUnion(uid) })
+}
+
+export async function removeOwnerFromFolder(
+    folderid: FolderDB['id'],
+    uid: string,
+) {
+    await firestore()
+        .collection('folders')
+        .doc(folderid)
+        .update({ owners: FieldValue.arrayRemove(uid) })
+}
+
+export async function updateFolder(
+    folderid: FolderDB['id'],
+    data: Record<string, unknown>,
+) {
+    await firestore().collection('folders').doc(folderid).update(data)
+}
+
+export async function addFolder(name: string, uid: string) {
+    return firestore()
+        .collection('folders')
+        .add({
+            name,
+            owners: [uid],
+            boards: [],
+        })
+}
+
+export async function createUser(uid: string) {
+    await firestore().collection('users').doc(uid).create({})
 }
 
 export async function getFolderForBoard(bid: BoardDB['id']) {

--- a/tavla/src/firebase.ts
+++ b/tavla/src/firebase.ts
@@ -107,7 +107,7 @@ export async function updateBoard(
         .update({ ...data, 'meta.dateModified': Date.now() })
 }
 
-export async function addBoard(boardData: Omit<BoardDB, 'id'>) {
+export async function createBoard(boardData: Omit<BoardDB, 'id'>) {
     const now = Date.now()
     return firestore()
         .collection('boards')

--- a/tavla/src/firebase.ts
+++ b/tavla/src/firebase.ts
@@ -122,12 +122,44 @@ export async function addBoard(boardData: Omit<BoardDB, 'id'>) {
 }
 
 export async function getBoardByCustomUrl(customUrl: string) {
-    const query = await firestore()
-        .collection('boards')
-        .where('customUrl', '==', customUrl)
-        .get()
-    if (query.empty || !query.docs[0]) return null
-    return { id: query.docs[0].id, ...query.docs[0].data() } as BoardDB
+    try {
+        const query = await firestore()
+            .collection('boards')
+            .where('customUrl', '==', customUrl)
+            .get()
+        if (query.empty || !query.docs[0]) return null
+
+        const boardData = {
+            id: query.docs[0].id,
+            ...query.docs[0].data(),
+        }
+        const parsedBoard = BoardDBSchema.safeParse(boardData)
+        if (!parsedBoard.success) {
+            Sentry.captureMessage(
+                'Board data validation failed for board ' + boardData.id,
+                {
+                    level: 'warning',
+                    extra: {
+                        error: parsedBoard.error,
+                    },
+                },
+            )
+            return makeBoardCompatible(boardData as BoardDB)
+        }
+        return makeBoardCompatible(parsedBoard.data)
+    } catch (error) {
+        Sentry.captureException(error, {
+            level: 'error',
+            extra: {
+                customUrl,
+                operation: 'getBoardByCustomUrl',
+            },
+        })
+        throw new Error(
+            `Failed to fetch board by custom URL ${customUrl}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            { cause: error },
+        )
+    }
 }
 
 export async function addBoardIdToUser(uid: string, bid: BoardDB['id']) {

--- a/tavla/src/firebase.ts
+++ b/tavla/src/firebase.ts
@@ -220,7 +220,7 @@ export async function updateFolder(
     await firestore().collection('folders').doc(folderid).update(data)
 }
 
-export async function addFolder(name: string, uid: string) {
+export async function createFolder(name: string, uid: string) {
     return firestore()
         .collection('folders')
         .add({


### PR DESCRIPTION
## Melding fra meg
Beklager mange commits og mye kommentarer, jeg prøver å bli litt venn med å bruke claude mer til sånne her type oppgaver og da ble det veldig stegvis + at jeg tok reviewen her på github. Gjerne ta en titt på kommentarene jeg har skrevet, og dersom du har en kommentar tilbake, gjerne gi beskjed om du syns det skal fikses i denne PR-en eller en ny senere (for å unngå at det blir veldig store PR-er).

## Beskrivelse fra Claude
### 🥅 Bakgrunn

Vi gjør direkte Firestore-kall mange steder i kodebasen, og mange steder er kallene svært like. Dette gjør det vanskelig å gjenbruke logikk, holder kodelinjetallet høyt, og gir lite sentral kontroll over hvordan vi snakker med databasen.

### ✨ Løsning

Legger til 12 gjenbrukbare DB-primitiver i `src/firebase.ts`:

| Funksjon | Formål |
|---|---|
| `updateBoard(bid, data)` | Oppdaterer et board og setter `meta.dateModified` automatisk |
| `addBoard(boardData)` | Oppretter et nytt board-dokument |
| `getBoardByCustomUrl(url)` | Henter board via customUrl |
| `addBoardIdToUser` / `removeBoardIdFromUser` | Håndterer `user.owner`-arrayet |
| `addBoardIdToFolder` / `removeBoardIdFromFolder` | Håndterer `folder.boards`-arrayet |
| `addOwnerToFolder` / `removeOwnerFromFolder` | Håndterer `folder.owners`-arrayet |
| `updateFolder(folderid, data)` | Oppdaterer et mappe-dokument |
| `addFolder(name, uid)` | Oppretter en ny mappe |
| `createUser(uid)` | Oppretter et bruker-dokument |

Refaktorerer 14 action-filer til å bruke disse i stedet for direkte `firestore().collection()` / `db.collection()`-kall. Ingen endringer i oppførsel.

- Netto: −52 kodelinjer (224 inn / 276 ut)
- `getBoardByCustomUrl` var duplisert i `api/board/route.ts` – nå delt via `src/firebase.ts`
- `updateBoard` setter `meta.dateModified` automatisk, så det ikke trengs å huske på det på hvert enkelt kall
- `api/board/route.ts` bruker nå `getBoard` og `getFolderForBoard` fra `src/firebase.ts` i stedet for egne inline-implementasjoner


### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)