### PR TITLE
💬 Endre ord fra "landingsside" til "forside" der det brukes (feks i navbaren)

### DIFF
--- a/tavla/app/_components/MobileNavbar.tsx
+++ b/tavla/app/_components/MobileNavbar.tsx
@@ -47,7 +47,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                     <div className="pl-10">
                         <Link
                             href="/"
-                            aria-label="Tilbake til landingssiden"
+                            aria-label="Tilbake til forsiden"
                             onClick={() =>
                                 posthog.capture('go_to_home_page', {
                                     location: 'nav_bar',

--- a/tavla/app/_components/Navbar.tsx
+++ b/tavla/app/_components/Navbar.tsx
@@ -23,7 +23,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                 <Image
                     src={TavlaLogoBlue}
                     height={32}
-                    alt="Gå tilbake til landingssiden"
+                    alt="Gå tilbake til forsiden"
                 />
             </Link>
             <div className="flex shrink-0 flex-row items-center gap-4">


### PR DESCRIPTION
### 🥅 Bakgrunn
- Feil bruk av sidenavn å kalle forsiden for en landingsside, som kan være misvisende for skjermleserbrukere

### ✨ Løsning

- Endret navn fra forside til landingsside
- Valgte å beholde alt av  "landing page" i tracking  foreløpig for å ikke skape forvirring!

