### PR TITLE
🐛 postUsageMetrics for Slack-tall bruker ikke stopPlaceId

### DIFF
--- a/tavla/firebase.json
+++ b/tavla/firebase.json
@@ -25,7 +25,6 @@
         "source": "firebaseFunctions",
         "runtime": "nodejs22",
         "predeploy": "yarn workspace @utils/firebase-functions build",
-        "postdeploy": "gcloud functions call postUsageMetricsHttp --gen2 --region=europe-west1",
         "region": "europe-west1",
         "isolate": true
     }

--- a/tavla/firebase.json
+++ b/tavla/firebase.json
@@ -25,6 +25,7 @@
         "source": "firebaseFunctions",
         "runtime": "nodejs22",
         "predeploy": "yarn workspace @utils/firebase-functions build",
+        "postdeploy": "gcloud functions call postUsageMetricsHttp --gen2 --region=europe-west1",
         "region": "europe-west1",
         "isolate": true
     }

--- a/tavla/firebaseFunctions/README.md
+++ b/tavla/firebaseFunctions/README.md
@@ -13,6 +13,7 @@ Foreløpig har vi bare oppsett for å deploye funksjoner fra terminal.
 2. For å deploye til enten dev eller prod, kjør `firebase use dev` eller `firebase use prd`. Dette er viktig for å ta i bruk riktig .env-fil.
 
 3. Kjør `firebase deploy --only functions` for å deploye alle functions eller `firebase deploy --only functions:funksjonsnavn` for å deploye en spesifikk funksjon.
+4. Du kan teste manuelt med `gcloud functions call funksjonnavn --gen2` hvis http-endepunkt er satt opp for dette. Eksempel: `gcloud functions call postUsageMetrics --gen2`. Husk å bruke `europe-west1`
 
 Funksjonene ligger under functions i firebase-ui'et. Her er det også lett å finne logger og andre detaljer om funksjonen.
 

--- a/tavla/firebaseFunctions/src/functions.ts
+++ b/tavla/firebaseFunctions/src/functions.ts
@@ -5,7 +5,7 @@ import {
 } from 'firebase-functions/v2/scheduler'
 import { secretParams } from './config/secretParams'
 
