### PR TITLE
🛠️ Få Biome til å virke når repoet åpnes på rot i VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "biome.lsp.bin": "tavla/node_modules/@biomejs/biome/bin/biome",
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.biome": "explicit",
+        "source.organizeImports.biome": "explicit"
+    }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+    "files": {
+        "includes": ["tavla/**"]
+    }
+}

--- a/tavla/biome.json
+++ b/tavla/biome.json
@@ -1,5 +1,7 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+    "root": false,
+    "extends": "//",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
### 🥅 Bakgrunn

`biome.json` lå kun i `tavla/`-undermappen. Når man åpnet repoet på rot i VS Code fant Biome-utvidelsen ingen config, og LSP-en startet ikke (`Unable to find the Biome binary`). Det fungerte bare hvis man åpnet den indre `tavla/`-mappen direkte — tungvint i en monorepo der `backend/`, `redirect/` og `migrations/` også ligger i roten.

### ✨ Løsning

Bruker Biomes offisielle [monorepo-mønster](https://biomejs.dev/guides/big-projects/):

- Ny minimal **root-config** `biome.json` i repo-roten, scoped til `tavla/**` (rører ikke Rust-/Python-mappene).
- `tavla/biome.json` blir en **nested config** med `"root": false` og `"extends": "//"`. All prosjektkonfig (regler, formatering, includes) bor fortsatt her — ingen oppførsel er endret, og `yarn lint`/`yarn fix` (`biome check .` fra `tavla/`) er uberørt.
- Ny `.vscode/settings.json` som peker `biome.lsp.bin` på binæren i `tavla/node_modules` (utvidelsen i v3 leter ellers kun i workspace-rotens `node_modules`) og setter Biome som default formatter med fix + organize imports on save.

Verifisert at `biome check` resolver config og kjører både fra repo-roten og fra `tavla/`.
