### PR TITLE
📈 DEL 1: Endrer format på Heartbeat så vi kan få oversikt over hvilke tavletyper som er aktive

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,14 +42,11 @@ pub struct Metrics {
     pub active_boards: Gauge,
 }
 
+
 #[derive(Serialize, Deserialize, Clone)]
 pub enum BoardType {
     #[serde(rename = "departure")]
     Departure,
-    #[serde(rename = "anonymousDeparture")]
-    AnonymousDeparture,
-    #[serde(rename = "arrival")]
-    Arrival,
     #[serde(rename = "directLink")]
     DirectLink,
 }
@@ -62,7 +59,7 @@ struct HeartbeatPayload {
     screen_width: u32,
     screen_height: u32,
     app: Option<String>,
-    boardtype: BoardType,
+    boardtype: Option<BoardType>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -73,7 +70,7 @@ pub struct ActiveInfo {
     pub screen_width: u32,
     pub screen_height: u32,
     pub app: Option<String>,
-    pub boardtype: BoardType,
+    pub boardtype: Option<BoardType>,
 }
 
 #[tokio::main]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,7 +42,6 @@ pub struct Metrics {
     pub active_boards: Gauge,
 }
 
-
 #[derive(Serialize, Deserialize, Clone)]
 pub enum BoardType {
     #[serde(rename = "departure")]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,14 +42,6 @@ pub struct Metrics {
     pub active_boards: Gauge,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub enum BoardType {
-    #[serde(rename = "departure")]
-    Departure,
-    #[serde(rename = "directLink")]
-    DirectLink,
-}
-
 #[derive(Serialize, Deserialize)]
 struct HeartbeatPayload {
     bid: String,
@@ -58,7 +50,7 @@ struct HeartbeatPayload {
     screen_width: u32,
     screen_height: u32,
     app: Option<String>,
-    board_type: Option<BoardType>,
+    is_direct_link: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -69,7 +61,7 @@ pub struct ActiveInfo {
     pub screen_width: u32,
     pub screen_height: u32,
     pub app: Option<String>,
-    pub board_type: Option<BoardType>,
+    pub is_direct_link: Option<bool>,
 }
 
 #[tokio::main]
@@ -391,7 +383,7 @@ async fn heartbeat(State(state): State<AppState>, body: String) -> Result<Status
             screen_width: payload.screen_width,
             screen_height: payload.screen_height,
             app: payload.app,
-            board_type: payload.board_type,
+            is_direct_link: payload.is_direct_link,
         }),
     )?;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -50,6 +50,7 @@ struct HeartbeatPayload {
     screen_width: u32,
     screen_height: u32,
     app: Option<String>,
+    boardtype: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -60,6 +61,7 @@ pub struct ActiveInfo {
     pub screen_width: u32,
     pub screen_height: u32,
     pub app: Option<String>,
+    pub boardtype: String,
 }
 
 #[tokio::main]
@@ -381,6 +383,7 @@ async fn heartbeat(State(state): State<AppState>, body: String) -> Result<Status
             screen_width: payload.screen_width,
             screen_height: payload.screen_height,
             app: payload.app,
+            boardtype: payload.boardtype,
         }),
     )?;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -58,7 +58,7 @@ struct HeartbeatPayload {
     screen_width: u32,
     screen_height: u32,
     app: Option<String>,
-    boardtype: Option<BoardType>,
+    board_type: Option<BoardType>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -69,7 +69,7 @@ pub struct ActiveInfo {
     pub screen_width: u32,
     pub screen_height: u32,
     pub app: Option<String>,
-    pub boardtype: Option<BoardType>,
+    pub board_type: Option<BoardType>,
 }
 
 #[tokio::main]
@@ -391,7 +391,7 @@ async fn heartbeat(State(state): State<AppState>, body: String) -> Result<Status
             screen_width: payload.screen_width,
             screen_height: payload.screen_height,
             app: payload.app,
-            boardtype: payload.boardtype,
+            board_type: payload.board_type,
         }),
     )?;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,6 +42,18 @@ pub struct Metrics {
     pub active_boards: Gauge,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+pub enum BoardType {
+    #[serde(rename = "departure")]
+    Departure,
+    #[serde(rename = "anonymousDeparture")]
+    AnonymousDeparture,
+    #[serde(rename = "arrival")]
+    Arrival,
+    #[serde(rename = "directLink")]
+    DirectLink,
+}
+
 #[derive(Serialize, Deserialize)]
 struct HeartbeatPayload {
     bid: String,
@@ -50,7 +62,7 @@ struct HeartbeatPayload {
     screen_width: u32,
     screen_height: u32,
     app: Option<String>,
-    boardtype: String,
+    boardtype: BoardType,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -61,7 +73,7 @@ pub struct ActiveInfo {
     pub screen_width: u32,
     pub screen_height: u32,
     pub app: Option<String>,
-    pub boardtype: String,
+    pub boardtype: BoardType,
 }
 
 #[tokio::main]

--- a/tavla/firebaseFunctions/src/backendUtils.ts
+++ b/tavla/firebaseFunctions/src/backendUtils.ts
@@ -7,7 +7,7 @@ type SingleActiveBoardFromRedis = {
     browser: string
     screen_width: number
     screen_height: number
-    boardtype?: 'departure' | 'directLink'
+    board_type?: 'departure' | 'directLink'
 }
 
 type ActiveBoardsFromRedis = {

--- a/tavla/firebaseFunctions/src/backendUtils.ts
+++ b/tavla/firebaseFunctions/src/backendUtils.ts
@@ -7,6 +7,7 @@ type SingleActiveBoardFromRedis = {
     browser: string
     screen_width: number
     screen_height: number
+    boardtype: string
 }
 
 type ActiveBoardsFromRedis = {

--- a/tavla/firebaseFunctions/src/backendUtils.ts
+++ b/tavla/firebaseFunctions/src/backendUtils.ts
@@ -7,7 +7,7 @@ type SingleActiveBoardFromRedis = {
     browser: string
     screen_width: number
     screen_height: number
-    boardtype: 'departure' | 'anonymousDeparture' | 'arrival' | 'directLink'
+    boardtype?: 'departure' | 'directLink'
 }
 
 type ActiveBoardsFromRedis = {

--- a/tavla/firebaseFunctions/src/backendUtils.ts
+++ b/tavla/firebaseFunctions/src/backendUtils.ts
@@ -7,7 +7,7 @@ type SingleActiveBoardFromRedis = {
     browser: string
     screen_width: number
     screen_height: number
-    board_type?: 'departure' | 'directLink'
+    isDirectLink?: boolean
 }
 
 type ActiveBoardsFromRedis = {

--- a/tavla/firebaseFunctions/src/backendUtils.ts
+++ b/tavla/firebaseFunctions/src/backendUtils.ts
@@ -7,7 +7,7 @@ type SingleActiveBoardFromRedis = {
     browser: string
     screen_width: number
     screen_height: number
-    boardtype: string
+    boardtype: 'departure' | 'anonymousDeparture' | 'arrival' | 'directLink'
 }
 
 type ActiveBoardsFromRedis = {


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi har nå flere ulike tavletyper, og det kan være nyttig å sende med metadata i heartbeat for å si noe om hva slags tavle som er oppe.

### ✨ Løsning
- Legger til boartype i heartbeat-payload. I førsteomgang er dette enten departure eller directLink.
- Feltet er foreløpig optional. Burde settes til ikke optional senere
- [Finnes en tilsvarende PR i tavla-visning](https://github.com/entur/tavla-visning/pull/104). PR-en i tavla bør merges først.

### ✅ Sjekkliste

- [ ] Oppdatert dokumentasjon (hvis relevant)