-const getDefaultOptions = () => {
+export const getDefaultOptions = () => {
     return {
         region: 'europe-west1' as const,
         secrets: secretParams.map((secret) => secret.name),

--- a/tavla/firebaseFunctions/src/index.ts
+++ b/tavla/firebaseFunctions/src/index.ts
@@ -1,4 +1,4 @@
-import { postUsageMetrics } from './postUsageMetrics'
+import { postUsageMetrics, postUsageMetricsHttp } from './postUsageMetrics'
 import { updateLastActiveOnSchedule } from './updateLastActiveOnSchedule'
 
-export { postUsageMetrics, updateLastActiveOnSchedule }
+export { postUsageMetrics, postUsageMetricsHttp, updateLastActiveOnSchedule }

--- a/tavla/firebaseFunctions/src/postUsageMetrics.ts
+++ b/tavla/firebaseFunctions/src/postUsageMetrics.ts
@@ -112,7 +112,7 @@ async function runUsageMetrics(): Promise<void> {
 
     let message = `God onsdag teamet! 👋🤓  Her kommer ukens TavleTall™️:
 
-Aktive tavler 📈: ${total} (uten stoppested/quay: ${failed})
+Aktive tavler 📈: ${total} (uten stoppested eller med feil i direktelenken: ${failed})
 
 Fordelt på fylker 👇`
 

--- a/tavla/firebaseFunctions/src/postUsageMetrics.ts
+++ b/tavla/firebaseFunctions/src/postUsageMetrics.ts
@@ -43,6 +43,9 @@ async function runUsageMetrics(): Promise<void> {
                 console.error(
                     `Failed to get placeId. Board with no stops added?`,
                 )
+                console.error(
+                    `Board ${client.bid} has no placeId ${placeId} and doesn't follow expected NSR:StopPlace: or NSR:Quay: format for boardId, skipping...`,
+                )
                 failed++
                 continue
             }
@@ -68,7 +71,7 @@ async function runUsageMetrics(): Promise<void> {
         }
 
         if(!county) {
-            const response = await details.json()
+            const response = await details.json() as any
 
             const centroid = response['centroid']
             let lat = centroid['latitude']
@@ -96,7 +99,7 @@ async function runUsageMetrics(): Promise<void> {
                         'ET-Client-Name': 'tavla-board-stats',
                     },
                 },
-            ).then((res) => res.json())
+            ).then((res) => res.json()) as any
 
             county = geocoderResponse['features'][0]['properties']['county']
         }
@@ -123,7 +126,7 @@ Fordelt på fylker 👇`
         message += `\n${palette}: ${count}`
     }
 
-    fetch(`${SLACK_WEBHOOK_TAVLETALL.value()}`, {
+    await fetch(`${SLACK_WEBHOOK_TAVLETALL.value()}`, {
         method: 'POST',
         body: JSON.stringify({
             text: message,

--- a/tavla/firebaseFunctions/src/postUsageMetrics.ts
+++ b/tavla/firebaseFunctions/src/postUsageMetrics.ts
@@ -1,8 +1,9 @@
 import * as admin from 'firebase-admin'
-import { getActiveBoardsFromRedis } from './backendUtils'
-import { getRuntimeConfig } from './config'
-import { SLACK_WEBHOOK_TAVLETALL } from './config/secretParams'
-import { scheduledFunction } from './functions'
+import {onRequest} from 'firebase-functions/v2/https'
+import {getActiveBoardsFromRedis} from './backendUtils'
+import {getRuntimeConfig} from './config'
+import {SLACK_WEBHOOK_TAVLETALL} from './config/secretParams'
+import {getDefaultOptions, scheduledFunction} from './functions'
 
 admin.initializeApp()
 
@@ -14,54 +15,59 @@ type LocationDetails = {
     placeId: string
 }
 
-export const postUsageMetrics = scheduledFunction(
-    '0 11 * * 3',
-    undefined,
-    async () => {
-        const { stopPlaceUrl, quayUrl, geocoderUrl } = getRuntimeConfig()
+async function runUsageMetrics(): Promise<void> {
+    const { stopPlaceUrl, quayUrl, geocoderUrl } = getRuntimeConfig()
 
-        const activeBoards = await getActiveBoardsFromRedis()
-        const boardCollection = admin.firestore().collection('boards')
+    const activeBoards = await getActiveBoardsFromRedis()
+    const boardCollection = admin.firestore().collection('boards')
 
-        const countyCount: Record<string, number> = {}
-        const paletteCount: Record<string, number> = {}
+    const countyCount: Record<string, number> = {}
+    const paletteCount: Record<string, number> = {}
 
-        let failed = 0
-        let total = 0
+    let failed = 0
+    let total = 0
 
-        for (const client of activeBoards.clients) {
-            const board = await boardCollection.doc(client.bid).get()
+    for (const client of activeBoards.clients) {
+        const board = await boardCollection.doc(client.bid).get()
 
-            const placeId: string = board.data()?.tiles[0]?.stopPlaceId
-            const palette: string = board.data()?.transportPalette ?? 'default'
+        let placeId: string = board.data()?.tiles[0]?.stopPlaceId
+        const palette: string = board.data()?.transportPalette ?? 'default'
+        let county: string = board.data()?.tiles[0]?.county
 
-            if (placeId == undefined) {
+        if (placeId == undefined) {
+            const boardId = client.bid
+            if(boardId.startsWith('NSR')) {
+                placeId = boardId
+            }
+            else {
                 console.error(
                     `Failed to get placeId. Board with no stops added?`,
                 )
                 failed++
                 continue
             }
+        }
 
-            if (paletteCount[palette]) paletteCount[palette]++
-            else paletteCount[palette] = 1
+        if (paletteCount[palette]) paletteCount[palette]++
+        else paletteCount[palette] = 1
 
-            const details = await fetch(
-                `${placeId.startsWith('NSR:StopPlace:') ? stopPlaceUrl : quayUrl}/${placeId}`,
-                {
-                    headers: {
-                        'ET-Client-Name': 'tavla-board-stats',
-                    },
+        const details = await fetch(
+            `${placeId.startsWith('NSR:StopPlace:') ? stopPlaceUrl : quayUrl}/${placeId}`,
+            {
+                headers: {
+                    'ET-Client-Name': 'tavla-board-stats',
                 },
+            },
+        )
+
+        if (!details.ok) {
+            console.error(
+                `Failed to fetch details for board ${client.bid} with placeId ${placeId}: ${details.status} ${details.statusText}`,
             )
+            continue
+        }
 
-            if (!details.ok) {
-                console.error(
-                    `Failed to fetch details for board ${client.bid} with placeId ${placeId}: ${details.status} ${details.statusText}`,
-                )
-                continue
-            }
-
+        if(!county) {
             const response = await details.json()
 
             const centroid = response['centroid']
@@ -92,36 +98,51 @@ export const postUsageMetrics = scheduledFunction(
                 },
             ).then((res) => res.json())
 
-            const county =
-                geocoderResponse['features'][0]['properties']['county']
-
-            if (countyCount[county]) countyCount[county]++
-            else countyCount[county] = 1
-
-            total++
+            county = geocoderResponse['features'][0]['properties']['county']
         }
 
-        let message = `God onsdag teamet! 👋🤓  Her kommer ukens TavleTall™️:
+        if (countyCount[county]) countyCount[county]++
+        else countyCount[county] = 1
+
+        total++
+    }
+
+    let message = `God onsdag teamet! 👋🤓  Her kommer ukens TavleTall™️:
 
 Aktive tavler 📈: ${total} (uten stoppested/quay: ${failed})
 
 Fordelt på fylker 👇`
 
