### PR TITLE
🔊 Log flere feil og 404-sider til GCP

### DIFF
--- a/tavla/app/error.tsx
+++ b/tavla/app/error.tsx
@@ -6,16 +6,25 @@ import * as Sentry from '@sentry/nextjs'
 import BeaverIllustration from 'assets/illustrations/Beaver.png'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useEffect } from 'react'
+import { logToGcp } from 'src/utils/logging'
 
 export default function ErrorPage({
     error,
 }: {
     error: Error & { digest?: string }
 }) {
+    const path = usePathname()
+
     useEffect(() => {
         Sentry.captureException(error)
-    }, [error])
+        logToGcp('error', `GET Internal Server Error: ${error.message}`, {
+            status: 500,
+            path,
+        })
+    }, [error, path])
+
     return (
         <main className="container flex flex-col items-center pb-10">
             <Heading3>Au da! Noe gikk galt!</Heading3>

--- a/tavla/app/global-error.tsx
+++ b/tavla/app/global-error.tsx
@@ -6,15 +6,23 @@ import * as Sentry from '@sentry/nextjs'
 import BeaverIllustration from 'assets/illustrations/Beaver.png'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useEffect } from 'react'
+import { logToGcp } from 'utils/logging'
 
 export default function GlobalErrorPage({
     error,
 }: {
     error: Error & { digest?: string }
 }) {
+    const path = usePathname()
+
     useEffect(() => {
         Sentry.captureException(error)
+        logToGcp('error', `GET Internal Server Error: ${error.message}`, {
+            status: 500,
+            path,
+        })
     }, [error])
 
     return (

--- a/tavla/app/not-found.tsx
+++ b/tavla/app/not-found.tsx
@@ -1,10 +1,24 @@
+'use client'
+
 import { Button } from '@entur/button'
 import { Heading3 } from '@entur/typography'
 import BeaverIllustration from 'assets/illustrations/Beaver.png'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+import { logToGcp } from 'utils/logging'
 
-function Custom404() {
+export default function NotFound() {
+    const path = usePathname()
+
+    useEffect(() => {
+        logToGcp('warning', `GET Page Not Found`, {
+            status: 404,
+            path: path,
+        })
+    }, [path])
+
     return (
         <main className="container flex flex-col items-center pb-10">
             <Heading3>Denne siden finnes ikke!</Heading3>
@@ -20,5 +34,3 @@ function Custom404() {
         </main>
     )
 }
-
-export default Custom404

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -13,7 +13,12 @@ function getLog() {
     return _log
 }
 
-type LogExtra = { bid?: string; folderId?: string }
+type LogExtra = {
+    bid?: string
+    folderId?: string
+    status?: number
+    path?: string
+}
 
 type LogPayload = {
     message: string
@@ -24,6 +29,7 @@ type LogPayload = {
     status?: number
     bid?: string
     folderId?: string
+    path?: string
 }
 
 function buildPayload(message: string, extra?: LogExtra): LogPayload {
@@ -86,6 +92,8 @@ export async function logToGcp(
         ? {
               bid: sanitizeForLog(extra?.bid),
               folderId: sanitizeForLog(extra?.folderId),
+              status: extra?.status,
+              path: sanitizeForLog(extra?.path),
           }
         : undefined
 


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi ønsker enda mer detaljer om hva som skjer med tjenesten, spesielt når noe går galt eller at en side ikke finnes. 

### ✨ Løsning
- Legg til flere kall til logToGcp fra sidene det gjelder (global-error, error, not-found)
- Denne PR-en sikrer at alle gangene man får opp feilsiden (den med "Au da..") så blir det logget til GCP.
- `logging.ts`: La til `status?: number` og `path?: string`
- `not-found.tsx`, `error.tsx` og `global-error.tsx`: Path hentes fra Next sitt `usePathname()`