### PR TITLE
🔊 Tillat feilmeldinger i kubernetes på GCP logger i prod også

### DIFF
--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -107,9 +107,7 @@ export async function logToGcp(
         buildPayload(safeMessage, extra),
     )
     await log.write(entry).catch((error) => {
-        if (process.env.NODE_ENV === 'development') {
-            // biome-ignore lint/suspicious/noConsole: Local logging in dev for why logging failed. Fail silently in prod.
-            console.error('GCP logging failed:', error)
-        }
+        // biome-ignore lint/suspicious/noConsole: Log errors on GCP logging in container output.
+        console.error('GCP logging failed:', error)
     })
 }


### PR DESCRIPTION
### 🥅 Bakgrunn
GCP logger dukker opp i dev, men ikke i prod.

### ✨ Løsning
- Tillat feilmeldinger å skrives ut i prod på lik linje med dev for feilsøking.