### PR TITLE
✨ Lagre linjer med retning (linesWithDirection) fra admin

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -39,8 +39,9 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         working-directory: tavla
         run: yarn install --frozen-lockfile
-      - name: lint and typecheck
+      - name: lint, typecheck and test
         working-directory: tavla
         run: |
           yarn lint
           yarn typecheck
+          yarn test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,14 @@ yarn dev                         # Start dev without state persistence
 yarn fix                         # Fix lint + format (Biome)
 yarn lint                        # Check only
 yarn typecheck                   # TypeScript check
+yarn test                        # Run unit tests (Vitest, run mode)
+yarn test:watch                  # Run unit tests in watch mode
 yarn generate                    # Regenerate GraphQL types (run after schema changes)
 yarn build                       # Build (dev)
 yarn build:prod                  # Build for production
 ```
 
-No unit test framework is configured — CI only runs `yarn lint` and `yarn typecheck`.
+Unit tests use Vitest (`*.test.ts`, co-located). CI runs `yarn lint`, `yarn typecheck` and `yarn test`.
 
 Dev URLs: App at `http://localhost:3000`, Firebase Emulator UI at `http://127.0.0.1:4000/`
 

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -72,6 +72,7 @@ export function TileCard({
             offset,
             displayName,
             quayLineKeys,
+            linesWithDirection: selectedLinesWithDirection,
         } = parseTileFormData(data)
         const columns = board.isCombinedTiles ? tile.columns : parsedColumns
 
@@ -98,10 +99,13 @@ export function TileCard({
                   }))
                   .filter((q) => q.whitelistedLines.length > 0)
 