-        for (const [county, count] of Object.entries(countyCount)) {
-            message += `\n${county}: ${count}`
-        }
+    for (const [county, count] of Object.entries(countyCount)) {
+        message += `\n${county}: ${count}`
+    }
 
-        message += `\n\nOg fargevalg 🎨:`
+    message += `\n\nOg fargevalg 🎨:`
 
-        for (const [palette, count] of Object.entries(paletteCount)) {
-            message += `\n${palette}: ${count}`
-        }
+    for (const [palette, count] of Object.entries(paletteCount)) {
+        message += `\n${palette}: ${count}`
+    }
 
-        fetch(`${SLACK_WEBHOOK_TAVLETALL.value()}`, {
-            method: 'POST',
-            body: JSON.stringify({
-                text: message,
-            }),
-        })
+    fetch(`${SLACK_WEBHOOK_TAVLETALL.value()}`, {
+        method: 'POST',
+        body: JSON.stringify({
+            text: message,
+        }),
+    })
+}
+
+export const postUsageMetrics = scheduledFunction(
+    '0 11 * * 3',
+    undefined,
+    async () => {
+        await runUsageMetrics()
+    },
+)
+
+export const postUsageMetricsHttp = onRequest(
+    getDefaultOptions(),
+    async (_req, res) => {
+        await runUsageMetrics()
+        res.status(200).send('OK')
     },
 )

--- a/tavla/firebaseFunctions/src/postUsageMetrics.ts
+++ b/tavla/firebaseFunctions/src/postUsageMetrics.ts
@@ -51,8 +51,7 @@ async function runUsageMetrics(): Promise<void> {
             }
         }
 
-        if (paletteCount[palette]) paletteCount[palette]++
-        else paletteCount[palette] = 1
+        paletteCount[palette] = (paletteCount[palette] ?? 0) + 1
 
         const details = await fetch(
             `${placeId.startsWith('NSR:StopPlace:') ? stopPlaceUrl : quayUrl}/${placeId}`,
@@ -101,11 +100,10 @@ async function runUsageMetrics(): Promise<void> {
                 },
             ).then((res) => res.json()) as any
 
-            county = geocoderResponse['features'][0]['properties']['county']
+            county = geocoderResponse['features']?.[0]?.['properties']?.['county'] ?? 'ukjent'
         }
 
-        if (countyCount[county]) countyCount[county]++
-        else countyCount[county] = 1
+        countyCount[county] = (countyCount[county] ?? 0) + 1
 
         total++
     }

--- a/tavla/firebaseFunctions/tsconfig.json
+++ b/tavla/firebaseFunctions/tsconfig.json
@@ -1,9 +1,11 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "moduleResolution": "node",
+        "moduleResolution": "node10",
+        "ignoreDeprecations": "6.0",
         "lib": ["es2021"],
         "noImplicitReturns": true,
+        "rootDir": "src",
         "outDir": "dist",
         "sourceMap": true,
         "strict": true,


### PR DESCRIPTION
### 👥 Brukerhistorie 

>Som en tavlis
>Ønsker jeg at det ukentlige skriptet vårt bruker riktig databaseskjema
>Slik at vi får riktige tall i Slack hver onsdag  

 ### 🥅 Bakgrunn

  postUsageMetrics Firebase-funksjonen støttet ikke tavler som
   er satt opp som direktelenker (der board-ID-en starter med
  NSR: i stedet for å ha et stoppested i tiles[0]). I tillegg
  var det ingen enkel måte å kjøre funksjonen manuelt på — den
   kunne bare trigges via cron. Det er også en. feil som var oppdaget hvor nye tavler brukte `stopPlaceId` og ikke `placeId`, som ikke hadde blitt deployet, men var fikset i koden.

 ### ✨ Løsning

  - Dra ut logikken til `runUsageMetrics()` slik at den kan
  deles mellom scheduled og HTTP-trigger
  - Støtt direktelenke-tavler: hvis `stopPlaceId` mangler men
  `boardId` starter med NSR, bruk boardId direkte som `stopPlaceId`
  - Hopp over geocoder-kall hvis county allerede finnes på
  tavlen i Firestore
  - Legg til optional chaining på `features[0]` i
  geocoder-svaret for å unngå krasj ved tomt resultat —
  fallback til 'ukjent'
  - Legg til `postUsageMetricsHttp` HTTP-endepunkt for å kunne
  trigge manuelt
  - Bedre feillogging: logg board-ID og forventet format ved
  ugyldige tavler

I skriptet brukes denne linjen:
```
const placeId = board.data()?.tiles[0]?.placeId;
```
For å hente ut stoppested-IDen. Vi har gått bort fra placeId og over til stopPlaceId. Denne linjen skal derfor lyde:
```
const placeId = board.data()?.tiles[0]?.stopPlaceId;
```
- [x]  Legge til manual trigger
- [x]  Legge inn at hvis tile.county finnes, bruk den i steden for å slå opp mot geokoder
- [x]  Hvis bid er en NSR id, slå opp med den

