### PR TITLE
💄 Vis navn på tavle på side for tavle uten bruker

### DIFF
--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { PrimaryButton } from '@entur/button'
 import { Modal } from '@entur/modal'
-import { Heading1, Heading3, LeadParagraph } from '@entur/typography'
+import { Heading1, Heading2, Heading3, LeadParagraph } from '@entur/typography'
 import { CreateUserButton } from 'app/_components/CreateUserButton'
 import { SettingsForm } from 'app/_components/TableSettings/SettingsForm'
 import { TileList } from 'app/_components/TileList'
@@ -79,33 +79,34 @@ function CreateBoardLocally() {
             </LeadParagraph>
             <div
                 data-transport-palette={board.transportPalette}
-                className="flex flex-col gap-4 rounded-md bg-tintLight px-6 py-8"
+                className="flex flex-col rounded-md bg-tintLight px-6 py-8"
             >
-                <Heading3 as="h2" margin="top">
-                    Hvilke stoppesteder vil du vise i tavlen?
-                </Heading3>
-                <TileSelector
-                    action={async (data: FormData) => {
-                        const tiles = formDataToTiles(data)
-                        setTiles([...board.tiles, ...tiles])
-                        resetPublishedBoard()
-                    }}
-                    trackingLocation="board_without_user"
-                />
-                <TileList
-                    board={board}
-                    setTilesLocalStorageBoard={(tiles) => {
-                        setTiles(tiles)
-                        resetPublishedBoard()
-                    }}
-                    bid={board.id}
-                />
-                <section
-                    data-theme={board.theme ?? 'dark'}
-                    aria-label="Forhåndsvisning av Tavla"
-                >
-                    <BoardPreview board={board} />
-                </section>
+                <Heading2 as="h2">{board.meta.title || 'Min tavle'}</Heading2>
+                <Heading3>Hvilke stoppesteder vil du vise i tavlen?</Heading3>
+                <div className="flex flex-col gap-4">
+                    <TileSelector
+                        action={async (data: FormData) => {
+                            const tiles = formDataToTiles(data)
+                            setTiles([...board.tiles, ...tiles])
+                            resetPublishedBoard()
+                        }}
+                        trackingLocation="board_without_user"
+                    />
+                    <TileList
+                        board={board}
+                        setTilesLocalStorageBoard={(tiles) => {
+                            setTiles(tiles)
+                            resetPublishedBoard()
+                        }}
+                        bid={board.id}
+                    />
+                    <section
+                        data-theme={board.theme ?? 'dark'}
+                        aria-label="Forhåndsvisning av Tavla"
+                    >
+                        <BoardPreview board={board} />
+                    </section>
+                </div>
             </div>
             {loaded && (
                 <SettingsForm board={board} onSubmit={handleSettingsSubmit} />


### PR DESCRIPTION
### 🥅 Bakgrunn
Som en bruker
Ønsker jeg å se navnet på tavlen på siden
Slik at jeg forstå hva som er hensikten med å ha et/endre navn på tavlen

### ✨ Løsning
- Legger inn navn med en `h2` øverst i grå boks
- Flytter på hvor `gap` settes 

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
|<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/d471cbda-d9e5-469a-9142-452f263d22b3" />|<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/e8f02317-0c74-4a74-96ec-ef262f527a4d" />|

### ✅ Sjekkliste

- [x] Testet i Chrome
- [x] Husket og testet UU