+        const linesWithDirection = allSelected ? [] : selectedLinesWithDirection
+
         const newTile: BoardTileDB = {
             ...tile,
             columns,
             quays: newQuays,
+            linesWithDirection,
             ...(board.meta.location && {
                 walkingDistance: {
                     distance: tile.walkingDistance?.distance,

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -4,45 +4,16 @@ import type { EventProps } from 'app/posthog/events'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import { useState } from 'react'
 import { useNonNullContext } from 'src/hooks/useNonNullContext'
-import type { BoardTileDB } from 'src/types/db-types/boards'
 import type { TTransportMode } from 'src/types/graphql-schema'
 import { TileContext } from '../context'
 import { PlatformAndLines } from '../PlatformAndLines'
 import type { QuayWithFrontText } from '../types'
-import { deriveLinesWithDirection, transportModeNames } from '../utils'
+import {
+    deriveLinesWithDirection,
+    getInitialCheckedLineIds,
+    transportModeNames,
+} from '../utils'
 import { TransportModeChip } from './TransportModeChip'
-
-function getInitialCheckedLineIds(
-    tile: BoardTileDB,
-    quays: QuayWithFrontText[],
-): Set<string> {
-    const set = new Set<string>()
-    const hasQuayFilter = tile.quays && tile.quays.length > 0
-
-    for (const quay of quays) {
-        const savedQuay = tile.quays?.find((q) => q.id === quay.id)
-        if (savedQuay) {
-            if (savedQuay.whitelistedLines.length === 0) {
-                for (const l of quay.lines) set.add(`${quay.id}||${l.id}`)
-            } else {
-                for (const lineId of savedQuay.whitelistedLines)
-                    set.add(`${quay.id}||${lineId}`)
-            }
-        } else if (hasQuayFilter) {
-            // Per-quay filter exists but this quay has no entry: nothing selected
-        } else if (tile.whitelistedLines && tile.whitelistedLines.length > 0) {
-            for (const l of quay.lines) {
-                if (tile.whitelistedLines?.includes(l.id)) {
-                    set.add(`${quay.id}||${l.id}`)
-                }
-            }
-        } else {
-            for (const l of quay.lines) set.add(`${quay.id}||${l.id}`)
-        }
-    }
-
-    return set
-}
 
 type QuaysByTransportMode = {
     mode: TTransportMode

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -9,7 +9,7 @@ import type { TTransportMode } from 'src/types/graphql-schema'
 import { TileContext } from '../context'
 import { PlatformAndLines } from '../PlatformAndLines'
 import type { QuayWithFrontText } from '../types'
-import { transportModeNames } from '../utils'
+import { deriveLinesWithDirection, transportModeNames } from '../utils'
 import { TransportModeChip } from './TransportModeChip'
 
 function getInitialCheckedLineIds(
@@ -211,6 +211,11 @@ export function SetVisibleLines({
 
     const totalQuayLinePairs = quays.reduce((sum, q) => sum + q.lines.length, 0)
 
+    const linesWithDirection = deriveLinesWithDirection(
+        quays,
+        Array.from(checkedLineIds),
+    )
+
     const handleToggleLine = (lineId: string) => {
         const newSet = new Set(checkedLineIds)
         if (newSet.has(lineId)) {
@@ -381,6 +386,10 @@ export function SetVisibleLines({
                 })}
             </div>
             <HiddenInput id="count" value={totalQuayLinePairs.toString()} />
+            <HiddenInput
+                id="linesWithDirection"
+                value={JSON.stringify(linesWithDirection)}
+            />
         </>
     )
 }

--- a/tavla/app/_components/TileCard/utils.test.ts
+++ b/tavla/app/_components/TileCard/utils.test.ts
@@ -7,8 +7,7 @@ import {
     parseTileFormData,
 } from './utils'
 
-// Minimal fixture — deriveLinesWithDirection bruker kun quay.id og
-// lines[].id/frontTexts, så vi caster forbi resten av TQuay-feltene.
+/* Minimal fixture — deriveLinesWithDirection bruker kun quay.id og lines[].id/frontTexts, så vi caster forbi resten av TQuay-feltene.*/
 function quay(
     id: string,
     lines: Array<{ id: string; frontTexts?: string[] }>,
@@ -16,8 +15,13 @@ function quay(
     return { id, lines } as unknown as QuayWithFrontText
 }
 
+/* deriveLinesWithDirection(quays, selectedKeys):
+ fra avhukede `${quayId}||${lineId}`-nøkler til `{ lineId, frontTexts }[]`.
+ En retning (frontText) er quay-spesifikk — samme linje kan gå ulik vei fra ulike quays. Tom `frontTexts` betyr "alle retninger";
+ er alle kjente retninger for en linje valgt, kollapses det til [] (så nye retninger blir med senere).
+ */
 describe('deriveLinesWithDirection', () => {
-    it('beholder spesifikk retning når bare én plattform er valgt (subset på tvers av quays)', () => {
+    it('tar bare med retningene fra de valgte quayene — samme linje kan gå ulik vei per quay, og en uvalgt quays retning skal ikke lekke inn', () => {
         const quays = [
             quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }]),
             quay('Q2', [{ id: 'L1', frontTexts: ['Sør'] }]),
@@ -27,7 +31,7 @@ describe('deriveLinesWithDirection', () => {
         ])
     })
 
-    it('kollapser til [] når alle kjente retninger for en linje er valgt', () => {
+    it('kollapser frontTexts til [] ("alle retninger") når alle kjente retninger for linja er valgt, slik at nye framtidige retninger blir med automatisk', () => {
         const quays = [
             quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }]),
             quay('Q2', [{ id: 'L1', frontTexts: ['Sør'] }]),
@@ -37,19 +41,19 @@ describe('deriveLinesWithDirection', () => {
         ])
     })
 
-    it('gir [] (alle retninger) for en valgt linje uten frontTexts (fail-open)', () => {
+    it('gir frontTexts: [] ("alle retninger", fail-open) for en valgt linje som mangler frontText-data, i stedet for å droppe linja', () => {
         const quays = [quay('Q1', [{ id: 'L2', frontTexts: [] }])]
         expect(deriveLinesWithDirection(quays, ['Q1||L2'])).toEqual([
             { lineId: 'L2', frontTexts: [] },
         ])
     })
 
-    it('returnerer tom liste når ingenting er valgt', () => {
+    it('returnerer [] når ingen quay-linje-par er valgt (intet linjefilter)', () => {
         const quays = [quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }])]
         expect(deriveLinesWithDirection(quays, [])).toEqual([])
     })
 
-    it('tar bare med valgte linjer', () => {
+    it('tar bare med linjer som faktisk er valgt, ikke øvrige linjer på samme quay', () => {
         const quays = [
             quay('Q1', [
                 { id: 'L1', frontTexts: ['Nord'] },
@@ -61,20 +65,20 @@ describe('deriveLinesWithDirection', () => {
         expect(result[0]?.lineId).toBe('L1')
     })
 
-    it('sorterer frontTexts deterministisk', () => {
+    it('sorterer frontTexts alfabetisk for deterministisk output, uavhengig av rekkefølgen de dukket opp i på quayene', () => {
         const quays = [
             quay('Q1', [{ id: 'L1', frontTexts: ['Storo', 'Bergkrystallen'] }]),
             quay('Q2', [{ id: 'L1', frontTexts: ['Sinsen'] }]),
         ]
-        // Q1 valgt (Storo + Bergkrystallen), Q2 (Sinsen) ikke → subset, sortert
         expect(deriveLinesWithDirection(quays, ['Q1||L1'])).toEqual([
             { lineId: 'L1', frontTexts: ['Bergkrystallen', 'Storo'] },
         ])
     })
 })
 
+/* parseTileFormData parser FormData fra admin-panelet til et objekt som kan brukes til å oppdatere en tile i databasen.*/
 describe('parseTileFormData', () => {
-    it('parser count som number (regresjon: allSelected ble alltid false)', () => {
+    it('parser count-feltet til et tall (ikke streng) — regresjon: som streng ble allSelected-sammenligningen (keys.length === count) alltid false', () => {
         const data = new FormData()
         data.append('count', '3')
         const result = parseTileFormData(data)
@@ -82,7 +86,7 @@ describe('parseTileFormData', () => {
         expect(typeof result.count).toBe('number')
     })
 
-    it('parser linesWithDirection fra JSON; fravær gir []', () => {
+    it('JSON-parser linesWithDirection-feltet, og returnerer [] når feltet mangler helt', () => {
         const withField = new FormData()
         withField.append(
             'linesWithDirection',
@@ -94,7 +98,7 @@ describe('parseTileFormData', () => {
         expect(parseTileFormData(new FormData()).linesWithDirection).toEqual([])
     })
 
-    it('samler kun checkbox-verdiene i quayLineKeys', () => {
+    it('plukker ut kun checkbox-verdiene (quay-linje-par) i quayLineKeys og at øvrige navngitte felt (columns, displayName) parses korrekt', () => {
         const data = new FormData()
         data.append('count', '2')
         data.append('columns', 'line')
@@ -110,7 +114,7 @@ describe('parseTileFormData', () => {
         expect(result.displayName).toBe('Testnavn')
     })
 })
-
+/* Minimal fixture — getInitialCheckedLineIds bruker kun tile.quays (id + whitelistedLines) og tile.whitelistedLines, så vi caster forbi resten av BoardTileDB-feltene.*/
 function adminTile(
     quays: Array<{ id: string; whitelistedLines: string[] }>,
     whitelistedLines?: string[],
@@ -118,8 +122,11 @@ function adminTile(
     return { quays, whitelistedLines } as unknown as BoardTileDB
 }
 
+/* getInitialCheckedLineIds(tile, quays): regner ut hvilke `${quayId}||${lineId}`-bokser som skal være forhåndsavhuket når en lagret tile åpnes.
+ `quays` er linjene hentet fra API-et (fasit på hva som finnes nå);
+ `tile` representerer det som er lagret i databasen*/
 describe('getInitialCheckedLineIds (read-back-presedens)', () => {
-    it('savedQuay med whitelist → kun de linjene', () => {
+    it('for quay lagret med en ikke-tom whitelistedLines returneres kun de linjene', () => {
         const tile = adminTile([{ id: 'Q1', whitelistedLines: ['L1'] }])
         const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
@@ -127,7 +134,7 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
         )
     })
 
-    it('savedQuay med tom whitelist → alle linjer på quayen', () => {
+    it('for quay lagret med tom whitelistedLines tolkes [] som "alle linjer på quayen" og alle linjer returneres', () => {
         const tile = adminTile([{ id: 'Q1', whitelistedLines: [] }])
         const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
@@ -135,7 +142,7 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
         )
     })
 
-    it('quay-filter finnes, men quay mangler i tile.quays → ingenting for den', () => {
+    it('tile har en quay med whitelistedLines, på stoppet finnes det flere quays som ikke er lagret på tile. Da returneres kun kombinasjon av lagret quay og linje', () => {
         const tile = adminTile([{ id: 'Q1', whitelistedLines: ['L1'] }])
         const quays = [quay('Q1', [{ id: 'L1' }]), quay('Q2', [{ id: 'L3' }])]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
@@ -143,15 +150,19 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
         )
     })
 
-    it('intet quay-filter + tile.whitelistedLines → de linjene på tvers av quays', () => {
+    it('når ingen quays lagret, men deprekert tile.whitelistedLines er satt så returneres alle kombinasjoner quay og valgt linje', () => {
         const tile = adminTile([], ['L1'])
-        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        const quays = [
+            quay('Q1', [{ id: 'L1' }, { id: 'L2' }]),
+            quay('Q2', [{ id: 'L1' }, { id: 'L3' }]),
+            quay('Q3', [{ id: 'L2' }, { id: 'L3' }]),
+        ]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
-            new Set(['Q1||L1']),
+            new Set(['Q1||L1', 'Q2||L1']),
         )
     })
 
-    it('intet filter → alt valgt', () => {
+    it('verken quays eller tile.whitelistedLines er satt så alle kombinasjoner returneres', () => {
         const tile = adminTile([])
         const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(

--- a/tavla/app/_components/TileCard/utils.test.ts
+++ b/tavla/app/_components/TileCard/utils.test.ts
@@ -1,0 +1,161 @@
+import type { BoardTileDB } from 'types/db-types/boards'
+import { describe, expect, it } from 'vitest'
+import type { QuayWithFrontText } from './types'
+import {
+    deriveLinesWithDirection,
+    getInitialCheckedLineIds,
+    parseTileFormData,
+} from './utils'
+
+// Minimal fixture — deriveLinesWithDirection bruker kun quay.id og
+// lines[].id/frontTexts, så vi caster forbi resten av TQuay-feltene.
+function quay(
+    id: string,
+    lines: Array<{ id: string; frontTexts?: string[] }>,
+): QuayWithFrontText {
+    return { id, lines } as unknown as QuayWithFrontText
+}
+
+describe('deriveLinesWithDirection', () => {
+    it('beholder spesifikk retning når bare én plattform er valgt (subset på tvers av quays)', () => {
+        const quays = [
+            quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }]),
+            quay('Q2', [{ id: 'L1', frontTexts: ['Sør'] }]),
+        ]
+        expect(deriveLinesWithDirection(quays, ['Q1||L1'])).toEqual([
+            { lineId: 'L1', frontTexts: ['Nord'] },
+        ])
+    })
+
+    it('kollapser til [] når alle kjente retninger for en linje er valgt', () => {
+        const quays = [
+            quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }]),
+            quay('Q2', [{ id: 'L1', frontTexts: ['Sør'] }]),
+        ]
+        expect(deriveLinesWithDirection(quays, ['Q1||L1', 'Q2||L1'])).toEqual([
+            { lineId: 'L1', frontTexts: [] },
+        ])
+    })
+
+    it('gir [] (alle retninger) for en valgt linje uten frontTexts (fail-open)', () => {
+        const quays = [quay('Q1', [{ id: 'L2', frontTexts: [] }])]
+        expect(deriveLinesWithDirection(quays, ['Q1||L2'])).toEqual([
+            { lineId: 'L2', frontTexts: [] },
+        ])
+    })
+
+    it('returnerer tom liste når ingenting er valgt', () => {
+        const quays = [quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }])]
+        expect(deriveLinesWithDirection(quays, [])).toEqual([])
+    })
+
+    it('tar bare med valgte linjer', () => {
+        const quays = [
+            quay('Q1', [
+                { id: 'L1', frontTexts: ['Nord'] },
+                { id: 'L2', frontTexts: ['Vest'] },
+            ]),
+        ]
+        const result = deriveLinesWithDirection(quays, ['Q1||L1'])
+        expect(result).toHaveLength(1)
+        expect(result[0]?.lineId).toBe('L1')
+    })
+
+    it('sorterer frontTexts deterministisk', () => {
+        const quays = [
+            quay('Q1', [{ id: 'L1', frontTexts: ['Storo', 'Bergkrystallen'] }]),
+            quay('Q2', [{ id: 'L1', frontTexts: ['Sinsen'] }]),
+        ]
+        // Q1 valgt (Storo + Bergkrystallen), Q2 (Sinsen) ikke → subset, sortert
+        expect(deriveLinesWithDirection(quays, ['Q1||L1'])).toEqual([
+            { lineId: 'L1', frontTexts: ['Bergkrystallen', 'Storo'] },
+        ])
+    })
+})
+
+describe('parseTileFormData', () => {
+    it('parser count som number (regresjon: allSelected ble alltid false)', () => {
+        const data = new FormData()
+        data.append('count', '3')
+        const result = parseTileFormData(data)
+        expect(result.count).toBe(3)
+        expect(typeof result.count).toBe('number')
+    })
+
+    it('parser linesWithDirection fra JSON; fravær gir []', () => {
+        const withField = new FormData()
+        withField.append(
+            'linesWithDirection',
+            JSON.stringify([{ lineId: 'L1', frontTexts: ['Nord'] }]),
+        )
+        expect(parseTileFormData(withField).linesWithDirection).toEqual([
+            { lineId: 'L1', frontTexts: ['Nord'] },
+        ])
+        expect(parseTileFormData(new FormData()).linesWithDirection).toEqual([])
+    })
+
+    it('samler kun checkbox-verdiene i quayLineKeys', () => {
+        const data = new FormData()
+        data.append('count', '2')
+        data.append('columns', 'line')
+        data.append('offset', '0')
+        data.append('displayName', 'Testnavn')
+        data.append('linesWithDirection', '[]')
+        data.append('tile-uuid-lines', 'Q1||L1')
+        data.append('tile-uuid-lines', 'Q1||L2')
+
+        const result = parseTileFormData(data)
+        expect(result.quayLineKeys).toEqual(['Q1||L1', 'Q1||L2'])
+        expect(result.columns).toEqual(['line'])
+        expect(result.displayName).toBe('Testnavn')
+    })
+})
+
+function adminTile(
+    quays: Array<{ id: string; whitelistedLines: string[] }>,
+    whitelistedLines?: string[],
+): BoardTileDB {
+    return { quays, whitelistedLines } as unknown as BoardTileDB
+}
+
+describe('getInitialCheckedLineIds (read-back-presedens)', () => {
+    it('savedQuay med whitelist → kun de linjene', () => {
+        const tile = adminTile([{ id: 'Q1', whitelistedLines: ['L1'] }])
+        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        expect(getInitialCheckedLineIds(tile, quays)).toEqual(
+            new Set(['Q1||L1']),
+        )
+    })
+
+    it('savedQuay med tom whitelist → alle linjer på quayen', () => {
+        const tile = adminTile([{ id: 'Q1', whitelistedLines: [] }])
+        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        expect(getInitialCheckedLineIds(tile, quays)).toEqual(
+            new Set(['Q1||L1', 'Q1||L2']),
+        )
+    })
+
+    it('quay-filter finnes, men quay mangler i tile.quays → ingenting for den', () => {
+        const tile = adminTile([{ id: 'Q1', whitelistedLines: ['L1'] }])
+        const quays = [quay('Q1', [{ id: 'L1' }]), quay('Q2', [{ id: 'L3' }])]
+        expect(getInitialCheckedLineIds(tile, quays)).toEqual(
+            new Set(['Q1||L1']),
+        )
+    })
+
+    it('intet quay-filter + tile.whitelistedLines → de linjene på tvers av quays', () => {
+        const tile = adminTile([], ['L1'])
+        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        expect(getInitialCheckedLineIds(tile, quays)).toEqual(
+            new Set(['Q1||L1']),
+        )
+    })
+
+    it('intet filter → alt valgt', () => {
+        const tile = adminTile([])
+        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        expect(getInitialCheckedLineIds(tile, quays)).toEqual(
+            new Set(['Q1||L1', 'Q1||L2']),
+        )
+    })
+})

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -1,5 +1,6 @@
 import type { TTransportMode } from 'src/types/graphql-schema'
-import type { TileColumnDB } from 'types/db-types/boards'
+import type { LineWithDirectionDB, TileColumnDB } from 'types/db-types/boards'
+import type { QuayWithFrontText } from './types'
 
 export function transportModeNames(
     transportMode: TTransportMode | null | undefined,
@@ -44,6 +45,7 @@ export type TileFormValues = {
     offset: number | null
     displayName: string
     quayLineKeys: string[]
+    linesWithDirection: LineWithDirectionDB[]
 }
 
 export function parseTileFormData(data: FormData): TileFormValues {
@@ -56,10 +58,75 @@ export function parseTileFormData(data: FormData): TileFormValues {
     const displayName = data.get('displayName') as string
     data.delete('displayName')
 
+    const linesWithDirectionRaw = data.get('linesWithDirection') as
+        | string
+        | null
+    data.delete('linesWithDirection')
+    const linesWithDirection: LineWithDirectionDB[] = JSON.parse(
+        linesWithDirectionRaw ?? '[]',
+    )
+
     const quayLineKeys: string[] = []
     for (const value of data.values()) {
         quayLineKeys.push(value as string)
     }
 
-    return { columns, count, offset, displayName, quayLineKeys }
+    return {
+        columns,
+        count,
+        offset,
+        displayName,
+        quayLineKeys,
+        linesWithDirection,
+    }
+}
+
+/**
+ *
+ * @param quays The quays with all lines and frontTexts
+ * @param selectedQuayLineKeys The currently selected quay-line pairs, in the
+ * form of `${quayId}||${lineId}`.
+ *
+ * @returns A list of lines with their selected directions (frontTexts). If all
+ * known directions of a line are selected, the line is returned with an empty
+ * `frontTexts` array, meaning "all directions"
+ *
+ */
+export function deriveLinesWithDirection(
+    quays: QuayWithFrontText[],
+    selectedQuayLineKeys: string[],
+): LineWithDirectionDB[] {
+    const selectedLineIds = new Set(selectedQuayLineKeys)
+    const selectedFrontTexts = new Map<string, Set<string>>()
+    const knownFrontTexts = new Map<string, Set<string>>()
+
+    for (const quay of quays) {
+        for (const line of quay.lines) {
+            const frontTexts = line.frontTexts ?? []
+
+            const known = knownFrontTexts.get(line.id) ?? new Set<string>()
+            for (const frontText of frontTexts) known.add(frontText)
+            knownFrontTexts.set(line.id, known)
+
+            if (selectedLineIds.has(`${quay.id}||${line.id}`)) {
+                const chosen =
+                    selectedFrontTexts.get(line.id) ?? new Set<string>()
+                for (const frontText of frontTexts) chosen.add(frontText)
+                selectedFrontTexts.set(line.id, chosen)
+            }
+        }
+    }
+
+    return Array.from(selectedFrontTexts.entries()).map(([lineId, chosen]) => {
+        const known = knownFrontTexts.get(lineId) ?? new Set<string>()
+        const allDirectionsChosen =
+            known.size > 0 &&
+            chosen.size >= known.size &&
+            Array.from(known).every((frontText) => chosen.has(frontText))
+
+        return {
+            lineId,
+            frontTexts: allDirectionsChosen ? [] : Array.from(chosen).sort(),
+        }
+    })
 }

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -51,7 +51,8 @@ export type TileFormValues = {
 export function parseTileFormData(data: FormData): TileFormValues {
     const columns = data.getAll('columns') as TileColumnDB[]
     data.delete('columns')
-    const count = data.get('count') as number | null
+    const countRaw = data.get('count')
+    const count = countRaw !== null ? Number(countRaw) : null
     data.delete('count')
     const offset = data.get('offset') as number | null
     data.delete('offset')

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -1,5 +1,9 @@
 import type { TTransportMode } from 'src/types/graphql-schema'
-import type { LineWithDirectionDB, TileColumnDB } from 'types/db-types/boards'
+import type {
+    BoardTileDB,
+    LineWithDirectionDB,
+    TileColumnDB,
+} from 'types/db-types/boards'
 import type { QuayWithFrontText } from './types'
 
 export function transportModeNames(
@@ -130,4 +134,35 @@ export function deriveLinesWithDirection(
             frontTexts: allDirectionsChosen ? [] : Array.from(chosen).sort(),
         }
     })
+}
+export function getInitialCheckedLineIds(
+    tile: BoardTileDB,
+    quays: QuayWithFrontText[],
+): Set<string> {
+    const set = new Set<string>()
+    const hasQuayFilter = tile.quays && tile.quays.length > 0
+
+    for (const quay of quays) {
+        const savedQuay = tile.quays?.find((q) => q.id === quay.id)
+        if (savedQuay) {
+            if (savedQuay.whitelistedLines.length === 0) {
+                for (const l of quay.lines) set.add(`${quay.id}||${l.id}`)
+            } else {
+                for (const lineId of savedQuay.whitelistedLines)
+                    set.add(`${quay.id}||${lineId}`)
+            }
+        } else if (hasQuayFilter) {
+            // Per-quay filter exists but this quay has no entry: nothing selected
+        } else if (tile.whitelistedLines && tile.whitelistedLines.length > 0) {
+            for (const l of quay.lines) {
+                if (tile.whitelistedLines?.includes(l.id)) {
+                    set.add(`${quay.id}||${l.id}`)
+                }
+            }
+        } else {
+            for (const l of quay.lines) set.add(`${quay.id}||${l.id}`)
+        }
+    }
+
+    return set
 }

--- a/tavla/package.json
+++ b/tavla/package.json
@@ -15,6 +15,8 @@
         "build": "next build",
         "build:prod": "NEXT_PUBLIC_ENV=prod next build",
         "typecheck": "tsc --noEmit --incremental false",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "start": "next start",
         "generate": "graphql-codegen",
         "lint": "biome check .",
@@ -82,7 +84,8 @@
         "lint-staged": "17.0.7",
         "postcss": "8.5.16",
         "tailwindcss": "3.4.19",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "4.1.8"
     },
     "packageManager": "yarn@4.10.3",
     "engines": {

--- a/tavla/vitest.config.ts
+++ b/tavla/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['app/**/*.test.ts', 'src/**/*.test.ts'],
+    },
+})

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -577,12 +577,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10/9aba37e0c11a75ef8372fd0a9c6e5396f4e8c1ebdd6fee737414787610a9dc1cd9bf188f525153561ca9363896e1135dd240f1ce28f3470dba3ad7e683e6db1a
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/8f7c622a49314df4d07952110e108e83b0fe129a8ddb9ef1e0ae372d754616169d5b0dd47a0d354a0fea2612abe42cedb582d15916936d1320c6c468acc804cc
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:^1.7.0":
   version: 1.8.1
   resolution: "@emnapi/runtime@npm:1.8.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/26725e202d4baefdc4a6ba770f703dfc80825a27c27a08c22bac1e1ce6f8f75c47b4fe9424d9b63239463c33ef20b650f08d710da18dfa1164a95e5acb865dba
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/297fb6b1d89744bd0b41d5fec32bade05dc8dcf1f70eba86527226609fb3f6ad3fa96b3b2377b7449709715b3bd1569654c9def1dbbc85fb6b9cb0cff5bc5ebf
   languageName: node
   linkType: hard
 
@@ -3459,6 +3487,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10/3e43425df17547d9d58ab69cce8e6cef38a062eccec4d2def5fc9e10e81cd19ae228b3ab9be4b149b57078d33913687511312d2414089877759b7db1f43625ba
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:16.2.9":
   version: 16.2.9
   resolution: "@next/env@npm:16.2.9"
@@ -3682,6 +3722,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.138.0":
+  version: 0.138.0
+  resolution: "@oxc-project/types@npm:0.138.0"
+  checksum: 10/5824409f98ad53e5cb7de64cae9d68c595029b6e68c66891031770c9b16f836cf076c81d833fed9360374b99cee25c5a2f86d5959445c47666b896ddecc17650
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -3852,6 +3899,122 @@ __metadata:
   version: 3.0.6
   resolution: "@repeaterjs/repeater@npm:3.0.6"
   checksum: 10/25698e822847b776006428f31e2d31fbcb4faccf30c1c8d68d6e1308e58b49afb08764d1dd15536ddd67775cd01fd6c2fb22f039c05a71865448fbcfb2246af2
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-android-arm64@npm:1.1.4"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.1.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-darwin-x64@npm:1.1.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.1.4"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.1.4"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.1.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.1.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.1.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.1.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.1.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.1.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.1.4"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.1.4"
+  dependencies:
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.1.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.1.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
   languageName: node
   linkType: hard
 
@@ -4388,6 +4551,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10/a209615c9e8b2ea535d7db0a5f6aa0f962fd4ab73ee86a46c100fb78116964af1f55a27c1794d4801e534a196794223daa25ff5135021e03c7828aa3d95e1763
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.15":
   version: 0.5.15
   resolution: "@swc/helpers@npm:0.5.15"
@@ -4425,6 +4595,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/6cf39f7a2926b1c8bc6fe3f9f03318a33dd6dae81bdbd059983f9c6ee22d10a827f12564d648c05a2d4926e03c86cbe2799fb20609ee65e9efc39603039b4765
+  languageName: node
+  linkType: hard
+
 "@types/body-parser@npm:*":
   version: 1.19.6
   resolution: "@types/body-parser@npm:1.19.6"
@@ -4439,6 +4618,16 @@ __metadata:
   version: 0.12.5
   resolution: "@types/caseless@npm:0.12.5"
   checksum: 10/f6a3628add76d27005495914c9c3873a93536957edaa5b69c63b46fe10b4649a6fecf16b676c1695f46aab851da47ec6047dcf3570fa8d9b6883492ff6d074e0
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10/e79947307dc235953622e65f83d2683835212357ca261389116ab90bed369ac862ba28b146b4fed08b503ae1e1a12cb93ce783f24bb8d562950469f4320e1c7c
   languageName: node
   linkType: hard
 
@@ -4457,6 +4646,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/9545cc532c9218754443f48a0c98c1a9ba4af1fe54a3425c95de75ff3158147bb39e666cb7c6bf98cc56a9c6dc7b4ce5b2cbdae6b55d5942e50c81b76ed6b825
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10/249a27b0bb22f6aa28461db56afa21ec044fa0e303221a62dff81831b20c8530502175f1a49060f7099e7be06181078548ac47c668de79ff9880241968d43d0c
   languageName: node
   linkType: hard
 
@@ -4693,6 +4889,88 @@ __metadata:
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
+
+"@vitest/expect@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/expect@npm:4.1.8"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/cb7d78e250ec77b7e180ac3e5f543501488c69b237d7ed97ffe9196c5e946b0e4a37be05a2ec38af7ce7750c1a98286480acdd247286a29c239b08a13b085d4b
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/mocker@npm:4.1.8"
+  dependencies:
+    "@vitest/spy": "npm:4.1.8"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10/fc977703b07d950aa170bafdef988bc7ba88f0a80159d1563ce95696763729ec1f6d015012aad36cf4e1b522d327b205292c56d76692d2a9f72285d694ed3cba
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/pretty-format@npm:4.1.8"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/56a4b685cdf9f2e9708025f17dab8c0fa990ab06e5b38606a1ddde52a09830a099843da6a1b127ee48217ab023bad7bd23c49eb4969d77dff07df363fad0bb0e
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/runner@npm:4.1.8"
+  dependencies:
+    "@vitest/utils": "npm:4.1.8"
+    pathe: "npm:^2.0.3"
+  checksum: 10/278d1482123877343731b3bb822d0280af928252ee263aab73ca189c39de3bb767ce715581870b2e1eb408f7cba01106a6989406cb2ada1332f181912558a3c1
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/snapshot@npm:4.1.8"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10/162ca0eccb72db02081b04307d21ac8d14c8fcd4a840872459274f589b1665f108bd4119dff19d5a2150a0e26b90531791ebec7ee74f0c2c5285b491cebbcfcb
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/spy@npm:4.1.8"
+  checksum: 10/53e948d8f5e229e969e704dc8a54fd42ad715b2b18f401592f4bba97dcf33bd4cf01d11af577d4efe42dc2d90c9e6574ec991531fd8f1bdfee916a1dd0828547
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/utils@npm:4.1.8"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.8"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/13250b9e7825d425cc9a3d22aeb2e8d117c93e96a192138e93d76bfe7d5a391ab3888c5aa9e0394b0314bdff41e441ad7a32b0c0caa00cd202223b88087dcc78
+  languageName: node
+  linkType: hard
 
 "@whatwg-node/disposablestack@npm:^0.0.6":
   version: 0.0.6
@@ -4988,6 +5266,13 @@ __metadata:
   version: 2.0.0
   resolution: "as-array@npm:2.0.0"
   checksum: 10/8d743c7aa4fbb9f3158ec6bef5119939b044cc2456c2eb2ed4a3a0912e480bb7eb7346238e9313f075d0f5ceb5b65659245e735405343f51476330f422b12476
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10/a0789dd882211b87116e81e2648ccb7f60340b34f19877dd020b39ebb4714e475eb943e14ba3e22201c221ef6645b7bfe10297e76b6ac95b48a9898c1211ce66
   languageName: node
   linkType: hard
 
@@ -5440,6 +5725,13 @@ __metadata:
     tslib: "npm:^2.0.3"
     upper-case-first: "npm:^2.0.2"
   checksum: 10/41fa8fa87f6d24d0835a2b4a9341a3eaecb64ac29cd7c5391f35d6175a0fa98ab044e7f2602e1ec3afc886231462ed71b5b80c590b8b41af903ec2c15e5c5931
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10/13cda42cc40aa46da04a41cf7e5c61df6b6ae0b4e8a8c8b40e04d6947e4d7951377ea8c14f9fa7fe5aaa9e8bd9ba414f11288dc958d4cee6f5221b9436f2778f
   languageName: node
   linkType: hard
 
@@ -6290,7 +6582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766
@@ -6586,6 +6878,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "es-module-lexer@npm:2.3.0"
+  checksum: 10/daf73d870758116a84ba5801ec297c891837f482bb0b9836a431e5b71965a544e909d9cb6a5887f7e08d23dd20ad13838e569c7029413da88402b9ea567f3afe
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -6667,6 +6966,15 @@ __metadata:
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
   checksum: 10/b02109c5d46bc2ed47de4990eef770f7457b1159a229f0999a09224d2b85ffeed2d7679cffcff90aeb4448e94b0168feb5265b209cdec29aad50a3d6e93d21e2
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10/a65728d5727b71de172c5df323385755a16c0fdab8234dc756c3854cfee343261ddfbb72a809a5660fac8c75d960bb3e21aa898c2d7e9b19bb298482ca58a3af
   languageName: node
   linkType: hard
 
@@ -6776,6 +7084,13 @@ __metadata:
     raw-body: "npm:^2.3.3"
     semver: "npm:^7.0.0"
   checksum: 10/0cbf236773ad65462087728e98c0fb71765f4f5d820bd87b70508a816f2fe30e72a1fd137652f2fc555e13712a7e2d6449df7d685dd6b4259d875aa1aedb2c74
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10/bad91f4b7eb807248695ee840a935d12818fe531ad523bc7ac7dcc540a4d86dc566a3ef829f4da6e8b5a458ac84092771739865114c91e7e8a9317302f401f09
   languageName: node
   linkType: hard
 
@@ -7380,7 +7695,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -7390,7 +7705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -8829,6 +9144,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-android-arm64@npm:1.32.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-x64@npm:1.32.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss@npm:1.32.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.32.0"
+    lightningcss-darwin-arm64: "npm:1.32.0"
+    lightningcss-darwin-x64: "npm:1.32.0"
+    lightningcss-freebsd-x64: "npm:1.32.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
+    lightningcss-linux-arm64-gnu: "npm:1.32.0"
+    lightningcss-linux-arm64-musl: "npm:1.32.0"
+    lightningcss-linux-x64-gnu: "npm:1.32.0"
+    lightningcss-linux-x64-musl: "npm:1.32.0"
+    lightningcss-win32-arm64-msvc: "npm:1.32.0"
+    lightningcss-win32-x64-msvc: "npm:1.32.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10/098e61007f0d0ec8b5c50884e33b543b551d1ff21bc7b062434b6638fd0b8596858f823b60dfc2a4aa756f3cb120ad79f2b7f4a55b1bda2c0269ab8cf476f114
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:^3.1.1, lilconfig@npm:^3.1.3":
   version: 3.1.3
   resolution: "lilconfig@npm:3.1.3"
@@ -9157,7 +9592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.3, magic-string@npm:~0.30.8":
+"magic-string@npm:^0.30.21, magic-string@npm:^0.30.3, magic-string@npm:~0.30.8":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -9834,6 +10269,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "obug@npm:2.1.3"
+  checksum: 10/574e5c3d3def75440c54c29ce8a6d82a5698116962d2f9f28fb13f6fd5dbcc01b7df1b8e02a95f816c8dba482dcf315d9c5c97d9e718516cfea8bd6c896dcf67
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:^2.2.0, on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -10207,6 +10649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10/01e9a69928f39087d96e1751ce7d6d50da8c39abf9a12e0ac2389c42c83bc76f78c45a475bd9026a02e6a6f79be63acc75667df855862fe567d99a00a540d23d
+  languageName: node
+  linkType: hard
+
 "pg-cloudflare@npm:^1.3.0":
   version: 1.3.0
   resolution: "pg-cloudflare@npm:1.3.0"
@@ -10447,7 +10896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.16":
+"postcss@npm:8.5.16, postcss@npm:^8.5.16":
   version: 8.5.16
   resolution: "postcss@npm:8.5.16"
   dependencies:
@@ -11182,6 +11631,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.1.3":
+  version: 1.1.4
+  resolution: "rolldown@npm:1.1.4"
+  dependencies:
+    "@oxc-project/types": "npm:=0.138.0"
+    "@rolldown/binding-android-arm64": "npm:1.1.4"
+    "@rolldown/binding-darwin-arm64": "npm:1.1.4"
+    "@rolldown/binding-darwin-x64": "npm:1.1.4"
+    "@rolldown/binding-freebsd-x64": "npm:1.1.4"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.1.4"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.1.4"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-x64-musl": "npm:1.1.4"
+    "@rolldown/binding-openharmony-arm64": "npm:1.1.4"
+    "@rolldown/binding-wasm32-wasi": "npm:1.1.4"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.1.4"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.1.4"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10/3bde96c472759a33dc64d8fa3dd832ba03d9114575efcd453d846eeba2c9cfd6180c36bdfc56eaf31ebaa678bea1897ba9b116e23c9bd1b486bb8ca40951024b
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^4.60.3":
   version: 4.60.4
   resolution: "rollup@npm:4.60.4"
@@ -11602,6 +12109,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10/e93ff66c6531a079af8fb217240df01f980155b5dc408d2d7bebc398dd284e383eb318153bf8acd4db3c4fe799aa5b9a641e38b0ba3b1975700b1c89547ea4e7
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.2":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -11771,6 +12285,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10/2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
 "stacktrace-parser@npm:^0.1.11":
   version: 0.1.11
   resolution: "stacktrace-parser@npm:0.1.11"
@@ -11791,6 +12312,13 @@ __metadata:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10/c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10/008146cdb834010383138d356e0dd3e3b0ac127a8229f711b8c518bb22940813cc0dcd654fc76b17f0b18179f56089f8b8e52bd6a7ffa0041a966581e7a44dbe
   languageName: node
   linkType: hard
 
@@ -12215,6 +12743,7 @@ __metadata:
     swr: "npm:2.4.1"
     tailwindcss: "npm:3.4.19"
     typescript: "npm:6.0.3"
+    vitest: "npm:4.1.8"
     zod: "npm:4.4.3"
   languageName: unknown
   linkType: soft
@@ -12302,7 +12831,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.2.4":
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10/cfa1e1418e91289219501703c4693c70708c91ffb7f040fd318d24aef419fb5a43e0c0160df9471499191968b2451d8da7f8087b08c3133c251c40d24aced06c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2, tinyexec@npm:^1.2.4":
   version: 1.2.4
   resolution: "tinyexec@npm:1.2.4"
   checksum: 10/f20b3e6f56f24c3ebe0129d0b6e657e561d225df2cf93c1a10362996232dd6ad4b8af8c9e81d258a64d09020e723772baf6fe0be26512dba7c61bb366d67b1f9
@@ -12316,6 +12852,23 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10/d72bd826a8b0fa5fa3929e7fe5ba48fceb2ae495df3a231b6c5408cd7d8c00b58ab5a9c2a76ba56a62ee9b5e083626f1f33599734bed1ffc4b792406408f0ca2
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10/4c2c01dde1e5bb9a74973daaae141d4d733d246280b2f9a7f6a9e7dd8e940d48b2580a6086125278777897bc44635d6ccec5f9f563c2179dd2129f4542d0ec05
   languageName: node
   linkType: hard
 
@@ -12783,6 +13336,131 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.1.3
+  resolution: "vite@npm:8.1.3"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.16"
+    rolldown: "npm:~1.1.3"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.3.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10/6dd12c59d2afb6204109d9cbbfe0706f1fb4c9dad5f88ecb43e328f94f8d071f7611f70c1d93f6e51222b451f8cdbbd9af141fae8a7c2562ceafef3800fcf45d
+  languageName: node
+  linkType: hard
+
+"vitest@npm:4.1.8":
+  version: 4.1.8
+  resolution: "vitest@npm:4.1.8"
+  dependencies:
+    "@vitest/expect": "npm:4.1.8"
+    "@vitest/mocker": "npm:4.1.8"
+    "@vitest/pretty-format": "npm:4.1.8"
+    "@vitest/runner": "npm:4.1.8"
+    "@vitest/snapshot": "npm:4.1.8"
+    "@vitest/spy": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.8
+    "@vitest/browser-preview": 4.1.8
+    "@vitest/browser-webdriverio": 4.1.8
+    "@vitest/coverage-istanbul": 4.1.8
+    "@vitest/coverage-v8": 4.1.8
+    "@vitest/ui": 4.1.8
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: vitest.mjs
+  checksum: 10/b9f1308436717da9558b36e149cac6bab8e3730aa7e90b49f9d7a84ba853e353d8afba7d406dc0abec731fb2a9ea9e92b89aba06b94b1a2802203048b43468af
+  languageName: node
+  linkType: hard
+
 "w3c-xmlserializer@npm:^5.0.0":
   version: 5.0.0
   resolution: "w3c-xmlserializer@npm:5.0.0"
@@ -12915,6 +13593,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10/df19b2cd8aac94b333fa29b42e8e371a21e634a742a3b156716f7752a5afe1d73fb5d8bce9b89326f453d96879e8fe626eb421e0117eb1a3ce9fd8c97f6b7db9
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10/0de6e6cd8f2f94a8b5ca44e84cf1751eadcac3ebedcdc6e5fbbe6c8011904afcbc1a2777c53496ec02ced7b81f2e7eda61e76bf8262a8bc3ceaa1f6040508051
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🥅 Bakgrunn

Vi går over fra quay-basert linjefiltrering (`quays[].whitelistedLines`, der quay er en proxy for retning) til å lagre linje + retning direkte som `linesWithDirection`, og filtrere på stopplass-nivå i visningen. Det fikser at avganger forsvinner fra tavla når de bytter spor i sanntid.

Denne PR-en får **admin til å skrive** feltet. Gammelt format (`quays`) skrives fortsatt (dual-write), og gammel håndtering røres ikke, slik at en senere opprydding kan fjerne de gamle feltene i et eget steg.

### ✨ Løsning

- Ny `deriveLinesWithDirection(quays, valgteNøkler)` i `utils.ts` som utleder `{ lineId, frontTexts }[]` fra dagens quay-valg.
- Utledningen skjer i `SetVisibleLines` og sendes via et skjult felt (`HiddenInput`)
- `parseTileFormData` leser/parser feltet; `TileCard.submit` lagrer `linesWithDirection` ved siden av `quays`. «Alt valgt» → `linesWithDirection: []`.
- Rører ikke `useLines`, selve valg-UI-et, eller `quays`-skrivingen.

## Bilder
Her er eksempeler som viser to tavler - den til venstre er satt opp før endringen (har ikke linesWithDirection) og den andre er satt opp etter (har linesWithDirection) begge vises med versjon av tavla visning som håndterer linesWithDirection hvis den er der (https://github.com/entur/tavla-visning/pull/121)

<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/3c22ebea-6ba9-470c-98ee-a6678e660e27" />

<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/679144cb-6857-4929-9cf1-3f53a250421a" />



### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)