### PR TITLE
📝 Rett opp utdatert dokumentasjon (stier, versjoner, struktur)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Monorepo with two main applications:
 - **`redirect/`** – Rust redirect service for custom board URLs
 - **`tavla/migrations/`** – Python migration scripts for Firestore
 
+This repo is the **admin/configuration app** where boards are created and edited. The public-facing board display (what renders on the screens) lives in a separate repo: [`entur/tavla-visning`](https://github.com/entur/tavla-visning). Run it locally to preview boards.
+
 ## Frontend Commands (`tavla/` directory)
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Keeping this file up to date
+
+This file is only useful while it matches reality. When a change you make would make a statement here stale, update CLAUDE.md in the **same** change — don't leave it for later. Watch especially for:
+
+- **Versions / tooling** — framework or language versions, package manager, lint/format tooling (`Repository Structure`, `Key Patterns`).
+- **Commands / scripts** — added, renamed, or removed `package.json` scripts, shell scripts, or `./migration` usage (`Frontend Commands`, `Backend Commands`, `Migrations`).
+- **Paths** — moved or renamed files referenced here (e.g. `getBackendUrl`, `getUserFromSessionCookie`, the `db-types` directory).
+- **Architecture** — new/changed backend endpoints, Redis channels, data sources, Firestore collections, or auth flow (`Architecture & Data Flow`).
+- **Env vars** — new required variables or changed defaults (`Environment Setup`).
+- **Conventions** — changes to commit/branch conventions, the PR template, or the GraphQL/`docs/EXPLORER_LINKS.md` regeneration rule.
+
+If a change touches developer-facing setup or workflow, also check whether `README.md`, `tavla/README.md`, `backend/readme.md`, or `docs/` need the same update. When unsure whether something belongs here, prefer a short, factual line over silence.
+
 ## What is Tavla
 
 Tavla is a free, real-time public departure board service for Norwegian public transport (Entur). Users create customizable boards for any transit stop in Norway, configure appearance, and share them via public URLs.
@@ -13,7 +26,7 @@ Monorepo with two main applications:
 - **`tavla/`** – Next.js 16 frontend (React 19, TypeScript, Tailwind CSS, Firebase emulator in dev)
 - **`backend/`** – Rust/Axum API server: thin layer between frontend and Redis pub/sub for real-time board updates
 - **`redirect/`** – Rust redirect service for custom board URLs
-- **`migrations/`** – Python migration scripts for Firestore
+- **`tavla/migrations/`** – Python migration scripts for Firestore
 
 ## Frontend Commands (`tavla/` directory)
 
@@ -73,7 +86,7 @@ Test the running server: `curl localhost:3001/active -H "Authorization: Bearer s
 
 Frontend needs `.env.local` in `tavla/` (get secrets from team password manager). Required variables include Firebase credentials, `BACKEND_API_KEY`, and `GOOGLE_APPLICATION_CREDENTIALS`.
 
-To connect frontend to local backend, temporarily change `getBackendUrl()` in `tavla/src/utils/index.ts` to return `'http://127.0.0.1:3001'`. **Do not commit this change.**
+To connect frontend to local backend, temporarily change `getBackendUrl()` in `tavla/src/utils/backendUrl.ts` to return `'http://127.0.0.1:3001'`. **Do not commit this change.**
 
 Backend env vars for local dev: `BACKEND_API_KEY=super_secret_key`, `REDIS_PASSWORD=super_secret_redis_pw`, plus Redis host/port vars. See `backend/readme.md` for the full table.
 
@@ -141,11 +154,11 @@ Keep sections Bilder and Sjekkliste, but dont change them from the template - a 
 
 ## Migrations
 
-From the repo root `migrations/` directory:
+From the `tavla/migrations/` directory (Python migration scripts for Firestore):
 
 ```bash
 ./migration setup          # First-time environment setup
 ./migration run scripts/<filename>   # Run a migration script
 ```
 
-To test locally with real dev data: stop emulator, run `python3 scripts/rollback_firestore local`, restart with `yarn dev:persist`.
+To test locally with real dev data: stop emulator, run `./migration run scripts/rollback_firestore.py local` (from `tavla/migrations/`), restart with `yarn dev:persist`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all offentlig transport i Norge. Løsningen utvikles av Entur, og er helt gratis og tilgjengelig for alle. Logg inn på [tavla.entur.no](https://tavla.entur.no/) for å komme i gang! Abonner på oppdateringer til Tavla ved å klikke på “Watch” i menyen.
 
+> **Merk:** Dette repoet er admin-/konfigurasjonsappen der man oppretter og redigerer tavler. Selve den offentlige tavle-visningen (det som vises på skjermene) rendres i et eget repo: [entur/tavla-visning](https://github.com/entur/tavla-visning).
+
 ## Hva du kan gjøre
 
 - Lage skreddersydde tavler (velg stopp, rekkefølge, layout)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all offentlig transport i Norge. Løsningen utvikles av Entur, og er helt gratis og tilgjengelig for alle. Logg inn på [tavla.entur.no](https://tavla.entur.no/) for å komme i gang! Abonner på oppdateringer til Tavla ved å klikke på “Watch” i menyen.
 
-> **Merk:** Dette repoet er admin-/konfigurasjonsappen der man oppretter og redigerer tavler. Selve den offentlige tavle-visningen (det som vises på skjermene) rendres i et eget repo: [entur/tavla-visning](https://github.com/entur/tavla-visning).
+> **Merk:** Dette repoet er admin-/konfigurasjonsappen der man oppretter og redigerer tavler. Selve tavle-visningen (det som vises på skjermene) rendres i et eget repo: [entur/tavla-visning](https://github.com/entur/tavla-visning).
 
 ## Hva du kan gjøre
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all off
 
 ```
 /
-├─ backend/        Rust (Axum) API + Redis
-├─ tavla/          Next.js-frontend
-├─ redirect/       Liten Rust-tjeneste (redirect)
-├─ migrations/     Skript og hjelpeverktøy
-├─ helm/           Deploy-konfigurasjon (Helm charts)
-└─ flake.nix       Valgfri Nix dev-miljøfil
+├─ backend/            Rust (Axum) API + Redis
+│  └─ helm/            Deploy-konfigurasjon for backend (Helm chart)
+├─ tavla/              Next.js-frontend
+│  ├─ migrations/      Python-migrasjonsskript for Firestore
+│  └─ helm/            Deploy-konfigurasjon for frontend (Helm chart)
+├─ redirect/           Liten Rust-tjeneste (redirect)
+├─ docs/               Dokumentasjon (database-skjema, GraphQL-lenker)
+└─ flake.nix           Valgfri Nix dev-miljøfil
 ```
 
 ## Teknologistack
@@ -29,12 +31,12 @@ Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all off
 | Frontend | Next.js 16, React 19, TypeScript, Tailwind |
 | Backend  | Rust (Axum), Tokio, Redis pub/sub          |
 | Data/Auth | Firebase (emulator i utvikling)            |
-| Verktøy  | Yarn 3, GraphQL Codegen, Sentry            |
+| Verktøy  | Yarn 4, GraphQL Codegen, Sentry            |
 
 ## Oversikt: slik kjører du (høytnivå)
 
 1. Start Redis (master + replica) – se `backend/readme.md` for detaljer
-2. Start backend (`cargo run`)
+2. Start backend (`./run-local.sh`, eller `cargo run` med miljøvariabler satt)
 3. Start frontend (`yarn dev` eller `yarn dev:persist`)
 4. Sett `BACKEND_API_KEY` i frontend (`.env.local`)
 5. Test med `curl` mot backend
@@ -56,6 +58,15 @@ Detaljer per delkomponent finnes i deres respektive README.
 | NEXT_PUBLIC_ENV | Frontend | Nei | dev | Bygg-/miljøflagg i frontend |
 | SENTRY_* | Frontend/Backend | Nei | – | Valgfri observability |
 | FIREBASE_* | Frontend | Ja (auth) | – | Konfig via emulator / service keys |
+
+## Videre dokumentasjon
+
+Mappen [`docs/`](docs/) inneholder mer utfyllende dokumentasjon:
+
+- [`docs/database.md`](docs/database.md) – Firebase/Firestore-oppsett, hvordan koble mot dev-databasen lokalt, migrering og sikkerhetskopiering/rollback
+- [`docs/EXPLORER_LINKS.md`](docs/EXPLORER_LINKS.md) – alle GraphQL-spørringene mot Journey Planner v3, klare til å kjøres i GraphQL Explorer
+
+Se ellers `backend/readme.md` og `tavla/README.md` for komponentspesifikke detaljer.
 
 ## Bidrag
 

--- a/backend/readme.md
+++ b/backend/readme.md
@@ -37,48 +37,56 @@ The code depends on Redis. Download Redis here:
 
 ### Start Redis
 
-Since we run our stack on Kubernetes we need to mock a master/replica structure locally (You could run the stack in its entirity on a local Kubernetes cluster, like Minikube. Do this on your own discretion)
+Siden vi kjører stacken på Kubernetes må vi etterligne en master/replica-struktur lokalt. (Du kan også kjøre hele stacken i en lokal Kubernetes-klynge som Minikube – på eget ansvar.)
 
-First, start the master instance. Executing the `redis-server` command with `-` as an input will put us in a state where we are reading configurations directly from stdin. We need to set the password for both the master and the replicas.
+`redis-server -` leser konfigurasjon fra stdin. Vi setter samme passord på både master og replica.
+
+**1. Start master (terminal 1):**
 
 ```sh
 redis-server -
 ```
 
-    
+Du skal se noe à la:
 
+```sh
+~ > redis-server -
+82635:C 20 Aug 2024 10:20:39.350 * Reading config from stdin
+```
 
-    Du skal se noe ala:
-    ```sh
-    ~ > redis-server -
-    82635:C 20 Aug 2024 10:20:39.350 * Reading config from stdin
-    ```
-    Skriv inn konfigurasjonen:
-    ```sh
-    masterauth super_secret_redis_pw
-    requirepass super_secret_redis_pw
-    ```
+Skriv inn konfigurasjonen:
+
+```sh
+masterauth super_secret_redis_pw
+requirepass super_secret_redis_pw
+```
 
 Terminalen ser da slik ut:
+
 ```sh
 ~ > redis-server -
 82635:C 20 Aug 2024 10:20:39.350 * Reading config from stdin
 masterauth super_secret_redis_pw
 requirepass super_secret_redis_pw
 ```
-Avslutt konfigurering av første instans med `CTRL-D`.
-2. Start replica i ny terminal:
-    ```sh
-    redis-server -
-    ```
 
-    Du skal se:
-    ```sh
-    ~ > redis-server -
-    82635:C 20 Aug 2024 10:20:39.350 * Reading config from stdin
-    ```
+Avslutt konfigureringen av første instans med `CTRL-D`.
+
+**2. Start replica (terminal 2):**
+
+```sh
+redis-server -
+```
+
+Du skal se:
+
+```sh
+~ > redis-server -
+82635:C 20 Aug 2024 10:20:39.350 * Reading config from stdin
+```
 
 Skriv inn konfigurasjonen:
+
 ```sh
 masterauth super_secret_redis_pw
 requirepass super_secret_redis_pw
@@ -87,6 +95,7 @@ replicaof 127.0.0.1 6379
 ```
 
 Terminalen ser da slik ut:
+
 ```sh
 ~ > redis-server -
 82635:C 20 Aug 2024 10:20:39.350 * Reading config from stdin
@@ -97,8 +106,8 @@ replicaof 127.0.0.1 6379
 ```
 
 Avslutt med `CTRL-D`.
-3. Verifiser Redis / sett teller:
-Koble til Redis i en ny terminal:
+
+**3. Verifiser og sett teller (terminal 3):**
 
 Koble til Redis i en ny terminal:
 
@@ -107,11 +116,13 @@ redis-cli
 ```
 
 Autentiser deg:
+
 ```sh
 auth super_secret_redis_pw
 ```
 
 Sett `active_boards` (teller for aktive tavler) til 0:
+
 ```sh
 set active_boards 0
 ```
@@ -164,14 +175,14 @@ Dette skal returnere `0` (siden du nettopp satte telleren til 0).
 
 For at frontend skal bruke din lokale backend må backend-URL midlertidig endres. **Ikke commit denne endringen.**
 
-Gå til `tavla/src/Shared/utils/index.ts` og endre funksjonen `getBackendUrl` til:
+Gå til `tavla/src/utils/backendUrl.ts` og endre funksjonen `getBackendUrl` til:
 ```ts
 export function getBackendUrl() {
     return 'http://127.0.0.1:3001'
 }
 ```
 
-Frontend trenger også en `.env.local` i `tavla/tavla` med:
+Frontend trenger også en `.env.local` i `tavla/`-mappen (frontend-roten) med:
 ```
 BACKEND_API_KEY="super_secret_key"
 ```

--- a/tavla/README.md
+++ b/tavla/README.md
@@ -1,20 +1,21 @@
 ## Frontend (Next.js) – Utviklerguide
 
-Denne mappen inneholder frontend-koden for Tavla (Next.js 15, React 18, TypeScript, Tailwind, Firebase-emulator i utvikling).
+Denne mappen inneholder frontend-koden for Tavla (Next.js 16, React 19, TypeScript, Tailwind, Firebase-emulator i utvikling).
 
 ### Forutsetninger
 
 - Node 22 (bruk gjerne `mise` eller `nvm`)
-- Yarn 3 (Berry) – allerede satt opp i repoet
+- Yarn 4 (Berry) – allerede satt opp i repoet
 - Firebase CLI (for emulatorer)
 - To interne service key JSON-filer: `ent-tavla-dev-*.json` og `ent-tavla-prd-*.json` (Disse finner du i teamets passord-manager, de skal ikke sjekkes inn i git)
 
 ### Installere avhengigheter
 
-```
-cd tavla/tavla
-yarn install --frozen-lockfile
+Frontend-koden ligger i `tavla/`-mappen i repo-roten (altså `tavla/tavla` sett fra mappen over repoet). Fra repo-roten:
 
+```
+cd tavla
+yarn install --frozen-lockfile
 ```
 
 ### Node-versjon (eksempel med mise)
@@ -24,7 +25,7 @@ brew install mise
 echo 'eval "$(mise activate bash)"' >> ~/.bashrc
 exec $SHELL
 node -v
-# Skal vise v18.x
+# Skal vise v22.x
 ```
 
 ### Kjøre i utvikling
@@ -54,7 +55,7 @@ Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
 | Fix (lint + format) | `yarn fix`                       |
 | Lint                | `yarn lint`                      |
 | Type-sjekk          | `yarn typecheck`                 |
-| Format-sjekk        | `yarn prettier`                  |
+| Format-sjekk        | `yarn format`                    |
 | Bygg (dev/prod)     | `yarn build` / `yarn build:prod` |
 | GraphQL codegen     | `yarn generate`                  |
 
@@ -62,7 +63,7 @@ Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
 
 ### Backend-integrasjon
 
-Frontend kaller Rust-backenden med bearer-token (`BACKEND_API_KEY`). Sørg for at nøkkel samsvarer med verdien backend prosessen forventer. Midlertidig endring av backend-URL kan gjøres i util-funksjon (ikke committ endringen).
+Frontend kaller Rust-backenden med bearer-token (`BACKEND_API_KEY`). Sørg for at nøkkelen samsvarer med verdien backend-prosessen forventer. For å peke mot en lokal backend kan du midlertidig endre `getBackendUrl()` i `tavla/src/utils/backendUrl.ts` til å returnere `'http://127.0.0.1:3001'` (**ikke commit denne endringen**).
 
 ### Git-konvensjoner (gitmoji-subsett)
 
@@ -92,9 +93,9 @@ bugfix/feil-i-refresh-endpoint
 rydding/refaktor-board-context
 ```
 
-### Migrasjonsskript (fra rot `migrations/`)
+### Migrasjonsskript (`tavla/migrations/`)
 
-Migreringsscriptet kan ta inn to argumenter - enten `setup` eller `run`:
+Kjør fra `tavla/migrations/`. Migreringsscriptet tar inn ett av to argumenter – enten `setup` eller `run`:
 
 For å sette opp mijøet for første gang:
 
@@ -113,7 +114,7 @@ For å kjøre en migreringsfil, putt filen i /scripts mappen og kjør:
 Du kan teste migreringsskriptene ved å kjøre de lokalt. Trenger du å skaffe deg litt ekte data, kan du "rollbacke" din lokale Firebase med data fra dev 🔥 Dette gjøres slik:
 
 1. Avslutt emulatoren (kill typ `yarn dev:persist`)
-2. Kjør `python3 scripts/rollback_firestore local`
+2. Kjør `./migration run scripts/rollback_firestore.py local`
 3. Start emulatoren: `yarn dev:persist`
 
 Nå kan du kjøre migrasjonsskriptet ditt som om det var mot dev. Dette korter ned litt på utviklingstiden for migrasjonsskripter.

--- a/tavla/README.md
+++ b/tavla/README.md
@@ -40,7 +40,7 @@ Tilgang:
 - App: http://localhost:3000
 - Firebase Emulator UI: http://127.0.0.1:4000/
 
-For forhåndsvisning av tavler må du også kjøre `tavla-visning`: https://github.com/entur/tavla-visning
+Dette repoet er admin-/konfigurasjonsappen. Selve tavle-visningen (det som rendres på skjermene) ligger i et eget repo. For å forhåndsvise tavler lokalt må du derfor også kjøre `tavla-visning`: https://github.com/entur/tavla-visning
 
 ### Miljøvariabler (lokalt minimum)
 


### PR DESCRIPTION
### 🥅 Bakgrunn

Gjennomgang av `README.md`, `tavla/README.md`, `backend/readme.md` og `CLAUDE.md` avdekket flere utdaterte og direkte feil opplysninger som gjør det vanskelig for nye utviklere å komme i gang.

### ✨ Løsning

- Rettet feil sti til `getBackendUrl` → `tavla/src/utils/backendUrl.ts` (i `CLAUDE.md` og `backend/readme.md`)
- Flyttet `migrations/`-referansene til riktig plassering `tavla/migrations/`, og oppdatert rollback-flyten til `./migration run scripts/rollback_firestore.py local`
- Oppdaterte versjoner: Next.js 16, React 19, Yarn 4, Node v22
- Byttet `yarn prettier` → `yarn format` (prosjektet bruker Biome, ikke Prettier)
- Rettet struktur-treet i `README.md` (`helm/` ligger under `backend/` og `tavla/`, la til `docs/`)
- Presiserte mappestrukturen rundt `cd tavla` vs `tavla/tavla`
- Ryddet opp i formateringen av Redis-oppsettseksjonen i `backend/readme.md` 
- La til en «Videre dokumentasjon»-seksjon i `README.md` som peker på `docs/`
- La til en instruks i `CLAUDE.md` om å holde dokumentasjonen oppdatert ved relevante endringer



🤖 Generated with [Claude Code](https://claude.com/claude-code)