### PR TITLE
🚸 Tilbakeknapp i publiseringsmodal for tavle uten bruker

### DIFF
--- a/tavla/app/(innlogget)/components/Login/Login.tsx
+++ b/tavla/app/(innlogget)/components/Login/Login.tsx
@@ -76,7 +76,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                     className="absolute right-4 top-4 flex flex-row gap-2"
                 >
                     <CloseIcon />
-                    <Label>Lukk</Label>
+                    <Label as="span">Lukk</Label>
                 </IconButton>
 
                 <Page page={pageParam as TLoginPage} />

--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -1,7 +1,14 @@
 'use client'
-import { PrimaryButton } from '@entur/button'
+import { IconButton, PrimaryButton } from '@entur/button'
+import { LeftArrowIcon } from '@entur/icons'
 import { Modal } from '@entur/modal'
-import { Heading1, Heading2, Heading3, LeadParagraph } from '@entur/typography'
+import {
+    Heading1,
+    Heading2,
+    Heading3,
+    Label,
+    LeadParagraph,
+} from '@entur/typography'
 import { CreateUserButton } from 'app/_components/CreateUserButton'
 import { SettingsForm } from 'app/_components/TableSettings/SettingsForm'
 import { TileList } from 'app/_components/TileList'
@@ -48,6 +55,10 @@ function CreateBoardLocally() {
     const resetPublishedBoard = useCallback(() => {
         setPublishState({ type: 'not-published' })
         setIsModalOpen(false)
+    }, [])
+
+    const resetToChoice = useCallback(() => {
+        setPublishState({ type: 'not-published' })
     }, [])
 
     const handleSettingsSubmit = useCallback(
@@ -124,6 +135,16 @@ function CreateBoardLocally() {
                 }}
                 title={getModalTitle(publishState)}
             >
+                {publishState.type === 'published' && (
+                    <IconButton
+                        aria-label="Tilbake"
+                        onClick={resetToChoice}
+                        className="absolute left-4 top-4 gap-2"
+                    >
+                        <LeftArrowIcon />
+                        <Label as="span">Tilbake</Label>
+                    </IconButton>
+                )}
                 <div className="w-full">
                     <PublishModalContent
                         publishState={publishState}
@@ -140,8 +161,6 @@ function getModalTitle(publishState: PublishBoardState) {
     switch (publishState.type) {
         case 'not-published':
             return 'Ferdig med tavla?'
-        case 'published':
-            return 'Din tavle er klar'
         case 'error':
             return 'Det skjedde en feil'
         default:

--- a/tavla/app/lag-tavle/components/PublishBoardModal.tsx
+++ b/tavla/app/lag-tavle/components/PublishBoardModal.tsx
@@ -2,7 +2,7 @@
 import { CopyableText } from '@entur/alert'
 import { PrimaryButton, SecondaryButton } from '@entur/button'
 import { LoadingDots } from '@entur/loader'
-import { Heading3, Paragraph } from '@entur/typography'
+import { Heading2, Heading3, Paragraph } from '@entur/typography'
 import { CreateUserButton } from 'app/_components/CreateUserButton'
 import type { PublishBoardState } from 'app/lag-tavle/components/CreateBoardLocally'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
@@ -82,8 +82,9 @@ export function PublishModalContent({
                 navigator.clipboard.writeText(boardLink)
             }
             return (
-                <>
-                    <Paragraph>
+                <div className="flex flex-col gap-4 pt-4">
+                    <Heading2 margin="none">Din tavle er klar</Heading2>
+                    <Paragraph margin="none">
                         Din tavle er nå klar! Kopier lenken og del den med andre
                         eller vis den på en skjerm.
                     </Paragraph>
@@ -115,7 +116,7 @@ export function PublishModalContent({
                             <ExternalIcon />
                         </PrimaryButton>
                     </div>
-                </>
+                </div>
             )
         }
         case 'error':


### PR DESCRIPTION
### 🥅 Bakgrunn

Som bruker som lager en tavle uten innlogging ønsker man å kunne ombestemme seg etter å ha valgt «Få lenke til tavla» — f.eks. for å velge «Opprett bruker» i stedet. Tidligere var det ingen vei tilbake.

### ✨ Løsning

- Legger til en «← Tilbake»-knapp absolutt posisjonert øverst til venstre i modalen (samme mønster som lukk-krysset øverst til høyre), synlig kun i `published`-tilstanden
- Tilbakeknappen tilbakestiller tilstanden til `not-published` uten å lukke modalen, slik at brukeren kan velge på nytt
- Fjerner modal-tittelen for `published`-tilstanden og tegner den manuelt i innholdet med nok toppmarg, slik at hover-bakgrunnen på tilbakeknappen ikke overlapper tittelen
- Fikser cursor-bug i `Label`-komponent brukt inni `IconButton`: `Label` renderer som `<label>`-element med `cursor: default` som overstyrte knappens `cursor: pointer` — løst med `as="span"` (gjelder også lukk-knappen i `Login.tsx`)

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="719" height="369" alt="image" src="https://github.com/user-attachments/assets/5cfb7f0d-b121-4d02-a783-39cabd899532" /> | <img width="719" height="369" alt="image" src="https://github.com/user-attachments/assets/2ef1f47b-cedf-46ce-bc09-f870a2d9b504" /> |

### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)