### PR TITLE
🔒 Dedupliser dompurify til 3.4.10

### DIFF
--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -6342,7 +6342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.4.10":
+"dompurify@npm:3.4.10, dompurify@npm:^3.3.2":
   version: 3.4.10
   resolution: "dompurify@npm:3.4.10"
   dependencies:
@@ -6351,18 +6351,6 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10/e051c70e7a0729d8cc04d40d7863dc8977495140857e81dc668fb548b7a43c7f80cfc973e3c9c0a6cd18b8eaa94ea7de9603daa02d38c8b15a9b32cc25a6f440
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "dompurify@npm:3.3.2"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10/3ca02559677ce6d9583a500f21ffbb6b9e88f1af99f69fa0d0d9442cddbac98810588c869f8b435addb5115492d6e49870024bca322169b941bafedb99c7f281
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🥅 Bakgrunn

`yarn.lock` hadde to kopier av `dompurify`: vår direkte avhengighet på `3.4.10`, og en gammel transitiv kopi `^3.3.2` som ble stående på `3.3.2`. Den gamle kopien trigget flere Dependabot-sikkerhetsvarsler (#465–471) med lave versjonsranger, selv om vår faktiske sanitering (`app/api/upload/route.ts`) bruker den direkte 3.4.10-kopien.

### ✨ Løsning

- Kjørt `yarn dedupe dompurify` slik at både direkte avhengighet og transitiv `^3.3.2` peker på `3.4.10`.
- Den sårbare `3.3.2`-kopien er fjernet fra `yarn.lock` (kun lockfile-endring, ingen versjonsbump i `package.json`).
- Lukker Dependabot-varsler #465–471 (alle ute av vulnerable range når eneste kopi er 3.4.10).


### ✅ Sjekkliste

- [ ] Testet i Chrome


🤖 Generated with [Claude Code](https://claude.com/claude-code)