### PR TITLE
📈 Metrikk for aktive direktetavler

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -127,16 +127,19 @@ async fn main() {
                         let keys: Vec<String> = keys;
                         metrics_updater.active_boards.set(keys.len() as f64);
 
-                        let mut direct_count: u64 = 0;
-                        for key in &keys {
-                            if let Ok(val) = connection.get::<_, String>(key).await {
-                                if let Ok(info) = serde_json::from_str::<ActiveInfo>(&val) {
-                                    if info.is_direct_link == Some(true) {
-                                        direct_count += 1;
-                                    }
-                                }
-                            }
-                        }
+                        let direct_count = if keys.is_empty() {
+                            0
+                        } else {
+                            connection
+                                .mget::<_, Vec<Option<String>>>(&keys)
+                                .await
+                                .unwrap_or_default()
+                                .iter()
+                                .flatten()
+                                .filter_map(|val| serde_json::from_str::<ActiveInfo>(val).ok())
+                                .filter(|info| info.is_direct_link == Some(true))
+                                .count() as u64
+                        };
                         metrics_updater
                             .active_direct_boards
                             .set(direct_count as f64);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -127,22 +127,30 @@ async fn main() {
                         let keys: Vec<String> = keys;
                         metrics_updater.active_boards.set(keys.len() as f64);
 
-                        let direct_count = if keys.is_empty() {
-                            0
+                        if !keys.is_empty() {
+                            match connection.mget::<_, Vec<Option<String>>>(&keys).await {
+                                Ok(values) => {
+                                    let direct_count = values
+                                        .iter()
+                                        .flatten()
+                                        .filter_map(|val| {
+                                            serde_json::from_str::<ActiveInfo>(val).ok()
+                                        })
+                                        .filter(|info| info.is_direct_link == Some(true))
+                                        .count();
+                                    metrics_updater
+                                        .active_direct_boards
+                                        .set(direct_count as f64);
+                                }
+                                Err(_) => {
+                                    eprintln!(
+                                        "Warning: Failed to read heartbeats for direct-link metric"
+                                    );
+                                }
+                            }
                         } else {
-                            connection
-                                .mget::<_, Vec<Option<String>>>(&keys)
-                                .await
-                                .unwrap_or_default()
-                                .iter()
-                                .flatten()
-                                .filter_map(|val| serde_json::from_str::<ActiveInfo>(val).ok())
-                                .filter(|info| info.is_direct_link == Some(true))
-                                .count() as u64
-                        };
-                        metrics_updater
-                            .active_direct_boards
-                            .set(direct_count as f64);
+                            metrics_updater.active_direct_boards.set(0.0);
+                        }
                     }
                     Err(_) => {
                         eprintln!("Warning: Failed to update metrics from Redis");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 pub struct Metrics {
     pub registry: Registry,
     pub active_boards: Gauge,
+    pub active_direct_boards: Gauge,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -83,9 +84,20 @@ async fn main() {
         .register(Box::new(active_boards_gauge.clone()))
         .expect("Failed to register metrics");
 
+    let active_direct_boards_gauge = Gauge::new(
+        "tavla_active_direct_sessions_current",
+        "Number of currently active tavla sessions/tabs that are direct-link boards (NSR id in URL, no board doc)",
+    )
+    .expect("Failed to create active_direct_sessions metric");
+
+    registry
+        .register(Box::new(active_direct_boards_gauge.clone()))
+        .expect("Failed to register direct metrics");
+
     let metrics = Arc::new(Metrics {
         registry,
         active_boards: active_boards_gauge,
+        active_direct_boards: active_direct_boards_gauge,
     });
 
     let listener = TcpListener::bind(format!("{}:{}", host, port))
@@ -115,6 +127,21 @@ async fn main() {
                     Ok(keys) => {
                         let keys: Vec<String> = keys;
                         metrics_updater.active_boards.set(keys.len() as f64);
+
+                        // Read each heartbeat to count how many are direct-link boards
+                        let mut direct_count: u64 = 0;
+                        for key in &keys {
+                            if let Ok(val) = connection.get::<_, String>(key).await {
+                                if let Ok(info) = serde_json::from_str::<ActiveInfo>(&val) {
+                                    if info.is_direct_link == Some(true) {
+                                        direct_count += 1;
+                                    }
+                                }
+                            }
+                        }
+                        metrics_updater
+                            .active_direct_boards
+                            .set(direct_count as f64);
                     }
                     Err(_) => {
                         eprintln!("Warning: Failed to update metrics from Redis");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -117,7 +117,6 @@ async fn main() {
         loop {
             interval.tick().await;
 
-            // Update active boards count
             if let Ok(mut connection) = redis_for_metrics.get_multiplexed_async_connection().await {
                 match redis::cmd("KEYS")
                     .arg("heartbeat:*")
@@ -128,7 +127,6 @@ async fn main() {
                         let keys: Vec<String> = keys;
                         metrics_updater.active_boards.set(keys.len() as f64);
 
-                        // Read each heartbeat to count how many are direct-link boards
                         let mut direct_count: u64 = 0;
                         for key in &keys {
                             if let Ok(val) = connection.get::<_, String>(key).await {


### PR DESCRIPTION
### 🥅 Bakgrunn

Vi kan i dag se totalt antall aktive tavler via Prometheus-metrikken `tavla_active_sessions_current` (vist i Grafana). Vi mangler å kunne skille ut hvor mange av disse som er **direktelenke-tavler** (NSR-id i URL, uten board-dokument i databasen). Disse er usynlige i de DB-baserte innsiktskildene våre, så heartbeat/metrics er eneste sted vi kan telle dem.

### ✨ Løsning

- Ny Prometheus-gauge `tavla_active_direct_sessions_current` registrert på det eksisterende `/metrics`-endepunktet (ikke et nytt endepunkt — Prometheus skraper kun ett).
- Bakgrunnsjobben (hvert 10. min) leser nå hver `heartbeat:*`-verdi og teller de med `is_direct_link == true`. Flagget lå allerede lagret i Redis, men ble aldri aggregert.
- Eksisterende `tavla_active_sessions_current` er uendret — ikke-brytende for dagens dashboard-paneler.




