### PR TITLE
✨ Legg til linesWithDirection-felt i datamodellen

### DIFF
--- a/tavla/src/types/db-types/boards.ts
+++ b/tavla/src/types/db-types/boards.ts
@@ -53,11 +53,17 @@ const quaySchema = z.object({
     whitelistedLines: z.array(z.string()),
 })
 
+const lineWithDirectionSchema = z.object({
+    lineId: z.string(),
+    frontTexts: z.array(z.string()),
+})
+
 const boardTileSchema = z.object({
     uuid: z.string(),
     name: z.string(),
     stopPlaceId: z.string(),
     quays: z.array(quaySchema),
+    linesWithDirection: z.array(lineWithDirectionSchema).optional(),
     walkingDistance: boardWalkingDistanceSchema.optional(),
     offset: z.number().optional(),
     displayName: z.string().optional(),
@@ -145,3 +151,5 @@ export const TileColumns: Record<TileColumnDB, string> = {
 } as const
 
 export type BoardTileDB = z.infer<typeof boardTileSchema>
+
+export type LineWithDirectionDB = z.infer<typeof lineWithDirectionSchema>


### PR DESCRIPTION
### 🥅 Bakgrunn

Vi er i gang med å endre hvordan linje- og retningsfiltrering lagres på tavle-tiles. Dagens modell binder filtrering til `quays[].whitelistedLines` (quay som proxy for retning), noe som gjør at avganger forsvinner fra tavla når de bytter spor i sanntid. Ny modell lagrer linje + retning direkte og filtrerer på stopplass-nivå (speiler Entur-appen).

Dette er **første steg** (datamodell/fundament) i det arbeidet — kun skjema, ingen lesere ennå.

### ✨ Løsning

- Nytt valgfritt tiles-felt `linesWithDirection: { lineId, frontTexts }[]` i `boardTileSchema` (Zod).
- Tom `frontTexts` betyr «alle retninger» for linja.
- Eksportert type `LineWithDirectionDB`.
- `quays` og deprekerte felt (`whitelistedLines`, `type`, `placeId`, `whitelistedTransportModes`) beholdes uendret — feltet er valgfritt, så umigrerte tavler validerer som før.
- `yarn typecheck` grønn.

Tilsvarende type legges til i `tavla-visning` i egen PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)