### PR TITLE
🧹 Rydder opp i tiles og settings

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -60,8 +60,12 @@ export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
 
 export async function getTileWithWalkingDistance(
     tile: BoardTileDB,
-    location: LocationDB,
+    location: LocationDB | undefined,
 ): Promise<BoardTileDB> {
+    if (!location) {
+        delete tile.walkingDistance
+        return tile
+    }
     logToGcp('info', 'action:getWalkingDistanceTile invoked')
     const fromCoordinates = await getStopPlaceCoordinates(tile.stopPlaceId)
     const toCoordinates = location.coordinate

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/actions.ts
@@ -58,7 +58,7 @@ export async function addTiles(bid: BoardDB['id'], tiles: BoardTileDB[]) {
     }
 }
 
-export async function getWalkingDistanceTile(
+export async function getTileWithWalkingDistance(
     tile: BoardTileDB,
     location: LocationDB,
 ): Promise<BoardTileDB> {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -1,5 +1,6 @@
 'use server'
 import * as Sentry from '@sentry/nextjs'
+import { getDefaultColumns } from 'app/_components/TileSelector/utils'
 import { getWalkingDistanceTile } from 'app/(innlogget)/tavler/[id]/rediger/actions'
 import {
     isEmptyOrSpaces,
@@ -74,7 +75,18 @@ export async function saveSettings(data: FormData) {
     try {
         await userHasAccessToEditBoard(board.id ?? '')
 
-        const tiles = await getTilesWithDistance(board, location)
+        const isCombinedTilesFromForm = viewType === 'combined'
+        const viewTypeChanged =
+            isCombinedTilesFromForm !== board.isCombinedTiles
+
+        const tiles = (await getTilesWithDistance(board, location)).map(
+            (tile) => ({
+                ...tile,
+                ...(viewTypeChanged && {
+                    columns: getDefaultColumns(isCombinedTilesFromForm),
+                }),
+            }),
+        )
 
         const footerContainsText =
             infoMessage &&
@@ -86,7 +98,7 @@ export async function saveSettings(data: FormData) {
             'meta.fontSize': font,
             'meta.location': location ?? FieldValue.delete(),
             theme: theme ?? 'dark',
-            isCombinedTiles: viewType !== 'separate',
+            isCombinedTiles: isCombinedTilesFromForm,
             footer: footerContainsText
                 ? { footer: infoMessage }
                 : FieldValue.delete(),

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -26,6 +26,8 @@ import type {
     BoardFontSize,
     BoardTheme,
     LocationDB,
+    TileColumnDB,
+    TileDB,
     TransportPalette,
 } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
@@ -78,14 +80,15 @@ export async function saveSettings(data: FormData) {
         const isCombinedTilesFromForm = viewType === 'combined'
         const viewTypeChanged =
             isCombinedTilesFromForm !== board.isCombinedTiles
+        const columns = viewTypeChanged
+            ? getDefaultColumns(isCombinedTilesFromForm)
+            : undefined
+        const locationChanged = !isSameLocation(location, board.meta.location)
 
-        const tiles = (await getTilesWithDistance(board, location)).map(
-            (tile) => ({
-                ...tile,
-                ...(viewTypeChanged && {
-                    columns: getDefaultColumns(isCombinedTilesFromForm),
-                }),
-            }),
+        const tiles = await Promise.all(
+            board.tiles.map((tile: TileDB) =>
+                buildUpdatedTile(tile, location, locationChanged, columns),
+            ),
         )
 
         const footerContainsText =
@@ -127,15 +130,30 @@ export async function saveSettings(data: FormData) {
     }
 }
 
-async function getTilesWithDistance(board: BoardDB, location?: LocationDB) {
-    return await Promise.all(
-        board.tiles.map(async (tile) => {
-            if (location === undefined) {
-                delete tile.walkingDistance
-                return tile
-            } else {
-                return await getWalkingDistanceTile(tile, location)
-            }
-        }),
+async function buildUpdatedTile(
+    tile: TileDB,
+    location: LocationDB | undefined,
+    locationUpdated: boolean,
+    columns: TileColumnDB[] | undefined,
+) {
+    if (location === undefined) {
+        const rest = { ...tile }
+        delete rest.walkingDistance
+        return columns ? { ...rest, columns } : rest
+    }
+
+    if (!locationUpdated) {
+        return columns ? { ...tile, columns } : tile
+    }
+    const newLocationOnTile = await getWalkingDistanceTile(tile, location)
+    return columns ? { ...newLocationOnTile, columns } : newLocationOnTile
+}
+
+function isSameLocation(a: LocationDB | undefined, b: LocationDB | undefined) {
+    if (a === undefined && b === undefined) return true
+    if (a === undefined || b === undefined) return false
+    return (
+        a.coordinate?.lat === b.coordinate?.lat &&
+        a.coordinate?.lng === b.coordinate?.lng
     )
 }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -80,7 +80,7 @@ export async function saveSettings(data: FormData) {
         const tiles = await Promise.all(
             board.tiles.map((tile) =>
                 isLocationChanged
-                    ? addOrRemoveWalkingDistanceFromTile(tile, location)
+                    ? getTileWithWalkingDistance(tile, location)
                     : tile,
             ),
         )
@@ -122,21 +122,6 @@ export async function saveSettings(data: FormData) {
         errors.general = handleError(error)
         return errors
     }
-}
-
-async function addOrRemoveWalkingDistanceFromTile(
-    tile: BoardTileDB,
-    location: LocationDB | undefined,
-) {
-    const userHasRemovedLocation = location === undefined
-
-    if (userHasRemovedLocation) {
-        const rest = { ...tile }
-        delete rest.walkingDistance
-        return rest
-    }
-
-    return await getTileWithWalkingDistance(tile, location)
 }
 
 function isSameLocation(a: LocationDB | undefined, b: LocationDB | undefined) {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -24,7 +24,6 @@ import type {
     BoardDB,
     BoardFontSize,
     BoardTheme,
-    BoardTileDB,
     LocationDB,
     TransportPalette,
 } from 'src/types/db-types/boards'

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 import * as Sentry from '@sentry/nextjs'
-import { getWalkingDistanceTile } from 'app/(innlogget)/tavler/[id]/rediger/actions'
+import { getTileWithWalkingDistance } from 'app/(innlogget)/tavler/[id]/rediger/actions'
 import {
     isEmptyOrSpaces,
     isOnlyWhiteSpace,
@@ -75,12 +75,13 @@ export async function saveSettings(data: FormData) {
     try {
         await userHasAccessToEditBoard(board.id ?? '')
 
-        const isCombinedTilesFromForm = viewType === 'combined'
-        const locationChanged = !isSameLocation(location, board.meta.location)
+        const isLocationChanged = !isSameLocation(location, board.meta.location)
 
         const tiles = await Promise.all(
             board.tiles.map((tile) =>
-                buildUpdatedTile(tile, location, locationChanged),
+                isLocationChanged
+                    ? addOrRemoveWalkingDistanceFromTile(tile, location)
+                    : tile,
             ),
         )
 
@@ -94,7 +95,7 @@ export async function saveSettings(data: FormData) {
             'meta.fontSize': font,
             'meta.location': location ?? FieldValue.delete(),
             theme: theme ?? 'dark',
-            isCombinedTiles: isCombinedTilesFromForm,
+            isCombinedTiles: viewType === 'combined',
             footer: footerContainsText
                 ? { footer: infoMessage }
                 : FieldValue.delete(),
@@ -123,21 +124,19 @@ export async function saveSettings(data: FormData) {
     }
 }
 
-async function buildUpdatedTile(
+async function addOrRemoveWalkingDistanceFromTile(
     tile: BoardTileDB,
     location: LocationDB | undefined,
-    locationUpdated: boolean,
 ) {
-    if (location === undefined) {
+    const userHasRemovedLocation = location === undefined
+
+    if (userHasRemovedLocation) {
         const rest = { ...tile }
         delete rest.walkingDistance
         return rest
     }
 
-    if (!locationUpdated) {
-        return tile
-    }
-    return await getWalkingDistanceTile(tile, location)
+    return await getTileWithWalkingDistance(tile, location)
 }
 
 function isSameLocation(a: LocationDB | undefined, b: LocationDB | undefined) {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -1,6 +1,5 @@
 'use server'
 import * as Sentry from '@sentry/nextjs'
-import { getDefaultColumns } from 'app/_components/TileSelector/utils'
 import { getWalkingDistanceTile } from 'app/(innlogget)/tavler/[id]/rediger/actions'
 import {
     isEmptyOrSpaces,
@@ -25,9 +24,8 @@ import type {
     BoardDB,
     BoardFontSize,
     BoardTheme,
+    BoardTileDB,
     LocationDB,
-    TileColumnDB,
-    TileDB,
     TransportPalette,
 } from 'src/types/db-types/boards'
 import { logToGcp } from 'src/utils/logging'
@@ -78,16 +76,11 @@ export async function saveSettings(data: FormData) {
         await userHasAccessToEditBoard(board.id ?? '')
 
         const isCombinedTilesFromForm = viewType === 'combined'
-        const viewTypeChanged =
-            isCombinedTilesFromForm !== board.isCombinedTiles
-        const columns = viewTypeChanged
-            ? getDefaultColumns(isCombinedTilesFromForm)
-            : undefined
         const locationChanged = !isSameLocation(location, board.meta.location)
 
         const tiles = await Promise.all(
-            board.tiles.map((tile: TileDB) =>
-                buildUpdatedTile(tile, location, locationChanged, columns),
+            board.tiles.map((tile) =>
+                buildUpdatedTile(tile, location, locationChanged),
             ),
         )
 
@@ -131,22 +124,20 @@ export async function saveSettings(data: FormData) {
 }
 
 async function buildUpdatedTile(
-    tile: TileDB,
+    tile: BoardTileDB,
     location: LocationDB | undefined,
     locationUpdated: boolean,
-    columns: TileColumnDB[] | undefined,
 ) {
     if (location === undefined) {
         const rest = { ...tile }
         delete rest.walkingDistance
-        return columns ? { ...rest, columns } : rest
+        return rest
     }
 
     if (!locationUpdated) {
-        return columns ? { ...tile, columns } : tile
+        return tile
     }
-    const newLocationOnTile = await getWalkingDistanceTile(tile, location)
-    return columns ? { ...newLocationOnTile, columns } : newLocationOnTile
+    return await getWalkingDistanceTile(tile, location)
 }
 
 function isSameLocation(a: LocationDB | undefined, b: LocationDB | undefined) {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -53,7 +53,7 @@ export default async function EditPage(props: TProps) {
     async function addTilesAction(data: FormData) {
         'use server'
 
-        const tiles = formDataToTiles(data)
+        const tiles = formDataToTiles(data, board?.isCombinedTiles)
         if (tiles.length === 0) return
 
         const tilesWithDistance = await Promise.all(

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -50,20 +50,22 @@ export default async function EditPage(props: TProps) {
     const access = await userCanEditBoard(params.id)
     if (!access) return redirect('/')
 
+    const definedBoard = board
+
     async function addTilesAction(data: FormData) {
         'use server'
 
-        const tiles = formDataToTiles(data, board?.isCombinedTiles)
+        const tiles = formDataToTiles(data, definedBoard.isCombinedTiles)
         if (tiles.length === 0) return
 
         const tilesWithDistance = await Promise.all(
             tiles
                 .filter((tile) => tile.stopPlaceId)
                 .map(async (tile) => {
-                    return board?.meta.location
+                    return definedBoard.meta.location
                         ? await getWalkingDistanceTile(
                               tile,
-                              board.meta.location,
+                              definedBoard.meta.location,
                           )
                         : (() => {
                               delete tile.walkingDistance

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -60,7 +60,7 @@ export default async function EditPage(props: TProps) {
             tiles
                 .filter((tile) => tile.stopPlaceId)
                 .map(async (tile) => {
-                    const tileWithDistance = board?.meta.location
+                    return board?.meta.location
                         ? await getWalkingDistanceTile(
                               tile,
                               board.meta.location,
@@ -69,7 +69,6 @@ export default async function EditPage(props: TProps) {
                               delete tile.walkingDistance
                               return tile
                           })()
-                    return tileWithDistance
                 }),
         )
         await addTiles(params.id, tilesWithDistance)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -53,12 +53,12 @@ export default async function EditPage(props: TProps) {
         return redirect('/')
     }
 
-    const { isCombinedTiles, meta } = board
+    const { meta } = board
 
     async function addTilesAction(data: FormData) {
         'use server'
 
-        const tiles = formDataToTiles(data, isCombinedTiles)
+        const tiles = formDataToTiles(data)
         if (tiles.length === 0) return
 
         const tilesWithDistance = await Promise.all(

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -12,7 +12,7 @@ import { getBoard, getFolderForBoard } from 'src/firebase'
 import type { BoardDB } from 'src/types/db-types/boards'
 import { getBoardLinkClient, getBoardLinkServer } from 'src/utils/boardLink'
 import { BreadcrumbsNav } from '../BreadcrumbsNav'
-import { addTiles, getWalkingDistanceTile } from './actions'
+import { addTiles, getTileWithWalkingDistance } from './actions'
 import { ActionsMenu } from './components/ActionsMenu'
 import { Copy } from './components/Buttons/Copy'
 import { CustomUrl } from './components/CustomUrl/CustomUrl'
@@ -45,28 +45,28 @@ export default async function EditPage(props: TProps) {
     if (!board) {
         return notFound()
     }
+
     const folder = await getFolderForBoard(params.id)
 
     const access = await userCanEditBoard(params.id)
-    if (!access) return redirect('/')
+    if (!access) {
+        return redirect('/')
+    }
 
-    const definedBoard = board
+    const { isCombinedTiles, meta } = board
 
     async function addTilesAction(data: FormData) {
         'use server'
 
-        const tiles = formDataToTiles(data, definedBoard.isCombinedTiles)
+        const tiles = formDataToTiles(data, isCombinedTiles)
         if (tiles.length === 0) return
 
         const tilesWithDistance = await Promise.all(
             tiles
                 .filter((tile) => tile.stopPlaceId)
                 .map(async (tile) => {
-                    return definedBoard.meta.location
-                        ? await getWalkingDistanceTile(
-                              tile,
-                              definedBoard.meta.location,
-                          )
+                    return meta.location
+                        ? await getTileWithWalkingDistance(tile, meta.location)
                         : (() => {
                               delete tile.walkingDistance
                               return tile

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -64,14 +64,7 @@ export default async function EditPage(props: TProps) {
         const tilesWithDistance = await Promise.all(
             tiles
                 .filter((tile) => tile.stopPlaceId)
-                .map(async (tile) => {
-                    return meta.location
-                        ? await getTileWithWalkingDistance(tile, meta.location)
-                        : (() => {
-                              delete tile.walkingDistance
-                              return tile
-                          })()
-                }),
+                .map((tile) => getTileWithWalkingDistance(tile, meta.location)),
         )
         await addTiles(params.id, tilesWithDistance)
 

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -17,7 +17,7 @@ import {
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import { uniqBy } from 'lodash'
 import { startTransition, useActionState, useState } from 'react'
-import type { BoardDB, BoardTileDB, TileColumnDB } from 'types/db-types/boards'
+import type { BoardDB, BoardTileDB } from 'types/db-types/boards'
 import { deleteTile, saveTile } from './actions'
 import { EditRemoveTileButtonGroup } from './components/EditRemoveTileButtonGroup'
 import { SaveCancelDeleteTileButtonGroup } from './components/SaveCancelDeleteTileButtonGroup'

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -2,7 +2,6 @@
 import { useToast } from '@entur/alert'
 import { BaseExpand } from '@entur/expand'
 import { Heading3 } from '@entur/typography'
-import { DEFAULT_COLUMNS } from 'app/_components/TileSelector/utils'
 import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
 import {
     getTransportModesFromLines,
@@ -77,7 +76,7 @@ function TileCard({
         _prevState: TFormFeedback | undefined,
         data: FormData,
     ) => {
-        let columns = data.getAll('columns') as TileColumnDB[]
+        const columns = data.getAll('columns') as TileColumnDB[]
         data.delete('columns')
         const count = data.get('count') as number | null
         data.delete('count')
@@ -113,10 +112,6 @@ function TileCard({
                           .map((l) => l.id),
                   }))
                   .filter((q) => q.whitelistedLines.length > 0)
-
-        if (isCombined) {
-            columns = tile.columns ?? DEFAULT_COLUMNS
-        }
 
         const newTile: BoardTileDB = {
             ...tile,

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -2,6 +2,7 @@
 import { useToast } from '@entur/alert'
 import { BaseExpand } from '@entur/expand'
 import { Heading3 } from '@entur/typography'
+import { getDefaultColumns } from 'app/_components/TileSelector/utils'
 import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
 import {
     getTransportModesFromLines,
@@ -27,6 +28,7 @@ import { SetVisibleLines } from './components/SetVisibleLines'
 import { TileArrows } from './components/TileArrows'
 import { TileContext } from './context'
 import { useLines } from './useLines'
+import { parseTileFormData } from './utils'
 
 export function TileCard({
     board,
@@ -65,22 +67,19 @@ export function TileCard({
         _prevState: TFormFeedback | undefined,
         data: FormData,
     ) => {
-        const columns = data.getAll('columns') as TileColumnDB[]
-        data.delete('columns')
-        const count = data.get('count') as number | null
-        data.delete('count')
-        const offset = data.get('offset') as number | null
-        data.delete('offset')
-        const displayName = data.get('displayName') as string
-        data.delete('displayName')
+        const {
+            columns: parsedColumns,
+            count,
+            offset,
+            displayName,
+            quayLineKeys,
+        } = parseTileFormData(data)
+        const columns = board.isCombinedTiles
+            ? getDefaultColumns(board.isCombinedTiles)
+            : parsedColumns
 
         if (isOnlyWhiteSpace(displayName)) {
             return getFormFeedbackForError('board/tiles-name-missing')
-        }
-
-        const quayLineKeys: string[] = []
-        for (const value of data.values()) {
-            quayLineKeys.push(value as string)
         }
 
         if (quayLineKeys.length === 0 && count !== null && count > 0) {

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -16,12 +16,7 @@ import {
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import { uniqBy } from 'lodash'
 import { startTransition, useActionState, useState } from 'react'
-import type {
-    BoardDB,
-    BoardTileDB,
-    LocationDB,
-    TileColumnDB,
-} from 'types/db-types/boards'
+import type { BoardDB, BoardTileDB, TileColumnDB } from 'types/db-types/boards'
 import { deleteTile, saveTile } from './actions'
 import { EditRemoveTileButtonGroup } from './components/EditRemoveTileButtonGroup'
 import { SaveCancelDeleteTileButtonGroup } from './components/SaveCancelDeleteTileButtonGroup'
@@ -33,35 +28,29 @@ import { TileArrows } from './components/TileArrows'
 import { TileContext } from './context'
 import { useLines } from './useLines'
 
-function TileCard({
-    bid,
+export function TileCard({
+    board,
     tile,
     index,
-    address,
-    localStorageBoard,
-    totalTiles,
-    isCombined,
     moveItem,
     setTilesLocalStorageBoard,
 }: {
-    bid: BoardDB['id']
+    board: BoardDB
     tile: BoardTileDB
     index: number
-    address?: LocationDB
-    localStorageBoard?: BoardDB
-    totalTiles: number
-    isCombined: boolean
     moveItem: (index: number, direction: string) => void
     setTilesLocalStorageBoard?: (tiles: BoardDB['tiles']) => void
 }) {
     const posthog = usePosthogTracking()
+
+    const totalTiles = board.tiles.length
 
     const [isOpen, setIsOpen] = useState(false)
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
     const [confirmOpen, setConfirmOpen] = useState(false)
     const [changedFields, setChangedFields] = useState<Set<string>>(new Set())
 
-    const isLocalStorageBoard = bid === LOCAL_STORAGE_BOARD_ID
+    const isLocalStorageBoard = board.id === LOCAL_STORAGE_BOARD_ID
     const trackingLocation = isLocalStorageBoard
         ? 'board_without_user'
         : 'board_page'
@@ -117,7 +106,7 @@ function TileCard({
             ...tile,
             columns,
             quays: newQuays,
-            ...(address && {
+            ...(board.meta.location && {
                 walkingDistance: {
                     distance: tile.walkingDistance?.distance,
                 },
@@ -130,7 +119,7 @@ function TileCard({
             if (isLocalStorageBoard) {
                 saveTileToLocalStorageBoard(newTile)
             } else {
-                await saveTile(bid, newTile)
+                await saveTile(board.id, newTile)
             }
             reset()
         } catch {
@@ -177,13 +166,13 @@ function TileCard({
         getTransportModesFromLines(uniqLines).sort(sortByTransportMode)
 
     const saveTileToLocalStorageBoard = (newTile: BoardTileDB) => {
-        if (!localStorageBoard) return null
-        const oldTileIndex = localStorageBoard.tiles.findIndex(
+        if (!isLocalStorageBoard) return null
+        const oldTileIndex = board.tiles.findIndex(
             (tile) => tile.uuid === newTile.uuid,
         )
         if (oldTileIndex === -1) return null
 
-        const updatedTiles = localStorageBoard.tiles.map((existingTile) =>
+        const updatedTiles = board.tiles.map((existingTile) =>
             existingTile.uuid === newTile.uuid ? newTile : existingTile,
         )
 
@@ -191,11 +180,9 @@ function TileCard({
     }
 
     const deleteTileLocalStorageBoard = () => {
-        if (!localStorageBoard) return null
+        if (!isLocalStorageBoard) return null
 
-        const remainingTiles = localStorageBoard.tiles.filter(
-            (t) => t.uuid !== tile.uuid,
-        )
+        const remainingTiles = board.tiles.filter((t) => t.uuid !== tile.uuid)
         if (setTilesLocalStorageBoard) setTilesLocalStorageBoard(remainingTiles)
 
         addToast(`${tile.name} fjernet!`)
@@ -213,7 +200,7 @@ function TileCard({
         if (isLocalStorageBoard) {
             deleteTileLocalStorageBoard()
         } else {
-            deleteTile(bid, tile).then(() => {
+            deleteTile(board.id, tile).then(() => {
                 addToast(`${tile.name} fjernet!`)
             })
         }
@@ -287,12 +274,12 @@ function TileCard({
                                 onFieldChanged={onFieldChanged}
                             />
                             <SetOffsetDepartureTime
-                                address={address}
+                                address={board.meta.location}
                                 trackingLocation={trackingLocation}
                                 onFieldChanged={onFieldChanged}
                             />
                             <SetColumns
-                                isCombined={isCombined}
+                                isCombined={board.isCombinedTiles}
                                 trackingLocation={trackingLocation}
                                 onFieldChanged={onFieldChanged}
                             />
@@ -330,5 +317,3 @@ function TileCard({
         </div>
     )
 }
-
-export { TileCard }

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -2,7 +2,6 @@
 import { useToast } from '@entur/alert'
 import { BaseExpand } from '@entur/expand'
 import { Heading3 } from '@entur/typography'
-import { getDefaultColumns } from 'app/_components/TileSelector/utils'
 import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
 import {
     getTransportModesFromLines,
@@ -74,9 +73,7 @@ export function TileCard({
             displayName,
             quayLineKeys,
         } = parseTileFormData(data)
-        const columns = board.isCombinedTiles
-            ? getDefaultColumns(board.isCombinedTiles)
-            : parsedColumns
+        const columns = board.isCombinedTiles ? tile.columns : parsedColumns
 
         if (isOnlyWhiteSpace(displayName)) {
             return getFormFeedbackForError('board/tiles-name-missing')

--- a/tavla/app/_components/TileCard/components/SetColumns.tsx
+++ b/tavla/app/_components/TileCard/components/SetColumns.tsx
@@ -3,7 +3,6 @@ import { FilterChip } from '@entur/chip'
 import { QuestionFilledIcon } from '@entur/icons'
 import { Tooltip } from '@entur/tooltip'
 import { Heading4, SubParagraph } from '@entur/typography'
-import { DEFAULT_COMBINED_COLUMNS } from 'app/_components/TileSelector/utils'
 import type { EventProps } from 'app/posthog/events'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import { isArray } from 'lodash'
@@ -63,10 +62,6 @@ function SetColumns({
             />
             <div className="mb-8 mt-2 flex flex-row flex-wrap gap-4">
                 {typedEntries(TileColumns).map(([key, value]) => {
-                    const columns = isCombined
-                        ? DEFAULT_COMBINED_COLUMNS
-                        : tile.columns
-
                     const columnValue: Record<
                         keyof typeof TileColumns,
                         EventProps<'stop_place_edit_interaction'>['column_value']
@@ -87,7 +82,8 @@ function SetColumns({
                             value={key}
                             disabled={isCombined}
                             defaultChecked={
-                                isArray(columns) && columns.includes(key)
+                                isArray(tile.columns) &&
+                                tile.columns.includes(key)
                             }
                             onChange={(e) => {
                                 onFieldChanged('columns')

--- a/tavla/app/_components/TileCard/components/SetColumns.tsx
+++ b/tavla/app/_components/TileCard/components/SetColumns.tsx
@@ -1,3 +1,4 @@
+import { SmallAlertBox } from '@entur/alert/'
 import { IconButton } from '@entur/button'
 import { FilterChip } from '@entur/chip'
 import { QuestionFilledIcon } from '@entur/icons'
@@ -46,13 +47,15 @@ function SetColumns({
                     </IconButton>
                 </Tooltip>
             </div>
-            <SubParagraph>
-                Her bestemmer du hvilke kolonner som skal vises i tavlen.
-            </SubParagraph>
-            {isCombined && (
-                <SubParagraph className="mb-2 !text-error">
-                    Har du samlet stoppestedene i én liste vil du ikke ha
-                    mulighet til å velge kolonner.
+
+            {isCombined ? (
+                <SmallAlertBox variant="info" className="mb-2 w-fit">
+                    Du har valgt å vise alle stoppesteder i en liste, og kan
+                    derfor ikke velge kolonner per stoppested.
+                </SmallAlertBox>
+            ) : (
+                <SubParagraph>
+                    Her bestemmer du hvilke kolonner som skal vises i tavlen.
                 </SubParagraph>
             )}
 
@@ -60,48 +63,53 @@ function SetColumns({
                 isOpen={isColumnModalOpen}
                 setIsOpen={setIsColumnModalOpen}
             />
-            <div className="mb-8 mt-2 flex flex-row flex-wrap gap-4">
-                {typedEntries(TileColumns).map(([key, value]) => {
-                    const columnValue: Record<
-                        keyof typeof TileColumns,
-                        EventProps<'stop_place_edit_interaction'>['column_value']
-                    > = {
-                        aimedTime: 'eta',
-                        arrivalTime: 'arrival',
-                        line: 'line',
-                        destination: 'destination',
-                        name: 'stop_place',
-                        platform: 'platform',
-                        time: 'expected',
-                    }
+            {!isCombined && (
+                <div className="mb-8 mt-2 flex flex-row flex-wrap gap-4">
+                    {typedEntries(TileColumns).map(([key, value]) => {
+                        const columnValue: Record<
+                            keyof typeof TileColumns,
+                            EventProps<'stop_place_edit_interaction'>['column_value']
+                        > = {
+                            aimedTime: 'eta',
+                            arrivalTime: 'arrival',
+                            line: 'line',
+                            destination: 'destination',
+                            name: 'stop_place',
+                            platform: 'platform',
+                            time: 'expected',
+                        }
 
-                    return (
-                        <FilterChip
-                            name="columns"
-                            key={key}
-                            value={key}
-                            disabled={isCombined}
-                            defaultChecked={
-                                isArray(tile.columns) &&
-                                tile.columns.includes(key)
-                            }
-                            onChange={(e) => {
-                                onFieldChanged('columns')
-                                posthog.capture('stop_place_edit_interaction', {
-                                    location: trackingLocation,
-                                    field: 'columns',
-                                    column_value: columnValue[key],
-                                    action: e.target.checked
-                                        ? 'toggled_on'
-                                        : 'toggled_off',
-                                })
-                            }}
-                        >
-                            {value}
-                        </FilterChip>
-                    )
-                })}
-            </div>
+                        return (
+                            <FilterChip
+                                name="columns"
+                                key={key}
+                                value={key}
+                                disabled={isCombined}
+                                defaultChecked={
+                                    isArray(tile.columns) &&
+                                    tile.columns.includes(key)
+                                }
+                                onChange={(e) => {
+                                    onFieldChanged('columns')
+                                    posthog.capture(
+                                        'stop_place_edit_interaction',
+                                        {
+                                            location: trackingLocation,
+                                            field: 'columns',
+                                            column_value: columnValue[key],
+                                            action: e.target.checked
+                                                ? 'toggled_on'
+                                                : 'toggled_off',
+                                        },
+                                    )
+                                }}
+                            >
+                                {value}
+                            </FilterChip>
+                        )
+                    })}
+                </div>
+            )}
         </>
     )
 }

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -1,4 +1,5 @@
 import type { TTransportMode } from 'src/types/graphql-schema'
+import type { TileColumnDB } from 'types/db-types/boards'
 
 export function transportModeNames(
     transportMode: TTransportMode | null | undefined,
@@ -35,4 +36,30 @@ export function transportModeNames(
         default:
             return null
     }
+}
+
+export type TileFormValues = {
+    columns: TileColumnDB[]
+    count: number | null
+    offset: number | null
+    displayName: string
+    quayLineKeys: string[]
+}
+
+export function parseTileFormData(data: FormData): TileFormValues {
+    const columns = data.getAll('columns') as TileColumnDB[]
+    data.delete('columns')
+    const count = data.get('count') as number | null
+    data.delete('count')
+    const offset = data.get('offset') as number | null
+    data.delete('offset')
+    const displayName = data.get('displayName') as string
+    data.delete('displayName')
+
+    const quayLineKeys: string[] = []
+    for (const value of data.values()) {
+        quayLineKeys.push(value as string)
+    }
+
+    return { columns, count, offset, displayName, quayLineKeys }
 }

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -1,38 +1,4 @@
 import type { TTransportMode } from 'src/types/graphql-schema'
-import type { LineWithFrontText } from './types'
-
-export function sortLineByPublicCode(
-    a: LineWithFrontText,
-    b: LineWithFrontText,
-) {
-    if (!a?.publicCode || !b?.publicCode) return 1
-
-    const containsLetters = /[a-zæøåA-ZÆØÅ]/
-    const aContainsLetters = containsLetters.test(a.publicCode)
-    const bContainsLetters = containsLetters.test(b.publicCode)
-
-    if (aContainsLetters && !bContainsLetters) return 1
-    else if (!aContainsLetters && bContainsLetters) return -1
-
-    return a.publicCode.localeCompare(b.publicCode, 'no-NB', {
-        numeric: true,
-    })
-}
-
-export function sortPublicCodes(a: string, b: string) {
-    if (!a || !b) return 1
-
-    const containsLetters = /[a-zæøåA-ZÆØÅ]/
-    const aContainsLetters = containsLetters.test(a)
-    const bContainsLetters = containsLetters.test(b)
-
-    if (aContainsLetters && !bContainsLetters) return 1
-    else if (!aContainsLetters && bContainsLetters) return -1
-
-    return a.localeCompare(b, 'no-NB', {
-        numeric: true,
-    })
-}
 
 export function transportModeNames(
     transportMode: TTransportMode | null | undefined,

--- a/tavla/app/_components/TileList.tsx
+++ b/tavla/app/_components/TileList.tsx
@@ -7,13 +7,11 @@ import { useEffect, useState } from 'react'
 import type { BoardDB, BoardTileDB } from 'src/types/db-types/boards'
 import { TileCard } from './TileCard/TileCard'
 
-function TileList({
+export function TileList({
     board,
     setTilesLocalStorageBoard,
-    bid,
 }: {
     board: BoardDB
-    bid?: BoardDB['id']
     setTilesLocalStorageBoard?: (tiles: BoardDB['tiles']) => void
 }) {
     const [tileArray, setTileArray] = useState<BoardTileDB[]>(board.tiles)
@@ -39,7 +37,7 @@ function TileList({
         newArray[index] = oldElement
 
         setTileArray(newArray)
-        if (bid === LOCAL_STORAGE_BOARD_ID && setTilesLocalStorageBoard) {
+        if (board.id === LOCAL_STORAGE_BOARD_ID && setTilesLocalStorageBoard) {
             setTilesLocalStorageBoard(newArray)
         } else {
             saveUpdatedTileOrder(board.id ?? '', newArray)
@@ -51,21 +49,13 @@ function TileList({
             {tileArray.map((tile, index) => (
                 <TileCard
                     key={tile.uuid}
-                    bid={bid ?? board.id ?? ''}
-                    localStorageBoard={
-                        bid === LOCAL_STORAGE_BOARD_ID ? board : undefined
-                    }
+                    board={board}
                     tile={tile}
-                    address={board.meta.location}
                     moveItem={debouncedSave}
                     index={index}
-                    totalTiles={board.tiles.length}
                     setTilesLocalStorageBoard={setTilesLocalStorageBoard}
-                    isCombined={board.isCombinedTiles}
                 />
             ))}
         </div>
     )
 }
-
-export { TileList }

--- a/tavla/app/_components/TileSelector/utils.ts
+++ b/tavla/app/_components/TileSelector/utils.ts
@@ -15,7 +15,7 @@ import type {
 } from 'types/db-types/boards'
 import { logToGcp } from 'utils/logging'
 
-export const DEFAULT_COLUMNS: TileColumnDB[] = ['line', 'destination', 'time']
+const DEFAULT_COLUMNS: TileColumnDB[] = ['line', 'destination', 'time']
 
 export type TypeOfPlace =
     | 'stop_place'
@@ -23,7 +23,7 @@ export type TypeOfPlace =
     | 'other'
     | 'current_position'
 
-export const DEFAULT_COMBINED_COLUMNS: TileColumnDB[] = [
+const DEFAULT_COMBINED_COLUMNS: TileColumnDB[] = [
     'line',
     'destination',
     'name',
@@ -34,7 +34,10 @@ export const DEFAULT_COMBINED_COLUMNS: TileColumnDB[] = [
 export const getDefaultColumns = (isCombined: boolean) =>
     isCombined ? DEFAULT_COMBINED_COLUMNS : DEFAULT_COLUMNS
 
-export function formDataToTiles(data: FormData): BoardTileDB[] {
+export function formDataToTiles(
+    data: FormData,
+    isCombined: boolean,
+): BoardTileDB[] {
     const closestStopPlacesJson = data.get('closest_stop_places') as string
     if (!closestStopPlacesJson) return []
 
@@ -49,7 +52,7 @@ export function formDataToTiles(data: FormData): BoardTileDB[] {
         quays: [],
         name: sp.name,
         uuid: nanoid(),
-        columns: DEFAULT_COLUMNS,
+        columns: getDefaultColumns(isCombined),
         county: sp.county || undefined,
     }))
 }

--- a/tavla/app/_components/TileSelector/utils.ts
+++ b/tavla/app/_components/TileSelector/utils.ts
@@ -31,6 +31,9 @@ export const DEFAULT_COMBINED_COLUMNS: TileColumnDB[] = [
     'time',
 ]
 
+export const getDefaultColumns = (isCombined: boolean) =>
+    isCombined ? DEFAULT_COMBINED_COLUMNS : DEFAULT_COLUMNS
+
 export function formDataToTiles(data: FormData): BoardTileDB[] {
     const closestStopPlacesJson = data.get('closest_stop_places') as string
     if (!closestStopPlacesJson) return []

--- a/tavla/app/_components/TileSelector/utils.ts
+++ b/tavla/app/_components/TileSelector/utils.ts
@@ -23,21 +23,7 @@ export type TypeOfPlace =
     | 'other'
     | 'current_position'
 
-const DEFAULT_COMBINED_COLUMNS: TileColumnDB[] = [
-    'line',
-    'destination',
-    'name',
-    'platform',
-    'time',
-]
-
-export const getDefaultColumns = (isCombined: boolean) =>
-    isCombined ? DEFAULT_COMBINED_COLUMNS : DEFAULT_COLUMNS
-
-export function formDataToTiles(
-    data: FormData,
-    isCombined: boolean,
-): BoardTileDB[] {
+export function formDataToTiles(data: FormData): BoardTileDB[] {
     const closestStopPlacesJson = data.get('closest_stop_places') as string
     if (!closestStopPlacesJson) return []
 
@@ -52,7 +38,7 @@ export function formDataToTiles(
         quays: [],
         name: sp.name,
         uuid: nanoid(),
-        columns: getDefaultColumns(isCombined),
+        columns: DEFAULT_COLUMNS,
         county: sp.county || undefined,
     }))
 }

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -1,5 +1,5 @@
 'use server'
-import { getWalkingDistanceTile } from 'app/(innlogget)/tavler/[id]/rediger/actions'
+import { getTileWithWalkingDistance } from 'app/(innlogget)/tavler/[id]/rediger/actions'
 import { initializeAdminApp } from 'app/(innlogget)/utils/firebase'
 import { createBoard } from 'src/firebase'
 import type {
@@ -29,7 +29,7 @@ export async function getTilesWithWalkingDistance(
                 delete tile.walkingDistance
                 return tile
             }
-            return getWalkingDistanceTile(tile, location)
+            return getTileWithWalkingDistance(tile, location)
         }),
     )
 }

--- a/tavla/app/lag-tavle/actions.ts
+++ b/tavla/app/lag-tavle/actions.ts
@@ -24,12 +24,6 @@ export async function getTilesWithWalkingDistance(
     location: LocationDB | undefined,
 ): Promise<BoardTileDB[]> {
     return Promise.all(
-        tiles.map(async (tile) => {
-            if (!location) {
-                delete tile.walkingDistance
-                return tile
-            }
-            return getTileWithWalkingDistance(tile, location)
-        }),
+        tiles.map((tile) => getTileWithWalkingDistance(tile, location)),
     )
 }

--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -27,7 +27,7 @@ export type PublishBoardState =
     | { type: 'published'; boardId: string }
     | { type: 'error'; message: string }
 
-function CreateBoardLocally() {
+export function CreateBoardLocally() {
     const { board, loaded, setTiles, onSubmit } = useSaveBoardInLocalStorage()
     const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -112,7 +112,6 @@ function CreateBoardLocally() {
                             setTiles(tiles)
                             resetPublishedBoard()
                         }}
-                        bid={board.id}
                     />
                     <section
                         data-theme={board.theme ?? 'dark'}
@@ -198,5 +197,3 @@ function PublishButton({
             )
     }
 }
-
-export { CreateBoardLocally }

--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -97,7 +97,10 @@ function CreateBoardLocally() {
                 <div className="flex flex-col gap-4">
                     <TileSelector
                         action={async (data: FormData) => {
-                            const tiles = formDataToTiles(data)
+                            const tiles = formDataToTiles(
+                                data,
+                                board.isCombinedTiles,
+                            )
                             setTiles([...board.tiles, ...tiles])
                             resetPublishedBoard()
                         }}

--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -97,10 +97,7 @@ export function CreateBoardLocally() {
                 <div className="flex flex-col gap-4">
                     <TileSelector
                         action={async (data: FormData) => {
-                            const tiles = formDataToTiles(
-                                data,
-                                board.isCombinedTiles,
-                            )
+                            const tiles = formDataToTiles(data)
                             setTiles([...board.tiles, ...tiles])
                             resetPublishedBoard()
                         }}

--- a/tavla/src/types/db-types/boards.ts
+++ b/tavla/src/types/db-types/boards.ts
@@ -118,6 +118,8 @@ export const BoardDBSchema = z.object({
 
 export type BoardDB = z.infer<typeof BoardDBSchema>
 
+export type TileDB = z.infer<typeof boardTileSchema>
+
 export type BoardFooter = z.infer<typeof boardFooterSchema>
 
 export type BoardTheme = z.infer<typeof boardThemeSchema>

--- a/tavla/src/types/db-types/boards.ts
+++ b/tavla/src/types/db-types/boards.ts
@@ -119,8 +119,6 @@ export const BoardDBSchema = z.object({
 
 export type BoardDB = z.infer<typeof BoardDBSchema>
 
-export type TileDB = z.infer<typeof boardTileSchema>
-
 export type BoardFooter = z.infer<typeof boardFooterSchema>
 
 export type BoardTheme = z.infer<typeof boardThemeSchema>


### PR DESCRIPTION
### 🥅 Bakgrunn
I forbindelse med at jeg skulle legge til nye kolonner for ankomsttavle, fant jeg diverse forbedringer som kunne vært gjort i relevante kodefiler. Se løsning for hva som er endret.

### ✨ Løsning
**Innstillinger** 
Før: vi beregnet gangavstand hver gang noe i innstillinger ble endret, selv om lokasjon ikke var endret.
Nå: i beregner gangavstand kun når lokasjon er endret.

**Dataflyt i Tiles** 
Før: Lokale boards sendte med både selve boardet i tillegg til masse felter som ligger i boarddataen. Boards fra db sendte ikke med hele boardet som et objekt, men mesteparten av feltene som var lagret på boardet.
Nå: Erstattet mange av propsene med en prop: board

**Kolonner når kombinert visning**
Før: Viste en rød feilmelding og kolonne-tags som det ikke gikk an å trykke på når kombinert visning var valgt
Nå: Viser en blå alert-boks om at kolonner ikke kan velges ved kombinert visning, viser ikke kolonne-tags

**I tillegg:**
- fjernet ubrukte utils
- lagde hjelpefunksjon for å hente default-kolonner, så det er mindre sannsynlig at vi setter feil (vi setter feil i prod nå).

|Før|Etter|
|--|--|
|<img width="980" height="870" alt="image" src="https://github.com/user-attachments/assets/9cec3921-fa99-4972-bf45-9b615c33c8df" />|<img width="985" height="825" alt="image" src="https://github.com/user-attachments/assets/617b8422-4aa1-44bf-8731-bbe21cb1f124" />|

### Ønsket testing av reviewer:
- innstillinger fungerer som normalt, og endrer ikke på felter som ikke bruker selv har endret på
- dersom man endrer en tile endres kun det man forventer at skal endres


### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
