### PR TITLE
🪵 Fjern bruker-id fra Sentry-feilmeldinger

### DIFF
--- a/tavla/app/(innlogget)/actions.ts
+++ b/tavla/app/(innlogget)/actions.ts
@@ -125,7 +125,7 @@ export async function getFoldersForUser(): Promise<Folder[]> {
             `Failed to fetch folders: ${error instanceof Error ? error.message : String(error)}`,
         )
         Sentry.captureMessage(
-            'Error while fetching folders for user with id ' + user.uid,
+            `Failed to fetch folders: ${error instanceof Error ? error.message : String(error)}`,
         )
         throw error
     }
@@ -247,12 +247,16 @@ export async function getPrivateBoardsForUser(folders: FolderDB[]) {
     const rawOwner = userWithBoards.owner ?? []
 
     if (!Array.isArray(rawOwner)) {
+        logToGcp(
+            'warning',
+            'Invalid owner field type in getPrivateBoardsForUser',
+            { folderId: folders[0]?.id },
+        )
         Sentry.captureMessage(
             'Invalid owner field type in getPrivateBoardsForUser',
             {
                 level: 'warning',
                 extra: {
-                    userId: userWithBoards.uid,
                     ownerType: typeof rawOwner,
                 },
             },

--- a/tavla/app/(innlogget)/components/CreateBoard/actions.ts
+++ b/tavla/app/(innlogget)/components/CreateBoard/actions.ts
@@ -51,12 +51,12 @@ export async function createBoardAction(
         logToGcp(
             'error',
             `Failed to create board: ${error instanceof Error ? error.message : String(error)}`,
+            { folderId: folderid },
         )
         Sentry.captureException(error, {
             extra: {
                 message:
                     'Error while adding newly created board to either user or folder',
-                userID: user.uid,
                 folderID: folderid,
             },
         })

--- a/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
+++ b/tavla/app/(innlogget)/components/DeleteAccount/actions.ts
@@ -17,7 +17,7 @@ import { logout } from '../Login/actions'
 
 export async function deleteAccount(data: FormData) {
     const user = await getUserFromSessionCookie()
-    if (!user || !user.uid) {
+    if (!user?.uid) {
         return getFormFeedbackForError('auth/operation-not-allowed')
     }
     logToGcp('info', 'action:deleteAccount invoked')
@@ -42,7 +42,6 @@ export async function deleteAccount(data: FormData) {
         Sentry.captureException(error, {
             extra: {
                 message: 'Error while deleting user account',
-                userID: user.uid,
             },
         })
         return getFormFeedbackForError('firebase/general')

--- a/tavla/app/(innlogget)/components/Login/Google.tsx
+++ b/tavla/app/(innlogget)/components/Login/Google.tsx
@@ -16,6 +16,7 @@ import {
 import Image from 'next/image'
 import { useState } from 'react'
 import { getClientApp } from 'src/utils/firebase'
+import { logToGcp } from 'utils/logging'
 import { create, login } from './actions'
 
 type Props = {
@@ -62,6 +63,10 @@ export default function Google({
                     'Endre denne innstillingen i nettleseren din for å logge på med Google.',
                 ])
             } else {
+                logToGcp(
+                    'error',
+                    `Error while creating new user with Google sign in`,
+                )
                 Sentry.captureException(error, {
                     extra: {
                         message:

--- a/tavla/app/(innlogget)/components/Login/actions.ts
+++ b/tavla/app/(innlogget)/components/Login/actions.ts
@@ -55,7 +55,6 @@ export async function create(uid: UserDB['uid']) {
         Sentry.captureException(error, {
             extra: {
                 message: 'Error while creating new user',
-                userID: uid,
             },
         })
         throw error

--- a/tavla/app/(innlogget)/mapper/[id]/page.tsx
+++ b/tavla/app/(innlogget)/mapper/[id]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata(props: TProps): Promise<Metadata> {
     const { id } = params
     const folder = await getFolder(id)
 
-    if (!folder || !folder.id) {
+    if (!folder?.id) {
         return notFound()
     }
     return {
@@ -56,11 +56,11 @@ async function getAuthenticatedUsers(
 
 async function FolderPage(props: TProps) {
     const user = await getUserFromSessionCookie()
-    if (!user || !user.uid) return redirect('/')
+    if (!user?.uid) return redirect('/')
 
     const params = await props.params
     const folder = await getFolder(params.id)
-    if (!folder || !folder.id) {
+    if (!folder?.id) {
         return notFound()
     }
     const boardsInFolder = await getBoardsForFolder(folder.id)

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
@@ -41,7 +41,6 @@ export async function removeUserAction(
             extra: {
                 message: 'Error while removing user from folder',
                 folderID: folderId,
-                userID: uid,
             },
         })
         return handleError(error)
@@ -80,7 +79,7 @@ export async function inviteUserAction(
         await addOwnerToFolder(folderid, invitee.uid)
         revalidatePath('/')
     } catch (error) {
-        const user = await getUserFromSessionCookie()
+        const _user = await getUserFromSessionCookie()
 
         logToGcp(
             'error',
@@ -93,7 +92,6 @@ export async function inviteUserAction(
             extra: {
                 message: 'Error while inviting user to folder',
                 folderID: folderid,
-                inviteeID: invitee.uid,
             },
         })
         return handleError(error)

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/actions.ts
@@ -15,7 +15,6 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { addOwnerToFolder } from 'src/firebase'
 import { logToGcp } from 'src/utils/logging'
-import { getUserFromSessionCookie } from '../../../utils/server'
 
 export async function removeUserAction(
     _prevState: TFormFeedback | undefined,
@@ -79,8 +78,6 @@ export async function inviteUserAction(
         await addOwnerToFolder(folderid, invitee.uid)
         revalidatePath('/')
     } catch (error) {
-        const _user = await getUserFromSessionCookie()
-
         logToGcp(
             'error',
             `Failed to invite user to folder: ${error instanceof Error ? error.message : String(error)}`,

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/utils.ts
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/utils.ts
@@ -4,7 +4,7 @@ export function getFilename(logoUrl?: string) {
 
     const file = logoUrl.match(regex)
 
-    if (!file || !file[1]) return ''
+    if (!file?.[1]) return ''
 
     return file[1]
 }

--- a/tavla/app/(innlogget)/oversikt/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/actions.ts
@@ -36,7 +36,6 @@ export async function saveBoardToFirebaseForUser(
             extra: {
                 message:
                     'Error while saving board from localStorage to firebase for user',
-                userID: user.uid,
             },
         })
         throw new Error('Failed to save board from localStorage to firebase', {

--- a/tavla/app/(innlogget)/oversikt/utils/actions.ts
+++ b/tavla/app/(innlogget)/oversikt/utils/actions.ts
@@ -97,7 +97,8 @@ export async function moveBoardAction(data: FormData) {
     } catch (e) {
         logToGcp(
             'error',
-            `Failed to move board ${bid}: ${e instanceof Error ? e.message : String(e)}`,
+            `Failed to move board: ${e instanceof Error ? e.message : String(e)}`,
+            { bid },
         )
         Sentry.captureException(e, {
             extra: {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -48,7 +48,8 @@ export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to save tile to board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save tile to board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureMessage(
             'Failed to save tile to board in firestore. BoardID: ' + bid,
@@ -97,7 +98,8 @@ export async function saveUpdatedTileOrder(
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to save tile order for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save tile order for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {
@@ -141,7 +143,8 @@ export async function saveCustomUrl(
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to save custom URL for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save custom URL for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -15,7 +15,7 @@ import { logToGcp } from 'src/utils/logging'
 initializeAdminApp()
 
 export async function duplicateBoard(
-    board: Omit<BoardDB, 'id'>,
+    board: BoardDB,
     folderid?: FolderDB['id'],
 ) {
     const user = await getUserFromSessionCookie()
@@ -49,6 +49,7 @@ export async function duplicateBoard(
         logToGcp(
             'error',
             `Failed to duplicate board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid: board.id },
         )
         Sentry.captureMessage('Error while duplicating board object: ' + board)
         throw error

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/DuplicateBoard/actions.ts
@@ -15,7 +15,7 @@ import { logToGcp } from 'src/utils/logging'
 initializeAdminApp()
 
 export async function duplicateBoard(
-    board: BoardDB,
+    board: Omit<BoardDB, 'id'>,
     folderid?: FolderDB['id'],
 ) {
     const user = await getUserFromSessionCookie()
@@ -49,7 +49,6 @@ export async function duplicateBoard(
         logToGcp(
             'error',
             `Failed to duplicate board: ${error instanceof Error ? error.message : String(error)}`,
-            { bid: board.id },
         )
         Sentry.captureMessage('Error while duplicating board object: ' + board)
         throw error

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -104,7 +104,8 @@ export async function saveSettings(data: FormData) {
 
         logToGcp(
             'error',
-            `Failed to save settings for board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to save settings for board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureException(error, {
             extra: { message: 'Error while saving settings', boardID: bid },

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata(props: TProps): Promise<Metadata> {
 export default async function EditPage(props: TProps) {
     const params = await props.params
     const user = await getUserFromSessionCookie()
-    if (!user || !user.uid) return redirect('/')
+    if (!user?.uid) return redirect('/')
 
     const board = await getBoard(params.id)
     if (!board) {

--- a/tavla/app/(innlogget)/utils/firebase.ts
+++ b/tavla/app/(innlogget)/utils/firebase.ts
@@ -41,7 +41,7 @@ export async function verifySession(session?: string) {
 
 export async function revokeUserTokenOnLogout() {
     const user = await getUserFromSessionCookie()
-    if (!user || !user.uid) {
+    if (!user?.uid) {
         return null
     }
     try {
@@ -61,15 +61,13 @@ export async function getUserWithBoardIds(): Promise<UserDB | null> {
     }
     const parsedUser = UserDBSchema.safeParse(userData)
     if (!parsedUser.success) {
-        Sentry.captureMessage(
-            'User data validation failed for user:' + userDoc.id,
-            {
-                level: 'warning',
-                extra: {
-                    error: parsedUser.error,
-                },
+        logToGcp('warning', `User data validation failed: ${parsedUser.error}`)
+        Sentry.captureMessage('User data validation failed', {
+            level: 'warning',
+            extra: {
+                error: parsedUser.error,
             },
-        )
+        })
         return null
     }
     return parsedUser.data
@@ -107,7 +105,8 @@ export async function deleteBoard(bid: BoardDB['id']) {
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to delete board ${bid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to delete board: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
         )
         Sentry.captureMessage('Failed to delete board with id: ' + bid)
         throw error
@@ -151,7 +150,8 @@ export async function deleteFolderBoard(
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to delete board ${bid} in folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to delete board in folder: ${error instanceof Error ? error.message : String(error)}`,
+            { folderId: folderid, bid },
         )
         Sentry.captureMessage(
             'Erorr while deleting board ' + bid + ' in folder ' + folderid,
@@ -166,10 +166,11 @@ export async function removeUserFromFolder(folderid: string, uid: string) {
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to remove user from folder ${folderid}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to remove user from folder: ${error instanceof Error ? error.message : String(error)}`,
+            { folderId: folderid },
         )
         Sentry.captureMessage(
-            'Error while removing user ' + uid + ' from folder ' + folderid,
+            'Error while removing user from folder ' + folderid,
         )
         throw error
     }
@@ -177,7 +178,7 @@ export async function removeUserFromFolder(folderid: string, uid: string) {
 
 export async function deleteUserFromFirebaseAuth() {
     const user = await getUserFromSessionCookie()
-    if (!user || !user.uid) {
+    if (!user?.uid) {
         return
     }
     try {
@@ -187,16 +188,14 @@ export async function deleteUserFromFirebaseAuth() {
             'error',
             `Failed to delete user from Firebase Auth: ${error instanceof Error ? error.message : String(error)}`,
         )
-        Sentry.captureMessage(
-            'Error while deleting user ' + user?.uid + ' from firebase auth',
-        )
+        Sentry.captureMessage('Error while deleting user from firebase auth')
         throw error
     }
 }
 
 export async function deleteUserFromFirestore() {
     const user = await getUserFromSessionCookie()
-    if (!user || !user.uid) {
+    if (!user?.uid) {
         return
     }
     try {
@@ -206,9 +205,7 @@ export async function deleteUserFromFirestore() {
             'error',
             `Failed to delete user from Firestore: ${error instanceof Error ? error.message : String(error)}`,
         )
-        Sentry.captureMessage(
-            'Error while deleting user ' + user?.uid + ' from firestore',
-        )
+        Sentry.captureMessage('Error while deleting user from firestore')
         throw error
     }
 }

--- a/tavla/app/(innlogget)/utils/position.ts
+++ b/tavla/app/(innlogget)/utils/position.ts
@@ -5,7 +5,7 @@ import type { GeoCoordinate, StopPlace } from './fetch'
 export async function getCurrentPosition(
     options?: PositionOptions,
 ): Promise<GeolocationPosition> {
-    if (!navigator || !navigator.geolocation) {
+    if (!navigator?.geolocation) {
         throw new Error('navigator.geolocation is not defined')
     }
 

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -5,7 +5,7 @@ export function sortLineByPublicCode(
     a: LineWithFrontText,
     b: LineWithFrontText,
 ) {
-    if (!a || !a.publicCode || !b || !b.publicCode) return 1
+    if (!a?.publicCode || !b?.publicCode) return 1
 
     const containsLetters = /[a-zæøåA-ZÆØÅ]/
     const aContainsLetters = containsLetters.test(a.publicCode)

--- a/tavla/app/_components/actions.ts
+++ b/tavla/app/_components/actions.ts
@@ -121,7 +121,7 @@ async function postForm(_prevState: TFormFeedback | undefined, data: FormData) {
     } catch (error) {
         logToGcp(
             'error',
-            `Failed to submit contact form: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to submit contact form: ${error instanceof Error ? error.message : String(error)} (form message: ${message})`,
         )
         Sentry.captureException(error, {
             extra: {

--- a/tavla/app/api/upload/route.ts
+++ b/tavla/app/api/upload/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
     const user = await getUserFromSessionCookie()
     const response = new Response()
     response.headers.set('Content-Type', 'application/json')
-    if (!user || !user.uid) {
+    if (!user?.uid) {
         logToGcp('warning', 'POST /api/upload: status=401 reason=invalid-token')
         return new Response(JSON.stringify({ error: 'Invalid token' }), {
             status: 401,

--- a/tavla/app/global-error.tsx
+++ b/tavla/app/global-error.tsx
@@ -23,7 +23,7 @@ export default function GlobalErrorPage({
             status: 500,
             path,
         })
-    }, [error])
+    }, [error, path])
 
     return (
         <html lang="no">

--- a/tavla/biome.json
+++ b/tavla/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/tavla/instrumentation.ts
+++ b/tavla/instrumentation.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/nextjs'
-
 export async function register() {
     if (process.env.NEXT_RUNTIME === 'nodejs') {
         await import('./sentry.server.config')
@@ -9,5 +7,3 @@ export async function register() {
         await import('./sentry.edge.config')
     }
 }
-
-export const onRequestError = Sentry.captureRequestError

--- a/tavla/src/firebase.ts
+++ b/tavla/src/firebase.ts
@@ -3,6 +3,7 @@ import admin, { firestore } from 'firebase-admin'
 import { FieldValue } from 'firebase-admin/firestore'
 import { type BoardDB, BoardDBSchema } from 'src/types/db-types/boards'
 import { type FolderDB, FolderDBSchema } from 'src/types/db-types/folders'
+import { logToGcp } from 'utils/logging'
 
 initializeAdminApp()
 
@@ -27,6 +28,11 @@ export async function getBoard(bid: BoardDB['id']) {
         }
         const parsedBoard = BoardDBSchema.safeParse(boardData)
         if (!parsedBoard.success) {
+            logToGcp(
+                'debug',
+                `Board data validation failed: ${parsedBoard.error}`,
+                { bid },
+            )
             Sentry.captureMessage(
                 'Board data validation failed for board ' + bid,
                 {
@@ -40,6 +46,9 @@ export async function getBoard(bid: BoardDB['id']) {
         }
         return parsedBoard.data
     } catch (error) {
+        logToGcp('error', `Fetching board from Firebase failed: ${error}`, {
+            bid,
+        })
         Sentry.captureException(error, {
             level: 'error',
             extra: {
@@ -69,6 +78,11 @@ export async function getFolder(folderid: FolderDB['id']) {
         }
         const parsedFolder = FolderDBSchema.safeParse(folderData)
         if (!parsedFolder.success) {
+            logToGcp(
+                'debug',
+                `Folder data validation failed (${parsedFolder.error})`,
+                { folderId: folderid },
+            )
             Sentry.captureMessage(
                 'Folder data validation failed for OID ' + folderid,
                 {
@@ -82,6 +96,9 @@ export async function getFolder(folderid: FolderDB['id']) {
         }
         return parsedFolder.data
     } catch (error) {
+        logToGcp('error', `Failed to fetch folder from Firebase: ${error}`, {
+            folderId: folderid,
+        })
         Sentry.captureException(error, {
             level: 'error',
             extra: {
@@ -134,6 +151,11 @@ export async function getBoardByCustomUrl(customUrl: string) {
         }
         const parsedBoard = BoardDBSchema.safeParse(boardData)
         if (!parsedBoard.success) {
+            logToGcp(
+                'debug',
+                `Board data validation failed (${parsedBoard.error})`,
+                { bid: boardData.id },
+            )
             Sentry.captureMessage(
                 'Board data validation failed for board ' + boardData.id,
                 {
@@ -147,6 +169,10 @@ export async function getBoardByCustomUrl(customUrl: string) {
         }
         return parsedBoard.data
     } catch (error) {
+        logToGcp(
+            'error',
+            `Failed to fetch board with custom url from Firebase: ${error}`,
+        )
         Sentry.captureException(error, {
             level: 'error',
             extra: {
@@ -248,6 +274,11 @@ export async function getFolderForBoard(bid: BoardDB['id']) {
             if (parsedFolder.success) {
                 return parsedFolder.data
             } else {
+                logToGcp(
+                    'debug',
+                    `Folder data validation failed: ${parsedFolder.error}`,
+                    { bid },
+                )
                 Sentry.captureMessage(
                     'Folder data validation failed for board ' + bid,
                     {
@@ -263,6 +294,10 @@ export async function getFolderForBoard(bid: BoardDB['id']) {
         })
         return folders[0] ?? null
     } catch (error) {
+        logToGcp(
+            'error',
+            `Failed to fetch folder for board from Firebase: ${error}`,
+        )
         Sentry.captureException(error, {
             level: 'error',
             extra: {

--- a/tavla/src/graphql/utils.ts
+++ b/tavla/src/graphql/utils.ts
@@ -29,6 +29,7 @@ async function fetchWithTimeout(
     } catch (error) {
         clearTimeout(timeoutScheduler)
         if (signal.aborted) {
+            logToGcp('error', `Departure fetch timed out: ${url} ${options}`)
             Sentry.captureException(new Error('Departure fetch timed out'), {
                 extra: {
                     url: url,
@@ -37,6 +38,7 @@ async function fetchWithTimeout(
             })
             throw new Error(FetchErrorTypes.TIMEOUT, { cause: error })
         }
+        logToGcp('error', `Unknown error occured during fetch: ${error}`)
         Sentry.captureException(error, {
             extra: {
                 message: 'Unknown error occured during fetch',
@@ -93,6 +95,10 @@ export async function fetcher<Data, Variables>([
     }
 
     if (res.data === null || res.data === undefined) {
+        logToGcp(
+            'warning',
+            `GraphQL returned null/undefined data: query: ${query}, response: ${res}`,
+        )
         Sentry.captureMessage('GraphQL returned null/undefined data', {
             level: 'warning',
             extra: {


### PR DESCRIPTION
  ### 🥅 Bakgrunn

  Sentry-kall inneholdt `user.uid` og andre bruker-ID-er i klartekst i feilmeldinger
  og `extra`-felt. Dette er et personvernproblem — Sentry er ikke godkjent for
  lagring av personidentifiserende data. I tillegg manglet flere steder GCP-logging,
  som gjør det vanskeligere å feilsøke i produksjon.

  ### ✨ Løsning

  - Fjerner `user.uid`, `uid`, `inviteeID` og lignende bruker-ID-er fra alle Sentry-kall
  - Erstatter ID-er i fritekstmeldinger med strukturerte felt der det er hensiktsmessig
    (f.eks. `bid`, `folderId` — disse er ikke personidentifiserende)
  - Legger til `logToGcp`-kall der det manglet: `src/firebase.ts`, `src/graphql/utils.ts`,
    `Login/Google.tsx` og flere action-filer
  - Flytter board-ID og folder-ID ut av loggmeldingsteksten og inn i strukturerte felt
    for bedre filtrering i GCP
  - Fjerner `onRequestError = Sentry.captureRequestError` fra `instrumentation.ts`
    (fanget opp request-feil med brukerkontext vi ikke skal logge)

  ### 📸 Bilder

  | Før   | Etter |
  | ----- | ----- |
  | bilde | bilde |

  ### ✅ Sjekkliste

  - [ ] Testet i Chrome, Firefox og Safari
  - [ ] Lagt på aktuell posthog-tracking
  - [ ] Husket og testet UU
  - [ ] Oppdatert dokumentasjon (hvis relevant)