### PR TITLE
🧹  Destrukturering av PosthogTracking

### DIFF
--- a/tavla/app/(innlogget)/components/CreateBoard/CreateBoard.tsx
+++ b/tavla/app/(innlogget)/components/CreateBoard/CreateBoard.tsx
@@ -17,13 +17,13 @@ type CreateBoardProps = {
 
 function CreateBoard({ folders, folder, trackingLocation }: CreateBoardProps) {
     const [isOpen, setIsOpen] = useState(false)
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <>
             <PrimaryButton
                 onClick={() => {
-                    posthog.capture('board_create_started', {
+                    capture('board_create_started', {
                         location: trackingLocation,
                         type: 'new',
                     })
@@ -37,7 +37,7 @@ function CreateBoard({ folders, folder, trackingLocation }: CreateBoardProps) {
                 open={isOpen}
                 size="small"
                 onDismiss={() => {
-                    posthog.capture('board_create_cancelled', {
+                    capture('board_create_cancelled', {
                         method: 'dismissed',
                     })
                     setIsOpen(false)
@@ -48,7 +48,7 @@ function CreateBoard({ folders, folder, trackingLocation }: CreateBoardProps) {
                 <IconButton
                     aria-label="Avbryt opprettelse av tavle"
                     onClick={() => {
-                        posthog.capture('board_create_cancelled', {
+                        capture('board_create_cancelled', {
                             method: 'close_icon',
                         })
                         setIsOpen(false)
@@ -61,7 +61,7 @@ function CreateBoard({ folders, folder, trackingLocation }: CreateBoardProps) {
                     folders={folders}
                     folder={folder}
                     onClose={() => {
-                        posthog.capture('board_create_cancelled', {
+                        capture('board_create_cancelled', {
                             method: 'cancel_button',
                         })
                         setIsOpen(false)

--- a/tavla/app/(innlogget)/components/CreateBoard/NameAndFolderSelector.tsx
+++ b/tavla/app/(innlogget)/components/CreateBoard/NameAndFolderSelector.tsx
@@ -39,7 +39,7 @@ function NameAndFolderSelector({
     onClose,
 }: NameAndFolderSelectorProps) {
     const [state, action] = useActionState(createBoardAction, undefined)
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const isArrivalDepartureFeatureFlagEnabled = useFeatureFlagEnabled(
         FeatureFlags.ARRIVAL_DEPARTURE_BOARD,
     )
@@ -106,7 +106,7 @@ function NameAndFolderSelector({
                         onChange={(item) => {
                             if (item) {
                                 setSelectedArrivalDeparture(item)
-                                posthog.capture('choose_board_type_selected', {
+                                capture('choose_board_type_selected', {
                                     type: item.value
                                         ? 'arrivals'
                                         : 'departures',
@@ -129,7 +129,7 @@ function NameAndFolderSelector({
                     variant="primary"
                     width="fluid"
                     onClick={() => {
-                        posthog.capture('board_created', {
+                        capture('board_created', {
                             folder_selected: !isNull(selectedFolder.value),
                             type_selected: selectedArrivalDeparture.value
                                 ? 'arrivals'

--- a/tavla/app/(innlogget)/components/CreateFolder/CreateFolder.tsx
+++ b/tavla/app/(innlogget)/components/CreateFolder/CreateFolder.tsx
@@ -17,13 +17,13 @@ function CreateFolder() {
     const [isOpen, setIsOpen] = useState(false)
     const [state, formAction] = useActionState(createFolderAction, undefined)
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <>
             <SecondaryButton
                 onClick={() => {
-                    posthog.capture('folder_create_started')
+                    capture('folder_create_started')
                     setIsOpen(true)
                 }}
             >
@@ -35,7 +35,7 @@ function CreateFolder() {
                 open={isOpen}
                 size="small"
                 onDismiss={() => {
-                    posthog.capture('folder_create_cancelled', {
+                    capture('folder_create_cancelled', {
                         method: 'dismissed',
                     })
                     setIsOpen(false)
@@ -45,7 +45,7 @@ function CreateFolder() {
                 <IconButton
                     aria-label="Lukk"
                     onClick={() => {
-                        posthog.capture('folder_create_cancelled', {
+                        capture('folder_create_cancelled', {
                             method: 'close_icon',
                         })
                         setIsOpen(false)
@@ -92,7 +92,7 @@ function CreateFolder() {
                             aria-label="Opprett mappe"
                             className="!mr-0"
                             onClick={() => {
-                                posthog.capture('folder_created')
+                                capture('folder_created')
                             }}
                         >
                             Opprett
@@ -104,7 +104,7 @@ function CreateFolder() {
                             variant="secondary"
                             aria-label="Avbryt opprett mappe"
                             onClick={() => {
-                                posthog.capture('folder_create_cancelled', {
+                                capture('folder_create_cancelled', {
                                     method: 'cancel_button',
                                 })
                                 setIsOpen(false)

--- a/tavla/app/(innlogget)/components/DeleteFolder/DeleteFolder.tsx
+++ b/tavla/app/(innlogget)/components/DeleteFolder/DeleteFolder.tsx
@@ -30,7 +30,7 @@ function DeleteFolder({
     type: 'icon' | 'button'
 }) {
     const { addToast } = useToast()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const [state, deleteFolder] = useActionState(deleteFolderAction, undefined)
     const [isOpen, setIsOpen] = useState(false)
@@ -60,7 +60,7 @@ function DeleteFolder({
                     ariaLabel={ariaLabel}
                     type={type}
                     onClick={() => {
-                        posthog.capture('folder_delete_started', {
+                        capture('folder_delete_started', {
                             location: 'folder',
                             folder_id: folder.id,
                         })
@@ -73,7 +73,7 @@ function DeleteFolder({
                 open={isOpen}
                 size="small"
                 onDismiss={() => {
-                    posthog.capture('folder_delete_cancelled', {
+                    capture('folder_delete_cancelled', {
                         location: 'folder',
                         folder_id: folder.id,
                         method: 'dismissed',
@@ -88,7 +88,7 @@ function DeleteFolder({
                 <IconButton
                     aria-label="Lukk"
                     onClick={() => {
-                        posthog.capture('folder_delete_cancelled', {
+                        capture('folder_delete_cancelled', {
                             location: 'folder',
                             folder_id: folder.id,
                             method: 'close_icon',
@@ -132,7 +132,7 @@ function DeleteFolder({
                             className="w-1/2"
                             width="fluid"
                             onClick={() => {
-                                posthog.capture('folder_deleted', {
+                                capture('folder_deleted', {
                                     location: 'folder',
                                     folder_id: folder.id,
                                 })
@@ -145,7 +145,7 @@ function DeleteFolder({
                             variant="secondary"
                             aria-label="Avbryt sletting"
                             onClick={() => {
-                                posthog.capture('folder_delete_cancelled', {
+                                capture('folder_delete_cancelled', {
                                     location: 'folder',
                                     folder_id: folder.id,
                                     method: 'cancelled',

--- a/tavla/app/(innlogget)/components/Login/Create.tsx
+++ b/tavla/app/(innlogget)/components/Login/Create.tsx
@@ -26,7 +26,7 @@ import { create } from './actions'
 import Google from './Google'
 
 function Create() {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const [email, setEmail] = useState('')
     const submit = async (
         _previousState: TFormFeedback | undefined,
@@ -105,7 +105,7 @@ function Create() {
                         width="fluid"
                         aria-label="Opprett bruker"
                         onClick={() => {
-                            posthog.capture('user_create_method_selected', {
+                            capture('user_create_method_selected', {
                                 location: 'user_modal',
                                 method: 'email',
                             })
@@ -126,7 +126,7 @@ function Create() {
                     className="underline"
                     href="?login=email"
                     onClick={() =>
-                        posthog.capture('user_login_started', {
+                        capture('user_login_started', {
                             location: 'user_modal',
                             context: 'create',
                         })

--- a/tavla/app/(innlogget)/components/Login/Email.tsx
+++ b/tavla/app/(innlogget)/components/Login/Email.tsx
@@ -27,7 +27,7 @@ import Google from './Google'
 import type { TLoginPage } from './types'
 
 function Email() {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const [email, setEmail] = useState('')
     const submit = async (
         _previousState: TFormFeedback | undefined,
@@ -123,7 +123,7 @@ function Email() {
                         className="underline"
                         href={getPathWithParams('reset')}
                         onClick={() =>
-                            posthog.capture('user_forgot_password', {
+                            capture('user_forgot_password', {
                                 location: 'user_modal',
                             })
                         }
@@ -137,7 +137,7 @@ function Email() {
                         width="fluid"
                         aria-label="Logg inn"
                         onClick={() => {
-                            posthog.capture('user_login_method_selected', {
+                            capture('user_login_method_selected', {
                                 method: 'email',
                                 location: 'user_modal',
                                 context: 'email',
@@ -156,7 +156,7 @@ function Email() {
                     className="underline"
                     href={getPathWithParams('create')}
                     onClick={() =>
-                        posthog.capture('user_create_started', {
+                        capture('user_create_started', {
                             location: 'user_modal',
                             context: 'email',
                         })

--- a/tavla/app/(innlogget)/components/Login/Entry.tsx
+++ b/tavla/app/(innlogget)/components/Login/Entry.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link'
 import Google from './Google'
 
 function Entry() {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <div className="flex flex-col items-center">
@@ -32,7 +32,7 @@ function Entry() {
                     as={Link}
                     href="lag-tavle"
                     onClick={() => {
-                        posthog.capture('board_create_without_user', {
+                        capture('board_create_without_user', {
                             location: 'user_modal',
                             context: 'entry',
                         })
@@ -46,7 +46,7 @@ function Entry() {
                     as={Link}
                     href="?login=email"
                     onClick={() => {
-                        posthog.capture('user_login_method_selected', {
+                        capture('user_login_method_selected', {
                             location: 'user_modal',
                             method: 'email',
                             context: 'entry',
@@ -68,7 +68,7 @@ function Entry() {
                     as={Link}
                     href="?login=create"
                     onClick={() => {
-                        posthog.capture('user_create_started', {
+                        capture('user_create_started', {
                             location: 'user_modal',
                             context: 'entry',
                         })

--- a/tavla/app/(innlogget)/components/Login/Google.tsx
+++ b/tavla/app/(innlogget)/components/Login/Google.tsx
@@ -30,7 +30,7 @@ export default function Google({
 }: Props) {
     const [isLoading, setIsLoading] = useState(false)
     const [errorMessage, setErrorMessage] = useState(['', ''])
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const googleAction = async () => {
         setIsLoading(true)
@@ -87,7 +87,7 @@ export default function Google({
             ) : (
                 <SecondaryButton
                     onClick={() => {
-                        posthog.capture('user_login_method_selected', {
+                        capture('user_login_method_selected', {
                             location: trackingLocation,
                             method: 'google',
                             context: trackingContext,

--- a/tavla/app/(innlogget)/components/Login/Login.tsx
+++ b/tavla/app/(innlogget)/components/Login/Login.tsx
@@ -17,7 +17,7 @@ import type { TLoginPage } from './types'
 function Login({ loggedIn }: { loggedIn: boolean }) {
     const router = useRouter()
     const pathname = usePathname()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const { open, pageParam } = usePageParam('login')
 
@@ -25,7 +25,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
         return (
             <IconButton
                 onClick={async () => {
-                    posthog.capture('user_log_out_started', {
+                    capture('user_log_out_started', {
                         location: 'nav_bar',
                     })
                     await logout()
@@ -45,7 +45,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 scroll={false}
                 className="shrink-0 gap-2"
                 onClick={() => {
-                    posthog.capture('user_login_started', {
+                    capture('user_login_started', {
                         location: 'nav_bar',
                     })
                 }}
@@ -60,7 +60,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 className="w-11/12 lg:w-full"
                 onDismiss={() => {
                     router.push(pathname ?? '/')
-                    posthog.capture('user_modal_closed', {
+                    capture('user_modal_closed', {
                         context: pageParam as TLoginPage,
                     })
                 }}
@@ -68,7 +68,7 @@ function Login({ loggedIn }: { loggedIn: boolean }) {
                 <IconButton
                     aria-label="Lukk"
                     onClick={() => {
-                        posthog.capture('user_modal_closed', {
+                        capture('user_modal_closed', {
                             context: pageParam as TLoginPage,
                         })
                         router.push(pathname ?? '/')

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/InviteUser.tsx
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/InviteUser.tsx
@@ -16,7 +16,7 @@ function InviteUser({ folderid }: { folderid?: FolderDB['id'] }) {
     const [state, formAction] = useActionState(inviteUserAction, undefined)
     const { addToast } = useToast()
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const formRef = useRef<HTMLFormElement>(null)
 
@@ -46,7 +46,7 @@ function InviteUser({ folderid }: { folderid?: FolderDB['id'] }) {
                     width="fluid"
                     className="mb-4 w-full sm:max-w-48"
                     onClick={() => {
-                        posthog.capture('folder_members_managed', {
+                        capture('folder_members_managed', {
                             location: 'folder',
                             folder_id: folderid ?? '',
                             method: 'invited',

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/MemberAdministration.tsx
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/MemberAdministration.tsx
@@ -22,13 +22,13 @@ function MemberAdministration({
 }) {
     const [isOpen, setIsOpen] = useState(false)
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <>
             <Button
                 onClick={() => {
-                    posthog.capture('folder_members_manage_started', {
+                    capture('folder_members_manage_started', {
                         location: 'folder',
                         folder_id: folder.id,
                     })
@@ -43,7 +43,7 @@ function MemberAdministration({
                 title="Administrer medlemmer"
                 open={isOpen}
                 onDismiss={() => {
-                    posthog.capture('folder_members_manage_cancelled', {
+                    capture('folder_members_manage_cancelled', {
                         location: 'folder',
                         folder_id: folder.id,
                         method: 'dismissed',

--- a/tavla/app/(innlogget)/mapper/components/MemberAdministration/RemoveUserButton.tsx
+++ b/tavla/app/(innlogget)/mapper/components/MemberAdministration/RemoveUserButton.tsx
@@ -19,7 +19,7 @@ function RemoveUserButton({
     const [, deleteUser] = useActionState(removeUserAction, undefined)
     const { addToast } = useToast()
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const action = async (data: FormData) => {
         deleteUser(data)
@@ -35,7 +35,7 @@ function RemoveUserButton({
                     type="submit"
                     className="gap-2"
                     onClick={() => {
-                        posthog.capture('folder_members_managed', {
+                        capture('folder_members_managed', {
                             location: 'folder',
                             folder_id: folderid ?? '',
                             method: 'removed',

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/LogoInput.tsx
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/LogoInput.tsx
@@ -23,10 +23,10 @@ function LogoInput({ folderid }: { folderid?: FolderDB['id'] }) {
     const [fileName, setFileName] = useState<string>()
     const router = useRouter()
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const clearLogo = () => {
-        posthog.capture('folder_logo_upload_cancelled', {
+        capture('folder_logo_upload_cancelled', {
             location: 'folder',
             folder_id: folderid ?? '',
             method: 'cancel_button',
@@ -115,7 +115,7 @@ function LogoInput({ folderid }: { folderid?: FolderDB['id'] }) {
                         aria-label="Last opp logo"
                         className="w-full justify-center"
                         onClick={() => {
-                            posthog.capture('folder_logo_uploaded', {
+                            capture('folder_logo_uploaded', {
                                 location: 'folder',
                                 folder_id: folderid ?? '',
                             })

--- a/tavla/app/(innlogget)/mapper/components/UploadLogo/UploadLogo.tsx
+++ b/tavla/app/(innlogget)/mapper/components/UploadLogo/UploadLogo.tsx
@@ -13,14 +13,14 @@ import { LogoInput } from './LogoInput'
 function UploadLogo({ folder }: { folder: FolderDB }) {
     const [isOpen, setIsOpen] = useState(false)
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <>
             <Button
                 variant="secondary"
                 onClick={() => {
-                    posthog.capture('folder_logo_upload_started', {
+                    capture('folder_logo_upload_started', {
                         location: 'folder',
                         folder_id: folder.id,
                     })
@@ -32,7 +32,7 @@ function UploadLogo({ folder }: { folder: FolderDB }) {
             <Modal
                 open={isOpen}
                 onDismiss={() => {
-                    posthog.capture('folder_logo_upload_cancelled', {
+                    capture('folder_logo_upload_cancelled', {
                         location: 'folder',
                         folder_id: folder.id,
                         method: 'dismissed',

--- a/tavla/app/(innlogget)/oversikt/components/Column/DeleteBoard.tsx
+++ b/tavla/app/(innlogget)/oversikt/components/Column/DeleteBoard.tsx
@@ -28,7 +28,7 @@ function DeleteBoard({
     trackingLocation: EventProps<'board_deleted'>['location']
 }) {
     const { addToast } = useToast()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const [state, deleteBoard] = useActionState(deleteBoardAction, undefined)
     const [isOpen, setIsOpen] = useState(false)
@@ -49,7 +49,7 @@ function DeleteBoard({
                 ariaLabel={ariaLabel}
                 type={type}
                 onClick={() => {
-                    posthog.capture('board_deleted', {
+                    capture('board_deleted', {
                         location: trackingLocation,
                     })
                     setIsOpen(true)

--- a/tavla/app/(innlogget)/oversikt/components/LocalStorageBoardBanner.tsx
+++ b/tavla/app/(innlogget)/oversikt/components/LocalStorageBoardBanner.tsx
@@ -13,7 +13,7 @@ export function LocalStorageBoardBanner() {
     const [board, setBoard] = useState<BoardDB | null>(null)
     const [loading, setLoading] = useState(false)
     const router = useRouter()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     useEffect(() => {
         const localStorageValue = localStorage.getItem(LOCAL_STORAGE_KEY)
@@ -31,7 +31,7 @@ export function LocalStorageBoardBanner() {
         try {
             const boardId = await saveBoardToFirebaseForUser(board)
             localStorage.removeItem(LOCAL_STORAGE_KEY)
-            posthog.capture('board_create_started', {
+            capture('board_create_started', {
                 location: 'admin',
                 type: 'from_local_storage',
             })
@@ -43,7 +43,7 @@ export function LocalStorageBoardBanner() {
 
     const handleDiscard = () => {
         localStorage.removeItem(LOCAL_STORAGE_KEY)
-        posthog.capture('board_dismiss_from_local_storage')
+        capture('board_dismiss_from_local_storage')
         setBoard(null)
     }
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Buttons/Copy.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Buttons/Copy.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 function Copy({ type, bid, board, trackingLocation }: Props) {
     const { addToast } = useToast()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     if (!bid) return null
 
@@ -27,7 +27,7 @@ function Copy({ type, bid, board, trackingLocation }: Props) {
         navigator.clipboard.writeText(boardLink)
         addToast('Lenken til tavlen ble kopiert!')
 
-        posthog.capture('board_copied', {
+        capture('board_copied', {
             location: trackingLocation,
         })
     }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Buttons/Open.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Buttons/Open.tsx
@@ -16,7 +16,7 @@ type Props = {
 }
 
 function Open({ type, bid, board, trackingLocation }: Props) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     if (!bid) {
         return null
@@ -35,7 +35,7 @@ function Open({ type, bid, board, trackingLocation }: Props) {
                 href={link ?? '/'}
                 target="_blank"
                 onClick={() => {
-                    posthog.capture('board_opened', {
+                    capture('board_opened', {
                         location: trackingLocation,
                     })
                 }}
@@ -58,7 +58,7 @@ function Open({ type, bid, board, trackingLocation }: Props) {
                 href={link ?? '/'}
                 target="_blank"
                 onClick={() =>
-                    posthog.capture('board_opened', {
+                    capture('board_opened', {
                         location: trackingLocation,
                     })
                 }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
@@ -23,7 +23,7 @@ function CustomUrl({
     bid: BoardDB['id']
     customUrl?: string
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const [open, setOpen] = useState(false)
     const [value, setValue] = useState(customUrl ?? '')
@@ -37,7 +37,7 @@ function CustomUrl({
         }
 
         debounceTimerRef.current = setTimeout(() => {
-            posthog.capture('custom_url_modified', { location: 'board_page' })
+            capture('custom_url_modified', { location: 'board_page' })
         }, TRACKING_DEBOUNCE_TIME)
 
         setFeedback(validateCustomUrl(newValue))
@@ -49,7 +49,7 @@ function CustomUrl({
 
     const submit = () => {
         startTransition(async () => {
-            posthog.capture('custom_url_saved', { location: 'board_page' })
+            capture('custom_url_saved', { location: 'board_page' })
             const result = await saveCustomUrl(bid, value)
             if (result.error) {
                 setFeedback(result.error)
@@ -69,7 +69,7 @@ function CustomUrl({
                 <IconButton
                     aria-label="Rediger lenken til tavla"
                     onClick={() => {
-                        posthog.capture('custom_url_modal_opened', {
+                        capture('custom_url_modal_opened', {
                             location: 'board_page',
                         })
                         setOpen(true)
@@ -82,7 +82,7 @@ function CustomUrl({
                 <Modal
                     size="medium"
                     onDismiss={() => {
-                        posthog.capture('custom_url_modal_closed', {
+                        capture('custom_url_modal_closed', {
                             location: 'board_page',
                         })
                         setOpen(false)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/RefreshButton.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/RefreshButton/RefreshButton.tsx
@@ -7,9 +7,9 @@ import { refreshBoard } from './actions'
 
 function RefreshButton({ board }: { board: BoardDB }) {
     const toast = useToast()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const refresh = async () => {
-        posthog.capture('board_published', {
+        capture('board_published', {
             location: 'board_page',
         })
         const status = await refreshBoard(board)

--- a/tavla/app/_components/ContactForm.tsx
+++ b/tavla/app/_components/ContactForm.tsx
@@ -18,7 +18,7 @@ import { SubmitButton } from './Form/SubmitButton'
 import ClientOnlyTextField from './NoSSR/TextField'
 
 function ContactForm() {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const { addToast } = useToast()
     const [isOpen, setIsOpen] = useState(false)
@@ -59,9 +59,9 @@ function ContactForm() {
                 setIsOpen={(open) => {
                     setIsOpen(open)
                     if (open) {
-                        posthog.capture('contact_form_opened')
+                        capture('contact_form_opened')
                     } else {
-                        posthog.capture('contact_form_closed')
+                        capture('contact_form_closed')
                     }
                 }}
             >
@@ -104,12 +104,9 @@ function ContactForm() {
                                 name="disabledEmail"
                                 onChange={(e) => {
                                     setDisabledEmail(e.target.checked)
-                                    posthog.capture(
-                                        'contact_form_email_disabled',
-                                        {
-                                            disabled: e.target.checked,
-                                        },
-                                    )
+                                    capture('contact_form_email_disabled', {
+                                        disabled: e.target.checked,
+                                    })
                                 }}
                             >
                                 Jeg ønsker ikke å oppgi e-postadresse og vil
@@ -141,9 +138,7 @@ function ContactForm() {
                         variant="primary"
                         width="fluid"
                         aria-label="Send"
-                        onClick={() =>
-                            posthog.capture('contact_form_submitted')
-                        }
+                        onClick={() => capture('contact_form_submitted')}
                     >
                         Send
                     </SubmitButton>

--- a/tavla/app/_components/CreateUserButton.tsx
+++ b/tavla/app/_components/CreateUserButton.tsx
@@ -10,7 +10,7 @@ function CreateUserButton({
     variant?: 'primary' | 'secondary'
     width?: 'auto' | 'fluid'
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     return (
         <Button
             variant={variant || 'primary'}
@@ -18,7 +18,7 @@ function CreateUserButton({
             as={Link}
             href="?login=create"
             onClick={() => {
-                posthog.capture('user_create_started', {
+                capture('user_create_started', {
                     location: 'board_without_user',
                 })
             }}

--- a/tavla/app/_components/Footer.tsx
+++ b/tavla/app/_components/Footer.tsx
@@ -9,7 +9,7 @@ import Link from 'next/link'
 import { showUC_UI as showUserCentricsUI } from './ConsentHandler'
 
 function Footer({ loggedIn }: { loggedIn: boolean }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     return (
         <footer className="eds-contrast">
             <div className="container pb-20 pt-16">
@@ -37,10 +37,9 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                     external
                                     href="https://www.entur.org/kontakt-oss/"
                                     onClick={() =>
-                                        posthog.capture(
-                                            'contact_customer_service',
-                                            { location: 'footer' },
-                                        )
+                                        capture('contact_customer_service', {
+                                            location: 'footer',
+                                        })
                                     }
                                     target="_blank"
                                 >
@@ -52,7 +51,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                     href="mailto:tavla@entur.org"
                                     target="_blank"
                                     onClick={() =>
-                                        posthog.capture('contact_tavla', {
+                                        capture('contact_tavla', {
                                             location: 'footer',
                                         })
                                     }
@@ -70,7 +69,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                     href="/hjelp"
                                     as={Link}
                                     onClick={() =>
-                                        posthog.capture('faq_link_clicked', {
+                                        capture('faq_link_clicked', {
                                             location: 'footer',
                                         })
                                     }
@@ -102,12 +101,9 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                 <EnturLink
                                     as="button"
                                     onClick={() => {
-                                        posthog.capture(
-                                            'cookie_settings_opened',
-                                            {
-                                                location: 'footer',
-                                            },
-                                        )
+                                        capture('cookie_settings_opened', {
+                                            location: 'footer',
+                                        })
                                         showUserCentricsUI()
                                     }}
                                     className="self-start"
@@ -121,7 +117,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
                                     href="https://github.com/entur/tavla"
                                     target="_blank"
                                     onClick={() =>
-                                        posthog.capture('github_link_clicked', {
+                                        capture('github_link_clicked', {
                                             location: 'footer',
                                         })
                                     }

--- a/tavla/app/_components/MobileNavbar.tsx
+++ b/tavla/app/_components/MobileNavbar.tsx
@@ -14,7 +14,7 @@ import { useState } from 'react'
 function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
     const pathname = usePathname()
     const [isOpen, setIsOpen] = useState(false)
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <div className="block md:hidden">
@@ -49,7 +49,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                             href="/"
                             aria-label="Tilbake til forsiden"
                             onClick={() =>
-                                posthog.capture('go_to_home_page', {
+                                capture('go_to_home_page', {
                                     location: 'nav_bar',
                                 })
                             }
@@ -64,7 +64,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                             <SideNavigationItem
                                 active={pathname?.includes('/oversikt')}
                                 onClick={async () => {
-                                    posthog.capture('admin_page_opened', {
+                                    capture('admin_page_opened', {
                                         location: 'nav_bar',
                                     })
                                     setIsOpen(false)
@@ -81,12 +81,9 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                                 as={Link}
                                 href="/lag-tavle"
                                 onClick={async () => {
-                                    posthog.capture(
-                                        'board_without_user_started',
-                                        {
-                                            location: 'nav_bar',
-                                        },
-                                    )
+                                    capture('board_without_user_started', {
+                                        location: 'nav_bar',
+                                    })
                                     setIsOpen(false)
                                 }}
                                 className="!text-primary"
@@ -98,7 +95,7 @@ function MobileNavbar({ loggedIn }: { loggedIn: boolean }) {
                         <SideNavigationItem
                             active={pathname?.includes('/hjelp')}
                             onClick={async () => {
-                                posthog.capture('faq_link_clicked', {
+                                capture('faq_link_clicked', {
                                     location: 'nav_bar',
                                 })
                                 setIsOpen(false)

--- a/tavla/app/_components/Navbar.tsx
+++ b/tavla/app/_components/Navbar.tsx
@@ -10,14 +10,14 @@ import { MobileNavbar } from './MobileNavbar'
 
 function Navbar({ loggedIn }: { loggedIn: boolean }) {
     const pathname = usePathname()
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <nav className="container flex flex-row items-center justify-between gap-3 py-8">
             <Link
                 href="/"
                 onClick={() =>
-                    posthog.capture('go_to_home_page', { location: 'nav_bar' })
+                    capture('go_to_home_page', { location: 'nav_bar' })
                 }
             >
                 <Image
@@ -35,7 +35,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                             href="/oversikt"
                             className="hidden flex-col !text-primary md:flex"
                             onClick={() => {
-                                posthog.capture('admin_page_opened', {
+                                capture('admin_page_opened', {
                                     location: 'nav_bar',
                                 })
                             }}
@@ -48,7 +48,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                             as={Link}
                             href="/lag-tavle"
                             onClick={() => {
-                                posthog.capture('board_without_user_started', {
+                                capture('board_without_user_started', {
                                     location: 'nav_bar',
                                 })
                             }}
@@ -63,7 +63,7 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
                         href="/hjelp"
                         className="hidden flex-col !text-primary md:flex"
                         onClick={() => {
-                            posthog.capture('faq_link_clicked', {
+                            capture('faq_link_clicked', {
                                 location: 'nav_bar',
                             })
                         }}

--- a/tavla/app/_components/NavigateToOversiktButton.tsx
+++ b/tavla/app/_components/NavigateToOversiktButton.tsx
@@ -5,7 +5,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import Link from 'next/link'
 
 export function NavigateToOversiktButton() {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     return (
         <Button
             variant="primary"
@@ -13,7 +13,7 @@ export function NavigateToOversiktButton() {
             as={Link}
             href="/oversikt"
             onClick={() => {
-                posthog.capture('admin_page_opened', {
+                capture('admin_page_opened', {
                     location: 'landing_page',
                 })
             }}

--- a/tavla/app/_components/TableSettings/ElementsSelect.tsx
+++ b/tavla/app/_components/TableSettings/ElementsSelect.tsx
@@ -13,7 +13,7 @@ function ElementSelect({
     selectedElements?: Elements[]
     onChange: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <div className="flex flex-col gap-1">
@@ -26,7 +26,7 @@ function ElementSelect({
                     name="clock"
                     value="clock"
                     onChange={() => {
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'element_select',
                             value: 'clock',
                         })
@@ -40,7 +40,7 @@ function ElementSelect({
                     name="logo"
                     value="logo"
                     onChange={() => {
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'element_select',
                             value: 'logo',
                         })

--- a/tavla/app/_components/TableSettings/FontSelect.tsx
+++ b/tavla/app/_components/TableSettings/FontSelect.tsx
@@ -10,7 +10,7 @@ function FontSelect({
     font?: BoardFontSize
     onChange: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <ChoiceChipGroupGeneral<BoardFontSize>
@@ -24,7 +24,7 @@ function FontSelect({
             name="font"
             ariaLabel="Tekststørrelse"
             onChange={(value) => {
-                posthog.capture('board_settings_changed', {
+                capture('board_settings_changed', {
                     setting: 'font',
                     value: value as 'small' | 'medium' | 'large',
                 })

--- a/tavla/app/_components/TableSettings/InfoMessage.tsx
+++ b/tavla/app/_components/TableSettings/InfoMessage.tsx
@@ -17,7 +17,7 @@ function InfoMessage({
     infoMessage?: BoardFooter
     onBlur: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const [selectedValue, setSelectedValue] = useState<string>(
         infoMessage?.footer ?? '',
     )
@@ -53,7 +53,7 @@ function InfoMessage({
                     }
 
                     debounceTimerRef.current = setTimeout(() => {
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'info_message',
                             value: 'changed',
                         })

--- a/tavla/app/_components/TableSettings/ThemeSelect.tsx
+++ b/tavla/app/_components/TableSettings/ThemeSelect.tsx
@@ -10,7 +10,7 @@ function ThemeSelect({
     theme?: BoardTheme
     onChange: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <ChoiceChipGroupGeneral<BoardTheme>
@@ -21,7 +21,7 @@ function ThemeSelect({
             ]}
             defaultValue={theme}
             onChange={(value) => {
-                posthog.capture('board_settings_changed', {
+                capture('board_settings_changed', {
                     setting: 'theme',
                     value: value as 'light' | 'dark',
                 })

--- a/tavla/app/_components/TableSettings/Title.tsx
+++ b/tavla/app/_components/TableSettings/Title.tsx
@@ -17,7 +17,7 @@ function Title({
     feedback?: TFormFeedback
     onBlur: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
 
     return (
@@ -39,7 +39,7 @@ function Title({
                     }
 
                     debounceTimerRef.current = setTimeout(() => {
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'title',
                             value: 'changed',
                         })

--- a/tavla/app/_components/TableSettings/TransportPaletteSelect.tsx
+++ b/tavla/app/_components/TableSettings/TransportPaletteSelect.tsx
@@ -45,7 +45,7 @@ function TransportPaletteSelect({
     allowedPalettes?: TransportPalette[]
     onChange: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const [selectedValue, setSelectedValue] =
         useState<TransportPalette>(transportPalette)
@@ -88,7 +88,7 @@ function TransportPaletteSelect({
                         const newValue = e.target.value as TransportPalette
                         handleChange(newValue)
 
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'transport_palette',
                             value: newValue,
                         })

--- a/tavla/app/_components/TableSettings/ViewType.tsx
+++ b/tavla/app/_components/TableSettings/ViewType.tsx
@@ -12,7 +12,7 @@ function ViewType({
     hasCombinedTiles: boolean
     onChange: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const [value, setValue] = useState(
         hasCombinedTiles ? 'combined' : 'separate',
     )
@@ -29,7 +29,7 @@ function ViewType({
                 <RadioGroup
                     name="viewType"
                     onChange={(e) => {
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'view_type',
                             value: e.target.value as 'combined' | 'separate',
                         })

--- a/tavla/app/_components/TableSettings/WalkingDistance.tsx
+++ b/tavla/app/_components/TableSettings/WalkingDistance.tsx
@@ -15,7 +15,7 @@ function WalkingDistance({
     location?: LocationDB
     onChange: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const { pointItems, selectedPoint, setSelectedPoint } =
         usePointSearch(location)
@@ -45,7 +45,7 @@ function WalkingDistance({
                     items={pointItems}
                     selectedItem={selectedPoint}
                     onChange={(e) => {
-                        posthog.capture('board_settings_changed', {
+                        capture('board_settings_changed', {
                             setting: 'board_location',
                             value: 'changed',
                         })

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -60,7 +60,7 @@ function PlatformAndLines({
     onToggleLine: (compositeKey: string) => void
     onToggleGroup: (compositeKeys: string[], checked: boolean) => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const selectedLinesInGroup = lines.filter((l) =>
         selectedLineIds.has(`${quayId}||${l.id}`),
@@ -137,7 +137,7 @@ function PlatformAndLines({
                     checked={isIndeterminate ? 'indeterminate' : isAllSelected}
                     onChange={(e) => {
                         const checked = e.target.checked
-                        posthog.capture('stop_place_edit_interaction', {
+                        capture('stop_place_edit_interaction', {
                             location: trackingLocation,
                             field: 'lines',
                             column_value: 'none',
@@ -162,7 +162,7 @@ function PlatformAndLines({
                         name={`${tile.uuid}-lines`}
                         data-transport-mode={line.transportMode}
                         onChange={() => {
-                            posthog.capture('stop_place_edit_interaction', {
+                            capture('stop_place_edit_interaction', {
                                 location: trackingLocation,
                                 field: 'lines',
                                 column_value: 'none',

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -42,7 +42,7 @@ export function TileCard({
     moveItem: (index: number, direction: string) => void
     setTilesLocalStorageBoard?: (tiles: BoardDB['tiles']) => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const totalTiles = board.tiles.length
 
@@ -189,7 +189,7 @@ export function TileCard({
     }
 
     const handleDeleteTile = () => {
-        posthog.capture('stop_place_deleted', {
+        capture('stop_place_deleted', {
             location: trackingLocation,
         })
 

--- a/tavla/app/_components/TileCard/components/EditRemoveTileButtonGroup.tsx
+++ b/tavla/app/_components/TileCard/components/EditRemoveTileButtonGroup.tsx
@@ -20,7 +20,7 @@ function EditRemoveTileButtonGroup({
     deleteTile: () => void
     trackingLocation: EventProps<'stop_place_edit_cancelled'>['location']
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <div className="flex gap-4">
@@ -32,11 +32,11 @@ function EditRemoveTileButtonGroup({
                 <SecondarySquareButton
                     onClick={() => {
                         if (!isTileOpen) {
-                            posthog.capture('stop_place_edit_started', {
+                            capture('stop_place_edit_started', {
                                 location: trackingLocation,
                             })
                         } else {
-                            posthog.capture('stop_place_edit_cancelled', {
+                            capture('stop_place_edit_cancelled', {
                                 location: trackingLocation,
                                 unsavedChanges: hasTileChanged,
                             })

--- a/tavla/app/_components/TileCard/components/SaveCancelDeleteTileButtonGroup.tsx
+++ b/tavla/app/_components/TileCard/components/SaveCancelDeleteTileButtonGroup.tsx
@@ -40,7 +40,7 @@ function SaveCancelDeleteTileButtonGroup({
     }
 }) {
     const tile = useNonNullContext(TileContext)
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     return (
         <>
@@ -54,7 +54,7 @@ function SaveCancelDeleteTileButtonGroup({
                     variant="primary"
                     aria-label="lagre valg"
                     onClick={() => {
-                        posthog.capture('stop_place_edit_saved', {
+                        capture('stop_place_edit_saved', {
                             location: trackingLocation,
                             ...fieldsChanged,
                         })
@@ -67,7 +67,7 @@ function SaveCancelDeleteTileButtonGroup({
                     aria-label="avbryt"
                     type="button"
                     onClick={() => {
-                        posthog.capture('stop_place_edit_cancelled', {
+                        capture('stop_place_edit_cancelled', {
                             location: trackingLocation,
                             unsavedChanges: hasTileChanged,
                         })
@@ -107,7 +107,7 @@ function SaveCancelDeleteTileButtonGroup({
                             form={tile.uuid}
                             aria-label="Lagre endringer"
                             onClick={() => {
-                                posthog.capture('stop_place_edit_saved', {
+                                capture('stop_place_edit_saved', {
                                     location: trackingLocation,
                                     ...fieldsChanged,
                                 })
@@ -121,7 +121,7 @@ function SaveCancelDeleteTileButtonGroup({
                             width="fluid"
                             aria-label="Forkast endringer"
                             onClick={() => {
-                                posthog.capture('stop_place_edit_discard', {
+                                capture('stop_place_edit_discard', {
                                     location: trackingLocation,
                                 })
                                 resetTile()

--- a/tavla/app/_components/TileCard/components/SetColumns.tsx
+++ b/tavla/app/_components/TileCard/components/SetColumns.tsx
@@ -1,4 +1,3 @@
-import { SmallAlertBox } from '@entur/alert/'
 import { IconButton } from '@entur/button'
 import { FilterChip } from '@entur/chip'
 import { QuestionFilledIcon } from '@entur/icons'
@@ -23,7 +22,7 @@ function SetColumns({
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     onFieldChanged: (field: string) => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const tile = useNonNullContext(TileContext)
     const [isColumnModalOpen, setIsColumnModalOpen] = useState(false)
 
@@ -47,15 +46,13 @@ function SetColumns({
                     </IconButton>
                 </Tooltip>
             </div>
-
-            {isCombined ? (
-                <SmallAlertBox variant="info" className="mb-2 w-fit">
-                    Du har valgt å vise alle stoppesteder i en liste, og kan
-                    derfor ikke velge kolonner per stoppested.
-                </SmallAlertBox>
-            ) : (
-                <SubParagraph>
-                    Her bestemmer du hvilke kolonner som skal vises i tavlen.
+            <SubParagraph>
+                Her bestemmer du hvilke kolonner som skal vises i tavlen.
+            </SubParagraph>
+            {isCombined && (
+                <SubParagraph className="mb-2 !text-error">
+                    Har du samlet stoppestedene i én liste vil du ikke ha
+                    mulighet til å velge kolonner.
                 </SubParagraph>
             )}
 
@@ -91,17 +88,14 @@ function SetColumns({
                                 }
                                 onChange={(e) => {
                                     onFieldChanged('columns')
-                                    posthog.capture(
-                                        'stop_place_edit_interaction',
-                                        {
-                                            location: trackingLocation,
-                                            field: 'columns',
-                                            column_value: columnValue[key],
-                                            action: e.target.checked
-                                                ? 'toggled_on'
-                                                : 'toggled_off',
-                                        },
-                                    )
+                                    capture('stop_place_edit_interaction', {
+                                        location: trackingLocation,
+                                        field: 'columns',
+                                        column_value: columnValue[key],
+                                        action: e.target.checked
+                                            ? 'toggled_on'
+                                            : 'toggled_off',
+                                    })
                                 }}
                             >
                                 {value}

--- a/tavla/app/_components/TileCard/components/SetOffsetDepartureTime.tsx
+++ b/tavla/app/_components/TileCard/components/SetOffsetDepartureTime.tsx
@@ -20,7 +20,7 @@ function SetOffsetDepartureTime({
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     onFieldChanged: (field: string) => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const tile = useNonNullContext(TileContext)
 
     const walkingDistanceInMinutes = Math.ceil(
@@ -67,7 +67,7 @@ function SetOffsetDepartureTime({
                         }
 
                         debounceTimerRef.current = setTimeout(() => {
-                            posthog.capture('stop_place_edit_interaction', {
+                            capture('stop_place_edit_interaction', {
                                 location: trackingLocation,
                                 field: 'offset',
                                 action: 'changed',
@@ -90,7 +90,7 @@ function SetOffsetDepartureTime({
                             )
                             onFieldChanged('offset_walking_dist')
 
-                            posthog.capture('stop_place_edit_interaction', {
+                            capture('stop_place_edit_interaction', {
                                 location: trackingLocation,
                                 field: 'offset_walking_dist',
                                 action: !offsetBasedOnWalkingDistance

--- a/tavla/app/_components/TileCard/components/SetStopPlaceName.tsx
+++ b/tavla/app/_components/TileCard/components/SetStopPlaceName.tsx
@@ -22,7 +22,7 @@ function SetStopPlaceName({
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     onFieldChanged: (field: string) => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const tile = useNonNullContext(TileContext)
     const [displayName, setDisplayName] = useState(tile.displayName ?? '')
     const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -58,7 +58,7 @@ function SetStopPlaceName({
                     }
 
                     debounceTimerRef.current = setTimeout(() => {
-                        posthog.capture('stop_place_edit_interaction', {
+                        capture('stop_place_edit_interaction', {
                             location: trackingLocation,
                             field: 'name',
                             action: 'changed',

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -200,7 +200,7 @@ function SetVisibleLines({
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     onFieldChanged: (field: string) => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
     const tile = useNonNullContext(TileContext)
 
     const { modes, quayModesMap, columns } = sortAndDistributeColumnItems(quays)
@@ -318,7 +318,7 @@ function SetVisibleLines({
                             isSelected={isSelected}
                             onClick={() => {
                                 onFieldChanged('transport_mode_filter')
-                                posthog.capture('stop_place_edit_interaction', {
+                                capture('stop_place_edit_interaction', {
                                     location: trackingLocation,
                                     field: 'transport_mode_filter',
                                     column_value: 'none',

--- a/tavla/app/_components/TileSelector/TileSelector.tsx
+++ b/tavla/app/_components/TileSelector/TileSelector.tsx
@@ -55,7 +55,7 @@ function TileSelector({
 
     const { fetchPosition, currentPositionState } = useCurrentPosition()
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const [state, setFormError] = useState<TFormFeedback | undefined>()
 
@@ -94,7 +94,7 @@ function TileSelector({
 
         const typeOfPlace = getTypeOfPlace(selectedItem)
 
-        posthog.capture('stop_place_add_interaction', {
+        capture('stop_place_add_interaction', {
             location: trackingLocation,
             field: 'stop_place',
             action: selectedItem?.value ? 'selected' : 'cleared',
@@ -151,7 +151,7 @@ function TileSelector({
                 setMainStopPlaceItem(null)
                 setTimeout(() => {
                     if (trackingLocation !== 'board_without_user') {
-                        posthog.capture('survey_set_up_board')
+                        capture('survey_set_up_board')
                     }
                 }, 5000)
             }}
@@ -162,7 +162,7 @@ function TileSelector({
                     items={counties}
                     selectedItems={selectedCounties}
                     onChange={(e) => {
-                        posthog.capture('stop_place_add_interaction', {
+                        capture('stop_place_add_interaction', {
                             location: trackingLocation,
                             field: 'county',
                             action:
@@ -203,7 +203,7 @@ function TileSelector({
                         const addedStopPlace =
                             selectedItems.length >
                             (selectedClosestStopPlaces?.length ?? 0)
-                        posthog.capture('stop_place_add_interaction', {
+                        capture('stop_place_add_interaction', {
                             location: trackingLocation,
                             field: 'closest_stop_places',
                             action: addedStopPlace ? 'added' : 'removed',
@@ -236,7 +236,7 @@ function TileSelector({
                 variant="secondary"
                 className="min-w-24"
                 onClick={() =>
-                    posthog.capture('stop_place_added', {
+                    capture('stop_place_added', {
                         location: trackingLocation,
                         county_count: selectedCounties.length,
                         typeOfPlace: getTypeOfPlace(selectedStopPlace),

--- a/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
+++ b/tavla/app/lag-tavle/components/CreateBoardLocally.tsx
@@ -35,11 +35,11 @@ export function CreateBoardLocally() {
         type: 'not-published',
     })
 
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     const handlePublish = async () => {
         setPublishState({ type: 'publishing' })
-        posthog.capture('board_share_selected')
+        capture('board_share_selected')
         try {
             const boardId = await publishBoard(board)
 
@@ -129,7 +129,7 @@ export function CreateBoardLocally() {
                 size="medium"
                 open={isModalOpen}
                 onDismiss={() => {
-                    posthog.capture('board_share_cancelled')
+                    capture('board_share_cancelled')
                     setIsModalOpen(false)
                 }}
                 title={getModalTitle(publishState)}
@@ -174,7 +174,7 @@ function PublishButton({
     publishState: PublishBoardState
     onClick: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     switch (publishState.type) {
         case 'error':
@@ -184,7 +184,7 @@ function PublishButton({
                 <PrimaryButton
                     onClick={() => {
                         onClick()
-                        posthog.capture('board_share_started')
+                        capture('board_share_started')
                     }}
                     loading={publishState.type === 'publishing'}
                     width="auto"

--- a/tavla/app/lag-tavle/components/PublishBoardModal.tsx
+++ b/tavla/app/lag-tavle/components/PublishBoardModal.tsx
@@ -20,7 +20,7 @@ export function PublishModalContent({
     handlePublish: () => void
     resetPublish: () => void
 }) {
-    const posthog = usePosthogTracking()
+    const { capture } = usePosthogTracking()
 
     switch (publishState.type) {
         case 'not-published':
@@ -76,7 +76,7 @@ export function PublishModalContent({
         case 'published': {
             const boardLink = getBoardLinkClient(publishState.boardId)
             function copyLink() {
-                posthog.capture('board_copied', {
+                capture('board_copied', {
                     location: 'board_without_user',
                 })
                 navigator.clipboard.writeText(boardLink)
@@ -102,7 +102,7 @@ export function PublishModalContent({
                         </PrimaryButton>
                         <PrimaryButton
                             onClick={() => {
-                                posthog.capture('board_opened', {
+                                capture('board_opened', {
                                     location: 'board_without_user',
                                 })
                                 window.open(


### PR DESCRIPTION
### 🥅 Bakgrunn
Vi ønsker å bruke et bedre format på posthog tracking. Dette burde ryddes opp i hele kodebasen.

### ✨ Løsning
Erstatt `const posthog = usePosthogTracking()` med `const { capture } = usePosthogTracking()` slik at capture-kallet forkortes fra `posthog.capture(...)` til `capture(...)`. Gjelder alle steder der kun capture hooken brukes.