### PR TITLE
🐛 Vent på log.write() i logToGcp så logger ikke forsvinner

### DIFF
--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -106,7 +106,7 @@ export async function logToGcp(
         { resource: { type: 'global' }, severity: safeLevel.toUpperCase() },
         buildPayload(safeMessage, extra),
     )
-    log.write(entry).catch((error) => {
+    await log.write(entry).catch((error) => {
         if (process.env.NODE_ENV === 'development') {
             // biome-ignore lint/suspicious/noConsole: Local logging in dev for why logging failed. Fail silently in prod.
             console.error('GCP logging failed:', error)


### PR DESCRIPTION
## 🥅 Bakgrunn
Logger dukket ikke opp i GCP etter at await ble fjernet fra kall til `logToGcp()`. Årsaken er at `log.write()` internt i `logToGcp()` aldri ble avventet og funksjonen returnerte umiddelbart, og GCP-loggingen ble ✨ abandonert ✨ av runtimen før responsen var sendt.

## ✨ Løsning
  - Legger til await på log.write(entry) inne i logToGcp, slik at funksjonen ikke
  returnerer før loggoppføringen faktisk er levert til GCP
  - Kall-steder trenger ikke å `await logToGcp()`