### PR TITLE
🐛 Skjule "forskyv avgangstid" for ankomstskjermer

### DIFF
--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -271,6 +271,7 @@ export function TileCard({
                             />
                             <SetOffsetDepartureTime
                                 address={board.meta.location}
+                                isArrivals={board.isArrivals ?? false}
                                 trackingLocation={trackingLocation}
                                 onFieldChanged={onFieldChanged}
                             />

--- a/tavla/app/_components/TileCard/components/SetOffsetDepartureTime.tsx
+++ b/tavla/app/_components/TileCard/components/SetOffsetDepartureTime.tsx
@@ -13,10 +13,12 @@ import { TileContext } from '../context'
 
 function SetOffsetDepartureTime({
     address,
+    isArrivals,
     trackingLocation,
     onFieldChanged,
 }: {
     address?: LocationDB
+    isArrivals: boolean
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     onFieldChanged: (field: string) => void
 }) {
@@ -37,6 +39,8 @@ function SetOffsetDepartureTime({
             setOffsetBasedOnWalkingDistance(false)
         }
     }, [address])
+
+    if (isArrivals) return null
 
     return (
         <>


### PR DESCRIPTION
### 🥅 Bakgrunn

- Gir ikke mening å ha "forskyv avgangstid" på ankomstskjermer

### ✨ Løsning

- Konklusjon er at det ikke gir mening å forskyve ankomsttidene, disse vil som regel stå på stasjonen (evt på båten) 
- Fjerne hele feltet + avkrysningsboks for å forskyve basert på gangavstand

### 📸 Bilder

| Avgangstavle   | Ankomsttavle |
| ----- | ----- |
|  <img width="904" height="552" alt="Screenshot 2026-07-01 at 15 07 05" src="https://github.com/user-attachments/assets/3817010b-498c-40f9-b9db-14cc7f5e4ff0" /> |  <img width="909" height="429" alt="Screenshot 2026-07-01 at 15 06 34" src="https://github.com/user-attachments/assets/97ae0690-308e-41a1-a5a9-68d859f6ed48" /> |


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
