### PR TITLE
✨🧹 trekker ut utils til egen fil, og legger til "stop" som reserved

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -18,6 +18,7 @@ import type {
     TransportPalette,
 } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
+import { validateCustomUrl } from './components/CustomUrl/utils'
 
 initializeAdminApp()
 
@@ -126,17 +127,8 @@ export async function saveCustomUrl(
 
     const trimmed = customUrl.trim()
 
-    if (trimmed && !/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
-        return {
-            error: 'Du kan kun bruke bokstaver (ikke æ, ø og å), tall, bindestrek og understrek.',
-        }
-    }
-
-    if (trimmed && /^preview/i.test(trimmed)) {
-        return {
-            error: 'Denne lenken kan ikke brukes.',
-        }
-    }
+    const validationError = validateCustomUrl(trimmed)
+    if (validationError) return { error: validationError }
 
     try {
         if (trimmed) {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
@@ -14,6 +14,7 @@ import { useRef, useState, useTransition } from 'react'
 import type { BoardDB } from 'types/db-types/boards'
 import { resolveVisTavlaBaseUrl } from 'utils/boardLink'
 import { saveCustomUrl } from '../../actions'
+import { validateCustomUrl } from './utils'
 
 function CustomUrl({
     bid,
@@ -39,13 +40,7 @@ function CustomUrl({
             posthog.capture('custom_url_modified', { location: 'board_page' })
         }, TRACKING_DEBOUNCE_TIME)
 
-        if (newValue && !/^[a-zA-Z0-9_-]*$/.test(newValue)) {
-            setFeedback(
-                'Du kan kun bruke bokstaver (ikke æ, ø og å), tall, bindestrek og understrek.',
-            )
-        } else {
-            setFeedback(undefined)
-        }
+        setFeedback(validateCustomUrl(newValue))
 
         setValue(newValue)
     }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/utils.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/utils.ts
@@ -1,0 +1,13 @@
+const RESERVED_SLUGS = /^(preview|stop)$/i
+const VALID_CHARS = /^[a-zA-Z0-9_-]+$/
+
+export function validateCustomUrl(value: string): string | undefined {
+    if (!value) return undefined
+    if (!VALID_CHARS.test(value)) {
+        return 'Du kan kun bruke bokstaver (ikke æ, ø og å), tall, bindestrek og understrek.'
+    }
+    if (RESERVED_SLUGS.test(value)) {
+        return 'Denne lenken kan ikke brukes.'
+    }
+    return undefined
+}


### PR DESCRIPTION
### 🥅 Bakgrunn
Et brukerønske er at man kan skrive inn lenke med snr-kode og få opp et defaultboard.

### ✨ Løsning

- Det meste av endringene skjer i tavla-visning, men vi ønsker å unngå at stop-kan brukes som selvvalgt url. 
- Trekker også ut begrensninger for customURL i egen util slik at vi ikke må skrive reglene to steder slik som det var. 
