### PR TITLE
🔧 Oppdater package.json "yarn emulators"-script til å ikke lagre i hver sin mappe på export

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "dev": "next dev & firebase emulators:start --only auth,firestore,storage --project=ent-tavla-dev",
         "dev:persist": "next dev & yarn emulators",
-        "emulators": "firebase emulators:start --only auth,firestore,storage --project=ent-tavla-dev --import=./.db --export-on-exit",
+        "emulators": "firebase emulators:start --only auth,firestore,storage --project=ent-tavla-dev --import=./.db --export-on-exit=./.db",
         "build": "next build",
         "build:prod": "NEXT_PUBLIC_ENV=prod next build",
         "typecheck": "tsc --noEmit --incremental false",


### PR DESCRIPTION
### 🥅 Bakgrunn
Som utvikler som jobber med lokal Firebase-emulator 
Ønsker jeg at yarn dev:persist faktisk lagrer tilstanden tilbake til .db-mappen når emulatoren stoppes
Slik at endringer jeg gjør lokalt ikke forsvinner og jeg ikke akkumulerer et hav av firebase-export-*-mapper i repoet.

### ✨ Løsning
Endre emulators-scriptet i tavla/package.json fra:

```
--import=./.db --export-on-exit
```
til:
```
--import=./.db --export-on-exit=./.db
```

### 📝 Akseptansekriterier

`yarn dev:persist` lager ikke nye `firebase-export-*`-mappene i tavla/ ved stopp

Data opprettet i én sesjon er tilgjengelig i neste sesjon etter `yarn dev:persist`

`yarn dev` (uten persist) er upåvirket

### Fikset dette noe?

Før endring:

i  Automatically exporting data using --export-on-exit "./.db" please wait for the export to finish...
i  Exporting data to: /Users/ola/Documents/Spire/Entur/tavla/tavla/.db
i  emulators: Received export request. Exporting data to /Users/ola/Documents/Spire/Entur/tavla/tavla/.db.

Etter endring:

i  Automatically exporting data using --export-on-exit "./.db" please wait for the export to finish...
i  Exporting data to: /Users/ola/Documents/Spire/Entur/tavla/tavla/.db
i  emulators: Received export request. Exporting data to /Users/ola/Documents/Spire/Entur/tavla/tavla/.db.

### Det vi har kommet fram til 👇 
Det ser ikke ut fra docs eller testing selv at dette er nødvendig, og tiltenkt funksjonalitet fra emulators er at dette allerede er håndtert. Det skader hvertfall ikke å legge det til for å være enda mer eksplisitt, men det burde kanskje gjøres en grundigere sjekk i framtiden for om det finnes en god løsning for dette. Vi har ikke fått reprodusert disse `firebase-export-xxx`-mappene.