### PR TITLE
🔒 Legg til endepunkt for feilrapportering fra tavla-visning

### DIFF
--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { logToGcp } from 'src/utils/logging'
+import rateLimit from 'src/utils/rateLimit'
+import { z } from 'zod'
+
+const ALLOWED_ORIGINS = [
+    'https://vis-tavla.entur.no',
+    'https://vis-tavla.dev.entur.no',
+    'http://localhost:5173',
+]
+
+const ErrorCode = z.enum(['display_error', 'unknown'])
+
+const ReportSchema = z.object({
+    boardId: z.string().regex(/^[A-Za-z0-9]{20}$/),
+    errorCode: ErrorCode,
+})
+
+const ipLimiter = rateLimit({ maxUniqueTokens: 500, interval: 60000 })
+const boardLimiter = rateLimit({ maxUniqueTokens: 2000, interval: 60000 })
+
+function corsHeaders(origin: string): Record<string, string> {
+    if (!ALLOWED_ORIGINS.includes(origin)) return {}
+    return { 'Access-Control-Allow-Origin': origin }
+}
+
+export async function POST(req: NextRequest) {
+    const origin = req.headers.get('origin') ?? ''
+    const headers = corsHeaders(origin)
+
+    const body = await req.json().catch(() => null)
+    const parsed = ReportSchema.safeParse(body)
+    if (!parsed.success) {
+        return NextResponse.json({ error: 'invalid' }, { status: 400, headers })
+    }
+
+    const { boardId, errorCode } = parsed.data
+    const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
+
+    try {
+        await ipLimiter.check(new Response(), 100, ip)
+        await boardLimiter.check(new Response(), 5, boardId)
+    } catch {
+        logToGcp('warning', `POST /api/report-error: status=429 bid=${boardId}`)
+        return NextResponse.json(
+            { error: 'rate limited' },
+            { status: 429, headers },
+        )
+    }
+
+    await logToGcp(
+        'error',
+        `POST /api/report-error: status=200 errorCode=${errorCode}`,
+        { bid: boardId },
+    )
+
+    return NextResponse.json({ ok: true }, { headers })
+}
+
+export async function OPTIONS(req: NextRequest) {
+    const origin = req.headers.get('origin') ?? ''
+    if (!ALLOWED_ORIGINS.includes(origin)) {
+        return new NextResponse(null, { status: 204 })
+    }
+    return new NextResponse(null, {
+        status: 204,
+        headers: {
+            'Access-Control-Allow-Origin': origin,
+            'Access-Control-Allow-Methods': 'POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        },
+    })
+}

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -31,10 +31,30 @@ export async function POST(req: NextRequest) {
     const origin = req.headers.get('origin') ?? ''
     const headers = corsHeaders(origin)
 
+    const contentLength = Number(req.headers.get('Content-Length') ?? '0')
+    if (contentLength > 500) {
+        return NextResponse.json(
+            { error: 'invalid request' },
+            { status: 400, headers },
+        )
+    }
+
+    const contentType = req.headers.get('Content-Type') ?? ''
+    if (contentType !== 'application/json') {
+        return NextResponse.json(
+            { error: 'invalid request' },
+            { status: 400, headers },
+        )
+    }
+
     const body = await req.json().catch(() => null)
     const parsed = ReportSchema.safeParse(body)
+
     if (!parsed.success) {
-        return NextResponse.json({ error: 'invalid' }, { status: 400, headers })
+        return NextResponse.json(
+            { error: 'invalid request' },
+            { status: 400, headers },
+        )
     }
 
     const { boardId, errorCode } = parsed.data

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
     const contentLength = Number(req.headers.get('Content-Length') ?? '0')
     if (contentLength > 500) {
         return NextResponse.json(
-            { error: 'invalid request' },
+            { error: 'invalid request: Content-Length' },
             { status: 400, headers },
         )
     }
@@ -42,7 +42,7 @@ export async function POST(req: NextRequest) {
     const contentType = req.headers.get('Content-Type') ?? ''
     if (contentType !== 'application/json') {
         return NextResponse.json(
-            { error: 'invalid request' },
+            { error: 'invalid request: Content-Type' },
             { status: 400, headers },
         )
     }
@@ -73,8 +73,8 @@ export async function POST(req: NextRequest) {
 
     await logToGcp(
         'error',
-        `POST /api/report-error: status=200 errorCode=${errorCode}`,
-        { bid: boardId },
+        `[tavla-visning] ${errorCode} reported from ${boardId}`,
+        { bid: boardId, errorCode: errorCode },
     )
 
     return NextResponse.json({ ok: true }, { headers })

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -64,7 +64,6 @@ export async function POST(req: NextRequest) {
         await ipLimiter.check(new Response(), 100, ip)
         await boardLimiter.check(new Response(), 5, boardId)
     } catch {
-        logToGcp('warning', `POST /api/report-error: status=429 bid=${boardId}`)
         return NextResponse.json(
             { error: 'rate limited' },
             { status: 429, headers },

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -17,6 +17,8 @@ const ReportSchema = z.object({
     errorCode: ErrorCode,
 })
 
+//Limits live in the memory of the pods. These are not hard limits, but work as per-instance LRU limiters.
+//Good to keep in mind as it can be abused to spam logs, but the risk is low.
 const ipLimiter = rateLimit({ maxUniqueTokens: 500, interval: 60000 })
 const boardLimiter = rateLimit({ maxUniqueTokens: 2000, interval: 60000 })
 

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { logToGcp } from 'src/utils/logging'
 import rateLimit from 'src/utils/rateLimit'
+import { clientIp } from 'utils/clientIp'
 import { z } from 'zod'
 
 const ALLOWED_ORIGINS = [
@@ -35,7 +36,7 @@ export async function POST(req: NextRequest) {
     }
 
     const { boardId, errorCode } = parsed.data
-    const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
+    const ip = clientIp(req)
 
     try {
         await ipLimiter.check(new Response(), 100, ip)

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -47,6 +47,8 @@ export async function POST(req: NextRequest) {
         )
     }
 
+    const userAgent = req.headers.get('User-Agent') ?? 'unknown User-Agent'
+
     const body = await req.json().catch(() => null)
     const parsed = ReportSchema.safeParse(body)
 
@@ -73,7 +75,7 @@ export async function POST(req: NextRequest) {
     await logToGcp(
         'error',
         `[tavla-visning] ${errorCode} reported from ${boardId}`,
-        { bid: boardId, errorCode: errorCode },
+        { bid: boardId, errorCode: errorCode, userAgent: userAgent },
     )
 
     return NextResponse.json({ ok: true }, { headers })

--- a/tavla/app/api/report-error/route.ts
+++ b/tavla/app/api/report-error/route.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 const ALLOWED_ORIGINS = [
     'https://vis-tavla.entur.no',
     'https://vis-tavla.dev.entur.no',
-    'http://localhost:5173',
+    ...(process.env.NODE_ENV !== 'production' ? ['http://localhost:5173'] : []),
 ]
 
 const ErrorCode = z.enum(['display_error', 'unknown'])

--- a/tavla/src/utils/clientIp.ts
+++ b/tavla/src/utils/clientIp.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from 'next/server'
+
+// Google Cloud Load Balancer appends the real client IP as the rightmost entry in XFF
+// Assumtion: GCLB sits right infront of the application. If anything else proxies the request,
+// update proxyDepth accordingly.
+// Everything left of this appended IP is client controlled and not to be trusted.
+const PROXY_DEPTH = 1
+
+export function clientIp(req: NextRequest): string {
+    const xff = req.headers.get('x-forwarded-for') ?? ''
+    const parts = xff
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+    return parts[parts.length - PROXY_DEPTH] ?? 'unknown'
+}

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -19,6 +19,7 @@ type LogExtra = {
     status?: number
     path?: string
     errorCode?: string
+    userAgent?: string
 }
 
 type LogType = 'server-action' | 'http' | 'graphql' | 'tavla-visning'
@@ -111,6 +112,7 @@ export async function logToGcp(
               status: extra?.status,
               path: sanitizeForLog(extra?.path),
               errorCode: sanitizeForLog(extra?.errorCode),
+              userAgent: sanitizeForLog(extra?.userAgent),
           }
         : undefined
 

--- a/tavla/src/utils/logging.ts
+++ b/tavla/src/utils/logging.ts
@@ -18,11 +18,14 @@ type LogExtra = {
     folderId?: string
     status?: number
     path?: string
+    errorCode?: string
 }
+
+type LogType = 'server-action' | 'http' | 'graphql' | 'tavla-visning'
 
 type LogPayload = {
     message: string
-    type?: 'server-action' | 'http' | 'graphql'
+    type?: LogType
     action?: string
     method?: string
     endpoint?: string
@@ -32,7 +35,19 @@ type LogPayload = {
     path?: string
 }
 
-function buildPayload(message: string, extra?: LogExtra): LogPayload {
+function buildPayload(
+    message: string,
+    extra?: LogExtra,
+    type?: LogType,
+): LogPayload {
+    if (type) {
+        return {
+            message,
+            type: 'tavla-visning',
+            ...extra,
+        }
+    }
+
     const actionMatch = message.match(/^action:(\w+)/)
     if (actionMatch) {
         return {
@@ -84,6 +99,7 @@ export async function logToGcp(
     level: LogLevel,
     message: string,
     extra?: LogExtra,
+    type?: LogType,
 ) {
     const safeLevel = sanitizeForLog(level) as LogLevel
     const safeMessage = sanitizeForLog(message)
@@ -94,6 +110,7 @@ export async function logToGcp(
               folderId: sanitizeForLog(extra?.folderId),
               status: extra?.status,
               path: sanitizeForLog(extra?.path),
+              errorCode: sanitizeForLog(extra?.errorCode),
           }
         : undefined
 
@@ -112,7 +129,7 @@ export async function logToGcp(
 
     const entry = log.entry(
         { resource: { type: 'global' }, severity: safeLevel.toUpperCase() },
-        buildPayload(safeMessage, extra),
+        buildPayload(safeMessage, extra, type),
     )
     await log.write(entry).catch((error) => {
         // biome-ignore lint/suspicious/noConsole: Log errors on GCP logging in container output.


### PR DESCRIPTION
### 🥅 Bakgrunn

  tavla-visning er mer kritisk enn tavla-admin, og per i dag er det ingen logging. I motsetning til
  tavla-admin, så er tavla-visning mye enklere, og har ikke støtte for Sentry eller strukturert logging, noe som gjør det vanskelig å oppdage klientfeil på tavlene som kjører rundt omkring.

  ### ✨ Løsning
Jeg undersøkte en del og kom fram til at det enkleste, og lureste her for å få logging og validering i gang er å sette opp et åpent endepunkt som tavla-visning can sende requests til. 😱 I know, I know. Jeg liker det ikke _helt_ fra et sikkerhetsperspektiv, men med veldig minimal body i requesten og streng validering + sanitering til logger uten at den går mot noe database osv så tenker jeg at dette er bra nok. Åpen kildekode gjør det trivielt å backwards engineere hva som foregår i Tavla, men dette hjelper nok veldig med å holde det greit og trygt 🔐 Jeg kan stå bak en løsning som bruker åpent endepunkt her hvertfall ✋, men om det er noen spørsmål / innvendinger så tar vi gjerne en diskusjon på det 🤓 Jeg er veldig glad i sikkerhet!

  - Nytt API-endepunkt `POST /api/report-error` i tavla-admin som tar imot strukturerte feilmeldinger fra
   tavla-visning
  - Payload er minimal: kun `boardId` (20-tegns alfanumerisk) og `errorCode` (fast enum:
  `display_error` | `unknown`)
  - Feil logges til GCP via eksisterende `logToGcp`-util
  - Sikkerhetstiltak mot åpent endepunkt:
    - Zod-validering avviser alt som ikke matcher schema (400)
    - Rate-limit: per IP (100/min) og per boardId (5/min) 👈 tallene kan endres, er bare forslag fra claudern, men synes det høres greit ut
    - CORS begrenser caller til `vis-tavla.entur.no`, `vis-tavla.dev.entur.no` og localhost (ikke sikkerhetstiltak men heller for ordens skyld at det ikke er dritlett å sende requests på egenhånd)
    - boardId-format validert med regex
    - Ingen verifisering mot Firestore (unngår timing-lekkasje og unødvendige DB-oppslag)

Da kan tavla-visning gjøre det så enkelt som å
```ts
  fetch('https://tavla.entur.no/api/report-error', {
      method: 'POST',
      headers: { 'Content-Type': 'application/json' },
      body: JSON.stringify({ boardId, errorCode: 'display_error' }),
  }).catch(function() {}) // fire-and-forget
```
for å sende en feilmelding slik at det dukker opp hos oss.

### 📸 Bilder

<img width="1461" height="302" alt="image" src="https://github.com/user-attachments/assets/bea4b3ac-83b6-49b3-8733-a1e8a15baf72" />

<img width="744" height="261" alt="image" src="https://github.com/user-attachments/assets/4804725e-d983-4cdd-a058-16dcad7a3ef0" />


