### PR TITLE
📈 Del 2: Sender med boardType til Heartbeat - tvungent å ha med board_type

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -58,7 +58,7 @@ struct HeartbeatPayload {
     screen_width: u32,
     screen_height: u32,
     app: Option<String>,
-    board_type: Option<BoardType>,
+    board_type: BoardType,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -69,7 +69,7 @@ pub struct ActiveInfo {
     pub screen_width: u32,
     pub screen_height: u32,
     pub app: Option<String>,
-    pub board_type: Option<BoardType>,
+    pub board_type: BoardType,
 }
 
 #[tokio::main]

--- a/tavla/firebaseFunctions/src/backendUtils.ts
+++ b/tavla/firebaseFunctions/src/backendUtils.ts
@@ -7,7 +7,7 @@ type SingleActiveBoardFromRedis = {
     browser: string
     screen_width: number
     screen_height: number
-    board_type?: 'departure' | 'directLink'
+    board_type: 'departure' | 'directLink'
 }
 
 type ActiveBoardsFromRedis = {


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi har nå flere ulike tavletyper, og det kan være nyttig å sende med metadata i heartbeat for å si noe om hva slags tavle som er oppe. For å unngå eventuelt trøbbel gjør [del 1 board_type optional](https://github.com/entur/tavla/pull/2486/changes), mens denne setter board_type til tvungen.

### ✨ Løsning

- Setter board_type til ikke-optional

Merges etter del 1- oppgavene i tavla og tavla-visning

### ✅ Sjekkliste

- [ ] Oppdatert dokumentasjon (hvis relevant)
