### PR TITLE
✨ Migrering 017: backfill linesWithDirection

### DIFF
--- a/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
@@ -18,14 +18,24 @@ Description:
     (samme QuayEstimatedCalls-query som admin bruker), unionert per linje på tvers
     av flisens quays. Vi lagrer EKSPLISITTE frontTexts (ingen "alle retninger ->
     []"-kollaps) for å bevare historiske retninger og slippe å hente alle quays
-    ved stoppet. Fail-open: valgt linje uten frontTexts lagres med [] (alle
-    retninger), aldri droppet.
+    ved stoppet.
+
+    Feilhåndtering av API-kall:
+      - Hvert quay-oppslag prøves på nytt med backoff (API_MAX_RETRIES).
+      - Blir et oppslag stående å feile, settes IKKE linesWithDirection på fliser
+        som bruker den quayen — de forblir umigrerte og fanges opp ved en senere
+        kjøring (idempotent). Vi skriver aldri ufullstendig retningsdata.
+      - Et VELLYKKET oppslag som gir 0 frontTexts for en linje (linja har ingen
+        avganger i vinduet) lagres som [] (alle retninger) — det er reell data,
+        ikke en feil.
 
     Additiv: quays / whitelistedLines beholdes urørt. En senere migrering (018)
     kan fjerne dem etter BigQuery-verifisering.
 
     NB: API-kall gjøres i en egen prefetch-fase UTENFOR transaksjonene (011 gjorde
-    API-kall inne i transaksjon -> GCP-timeout).
+    API-kall inne i transaksjon -> GCP-timeout). Transaksjonscallbacken er fri for
+    side-effekter (logging skjer etter commit), siden Firestore kan kjøre den om
+    igjen ved contention.
 
 Usage:
     ./migration run scripts/017_migrate_quays_to_linesWithDirection.py
@@ -46,6 +56,9 @@ COLLECTION = "boards"
 JOURNEY_PLANNER_URL = "https://api.entur.io/journey-planner/v3/graphql"
 CLIENT_NAME = "entur-tavla"
 API_SLEEP_SECONDS = 0.2
+API_MAX_RETRIES = 3
+API_RETRY_BACKOFF_SECONDS = 2  # base for eksponentiell backoff (2, 4, 8 ...)
+API_TIMEOUT_SECONDS = 30
 LOG_FILENAME = "migration_017_log.txt"
 
 # Samme query som admin (tavla/src/graphql/queries/quayEstimatedCalls.graphql):
@@ -151,40 +164,63 @@ def print_scan_summary(label: str, stats: dict, needed: set | None):
 # Fase B: prefetch frontTexts per (quayId, mode) -- UTENFOR transaksjon
 # ---------------------------------------------------------------------------
 def fetch_quay_fronttexts(quay_id: str, mode: str) -> dict:
-    """Returnerer { lineId: set(frontText) } for en quay. Kaster ved API-feil."""
-    response = requests.post(
-        JOURNEY_PLANNER_URL,
-        headers={
-            "Content-Type": "application/json",
-            "ET-Client-Name": CLIENT_NAME,
-        },
-        json={
-            "query": QUAY_ESTIMATED_CALLS_QUERY,
-            "variables": {"quayId": quay_id, "arrivalDeparture": mode},
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
+    """
+    Returnerer { lineId: set(frontText) } for en quay.
+    Prøver på nytt med backoff; kaster siste feil når alle forsøk er brukt opp.
+    """
+    last_error = None
+    for attempt in range(1, API_MAX_RETRIES + 1):
+        try:
+            response = requests.post(
+                JOURNEY_PLANNER_URL,
+                headers={
+                    "Content-Type": "application/json",
+                    "ET-Client-Name": CLIENT_NAME,
+                },
+                json={
+                    "query": QUAY_ESTIMATED_CALLS_QUERY,
+                    "variables": {"quayId": quay_id, "arrivalDeparture": mode},
+                },
+                timeout=API_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            payload = response.json()
 
-    data = response.json().get("data") or {}
-    quay = data.get("quay") or {}
-    calls = quay.get("estimatedCalls") or []
+            # GraphQL kan svare 200 med errors + null data -> behandle som feil.
+            if payload.get("errors"):
+                raise RuntimeError(f"GraphQL errors: {payload['errors']}")
 
-    line_to_fronttexts: dict = {}
-    for call in calls:
-        line = (call.get("serviceJourney") or {}).get("line") or {}
-        line_id = line.get("id")
-        front_text = (call.get("destinationDisplay") or {}).get("frontText")
-        if not line_id or not front_text:
-            continue
-        line_to_fronttexts.setdefault(line_id, set()).add(front_text)
+            data = payload.get("data") or {}
+            quay = data.get("quay") or {}
+            calls = quay.get("estimatedCalls") or []
 
-    return line_to_fronttexts
+            line_to_fronttexts: dict = {}
+            for call in calls:
+                line = (call.get("serviceJourney") or {}).get("line") or {}
+                line_id = line.get("id")
+                front_text = (call.get("destinationDisplay") or {}).get("frontText")
+                if not line_id or not front_text:
+                    continue
+                line_to_fronttexts.setdefault(line_id, set()).add(front_text)
+
+            return line_to_fronttexts
+
+        except Exception as e:  # noqa: BLE001 - transient nettverks-/API-feil
+            last_error = e
+            if attempt < API_MAX_RETRIES:
+                time.sleep(API_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1)))
+
+    raise last_error
 
 
-def build_cache(needed: set) -> dict:
-    """{ (quayId, mode): { lineId: set(frontText) } }. Fail-open ved feil."""
+def build_cache(needed: set) -> tuple:
+    """
+    Returnerer (cache, failed):
+      - cache:  { (quayId, mode): { lineId: set(frontText) } } for vellykkede oppslag
+      - failed: set av (quayId, mode) som feilet etter alle forsøk
+    """
     cache = {}
+    failed = set()
     total = len(needed)
 
     with open(LOG_FILENAME, "a", encoding="utf-8") as log_file:
@@ -198,13 +234,12 @@ def build_cache(needed: set) -> dict:
                     f"🔍 {quay_id} [{mode}]: {len(fronttexts)} linjer, "
                     f"{num_fronttexts} frontTexts\n"
                 )
-                if not fronttexts:
-                    log_file.write(
-                        f"⚠️ {quay_id} [{mode}]: ingen frontTexts (fail-open)\n"
-                    )
-            except Exception as e:
-                cache[(quay_id, mode)] = {}
-                log_file.write(f"❌ {quay_id} [{mode}]: API-feil: {e}\n")
+            except Exception as e:  # noqa: BLE001
+                failed.add((quay_id, mode))
+                log_file.write(
+                    f"❌ {quay_id} [{mode}]: API-feil etter {API_MAX_RETRIES} "
+                    f"forsøk: {e} — fliser som bruker denne quayen forblir umigrerte\n"
+                )
 
             if i % 25 == 0:
                 log_file.flush()
@@ -212,11 +247,14 @@ def build_cache(needed: set) -> dict:
 
             time.sleep(API_SLEEP_SECONDS)
 
-    return cache
+        if failed:
+            log_file.write(f"\n⚠️ {len(failed)} quay-oppslag feilet totalt.\n")
+
+    return cache, failed
 
 
 # ---------------------------------------------------------------------------
-# Fase C: transform + transaksjonell skriv
+# Fase C: transform (ren, uten I/O) + transaksjonell skriv
 # ---------------------------------------------------------------------------
 def build_stop_place_legacy(tile: dict) -> list:
     """Flis-nivå whitelistedLines -> hver linje med frontTexts: [] (alle retninger)."""
@@ -235,7 +273,7 @@ def build_quay_lines_with_direction(tile: dict, mode: str, cache: dict) -> list:
         whitelisted = quay.get("whitelistedLines") or []
         if whitelisted:
             for line_id in whitelisted:
-                # tomt sett = fail-open [] (alle retninger)
+                # tomt sett = vellykket oppslag uten frontTexts -> [] (alle retninger)
                 acc.setdefault(line_id, set()).update(quay_map.get(line_id, set()))
         else:
             # tom quay-whitelist = alle linjer på plattformen
@@ -248,10 +286,16 @@ def build_quay_lines_with_direction(tile: dict, mode: str, cache: dict) -> list:
     ]
 
 
-def transform_tiles(tiles: list, mode: str, cache: dict, log_file) -> tuple:
-    """Returnerer (new_tiles, antall_endrede_fliser)."""
+def transform_tiles(tiles: list, mode: str, cache: dict, failed: set) -> tuple:
+    """
+    Ren funksjon (ingen I/O — trygg ved transaksjons-retry).
+    Returnerer (new_tiles, changed, deferred, log_lines).
+    Fliser hvis quay-oppslag feilet utsettes (ingen linesWithDirection).
+    """
     new_tiles = copy.deepcopy(tiles)
     changed = 0
+    deferred = 0
+    log_lines: list = []
 
     for tile in new_tiles:
         cls = classify_tile(tile)
@@ -259,6 +303,15 @@ def transform_tiles(tiles: list, mode: str, cache: dict, log_file) -> tuple:
             tile["linesWithDirection"] = build_stop_place_legacy(tile)
             changed += 1
         elif cls == "quay":
+            quay_ids = [q.get("id") for q in tile.get("quays") or []]
+            if any((quay_id, mode) in failed for quay_id in quay_ids):
+                # Ufullstendig data -> ikke migrer flisa; tas ved neste kjøring.
+                deferred += 1
+                log_lines.append(
+                    f"   ⏭️ flis {tile.get('uuid', '?')}: utsatt (API-feil på quay) "
+                    f"— forblir umigrert"
+                )
+                continue
             lines_with_direction = build_quay_lines_with_direction(tile, mode, cache)
             tile["linesWithDirection"] = lines_with_direction
             changed += 1
@@ -268,39 +321,54 @@ def transform_tiles(tiles: list, mode: str, cache: dict, log_file) -> tuple:
                 if not entry["frontTexts"]
             ]
             if empty:
-                log_file.write(
+                log_lines.append(
                     f"   ⚠️ flis {tile.get('uuid', '?')}: {len(empty)} linje(r) "
-                    f"uten frontTexts (alle retninger): {empty}\n"
+                    f"uten frontTexts (alle retninger): {empty}"
                 )
         # show_all / already_migrated: urørt
 
-    return new_tiles, changed
+    return new_tiles, changed, deferred, log_lines
 
 
 @firestore.transactional
-def migrate_board(transaction, board_ref, cache, log_file):
+def migrate_board(transaction, board_ref, cache, failed):
+    """
+    Side-effekt-fri: gjør kun read + (evt.) update, og returnerer et resultat som
+    kalleren logger ETTER commit. Firestore kan kjøre denne om igjen ved contention.
+    """
     snapshot = board_ref.get(transaction=transaction)
     if not snapshot.exists:
-        log_file.write(f"☠️ Board finnes ikke: {board_ref.id}\n")
-        return False
+        return {"status": "missing", "log_lines": []}
 
     data = snapshot.to_dict() or {}
     tiles = data.get("tiles") or []
 
     if not board_needs_migration(tiles):
-        return None  # None = ingen endring nødvendig
+        return {"status": "skip", "log_lines": []}
 
     mode = board_mode(data)
-    new_tiles, changed = transform_tiles(tiles, mode, cache, log_file)
+    new_tiles, changed, deferred, log_lines = transform_tiles(
+        tiles, mode, cache, failed
+    )
+
+    if changed == 0:
+        # Alle migrerbare fliser ble utsatt (API-feil) -> ikke skriv.
+        return {"status": "deferred", "deferred": deferred, "log_lines": log_lines}
+
     transaction.update(board_ref, {"tiles": new_tiles})
-    log_file.write(f"✅ {board_ref.id}: {changed} flis(er) migrert\n")
-    return True
+    return {
+        "status": "ok",
+        "changed": changed,
+        "deferred": deferred,
+        "log_lines": log_lines,
+    }
 
 
-def migrate_all(db: firestore.Client, cache: dict):
+def migrate_all(db: firestore.Client, cache: dict, failed: set):
     collection_ref = db.collection(COLLECTION)
     success_count = 0
     skip_count = 0
+    deferred_count = 0
     fail_count = 0
     total_count = 0
 
@@ -309,22 +377,40 @@ def migrate_all(db: firestore.Client, cache: dict):
         for i, doc_snap in enumerate(stream_in_batches(collection_ref)):
             total_count += 1
             board_id = doc_snap.id
-            log_file.write(f"\n-----> 🏁 Board: {board_id}\n")
 
             try:
                 board_ref = db.collection(COLLECTION).document(board_id)
                 transaction = db.transaction()
-                result = migrate_board(transaction, board_ref, cache, log_file)
+                result = migrate_board(transaction, board_ref, cache, failed)
+                status = result["status"]
 
-                if result is True:
+                # Logg ETTER commit (transaksjonscallbacken er side-effekt-fri).
+                if result["log_lines"]:
+                    log_file.write(f"\n-----> 🏁 Board: {board_id}\n")
+                    for line in result["log_lines"]:
+                        log_file.write(line + "\n")
+
+                if status == "ok":
                     success_count += 1
-                elif result is None:
+                    suffix = (
+                        f", {result['deferred']} utsatt" if result["deferred"] else ""
+                    )
+                    log_file.write(
+                        f"✅ {board_id}: {result['changed']} flis(er) migrert{suffix}\n"
+                    )
+                elif status == "deferred":
+                    deferred_count += 1
+                    log_file.write(
+                        f"⏭️ {board_id}: alle migrerbare fliser utsatt (API-feil) "
+                        f"— umigrert, tas ved neste kjøring\n"
+                    )
+                elif status == "skip":
                     skip_count += 1
-                    log_file.write("⏭️ Ingenting å migrere, hopper over\n")
-                else:
+                elif status == "missing":
                     fail_count += 1
+                    log_file.write(f"☠️ Board finnes ikke: {board_id}\n")
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 fail_count += 1
                 log_file.write(f"❌ Feil ved oppdatering av {board_id}: {str(e)}\n")
 
@@ -337,9 +423,15 @@ def migrate_all(db: firestore.Client, cache: dict):
 
         log_file.write(
             f"\n🎉 Ferdig: {success_count} migrert, {skip_count} hoppet over, "
-            f"{fail_count} feilet, {total_count} totalt 🎉\n"
+            f"{deferred_count} utsatt (API-feil), {fail_count} feilet, "
+            f"{total_count} totalt 🎉\n"
         )
         print(f"Migrering fullført. Se {LOG_FILENAME} for detaljer.")
+        if deferred_count:
+            print(
+                f"⚠️ {deferred_count} board(s) utsatt pga. API-feil — "
+                f"kjør skriptet på nytt senere for å fange dem opp."
+            )
 
 
 def stream_in_batches(collection_ref, batch_size=500):
@@ -371,9 +463,11 @@ def run():
         return
 
     print(f"\n🌐 Henter frontTexts for {len(needed)} unike (quay, mode)-oppslag...")
-    cache = build_cache(needed)
+    cache, failed = build_cache(needed)
+    if failed:
+        print(f"⚠️ {len(failed)} quay-oppslag feilet — berørte fliser forblir umigrerte.")
 
-    migrate_all(db, cache)
+    migrate_all(db, cache, failed)
 
     print("\n🔍 Scanner databasen etter migrering...")
     stats_after, _ = scan_and_collect(db)

--- a/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
@@ -1,0 +1,384 @@
+"""
+Purpose: Backfyll linesWithDirection på tiles fra quays / whitelistedLines
+
+Description:
+    Itererer gjennom alle boards og legger til det nye feltet
+    tiles[].linesWithDirection ({ lineId, frontTexts }[]) basert på eksisterende
+    filtrering. Feltet konsumeres av visningen (stopplass-nivå + klient-filter på
+    (lineId, frontText)) og erstatter quay-basert filtrering.
+
+    Klassifisering per flis (presedens: linesWithDirection -> quays ->
+    whitelistedLines -> show_all):
+      - already_migrated : har linesWithDirection      -> urørt (idempotent)
+      - quay             : quays ikke-tom              -> API-oppslag per quay
+      - stop_place_legacy: tom quays + whitelistedLines -> frontTexts: [] per linje
+      - show_all         : verken filter               -> ingen endring
+
+    For quay-fliser hentes frontTexts per (quay, linje) fra journey-planner
+    (samme QuayEstimatedCalls-query som admin bruker), unionert per linje på tvers
+    av flisens quays. Vi lagrer EKSPLISITTE frontTexts (ingen "alle retninger ->
+    []"-kollaps) for å bevare historiske retninger og slippe å hente alle quays
+    ved stoppet. Fail-open: valgt linje uten frontTexts lagres med [] (alle
+    retninger), aldri droppet.
+
+    Additiv: quays / whitelistedLines beholdes urørt. En senere migrering (018)
+    kan fjerne dem etter BigQuery-verifisering.
+
+    NB: API-kall gjøres i en egen prefetch-fase UTENFOR transaksjonene (011 gjorde
+    API-kall inne i transaksjon -> GCP-timeout).
+
+Usage:
+    ./migration run scripts/017_migrate_quays_to_linesWithDirection.py
+
+Date: 2026-07-07
+Author: Guro
+"""
+
+import copy
+import time
+
+import init
+import requests
+from google.cloud import firestore
+
+COLLECTION = "boards"
+
+JOURNEY_PLANNER_URL = "https://api.entur.io/journey-planner/v3/graphql"
+CLIENT_NAME = "entur-tavla"
+API_SLEEP_SECONDS = 0.2
+LOG_FILENAME = "migration_017_log.txt"
+
+# Samme query som admin (tavla/src/graphql/queries/quayEstimatedCalls.graphql):
+# numberOfDeparturesPerLineAndDestinationDisplay: 1 enumererer distinkte
+# (linje, destinasjon)-par; timeRange 7 dager fanger sjeldne avganger.
+QUAY_ESTIMATED_CALLS_QUERY = """
+query QuayEstimatedCalls(
+    $quayId: String!
+    $numberOfDepartures: Int = 200
+    $arrivalDeparture: ArrivalDeparture = departures
+) {
+    quay(id: $quayId) {
+        estimatedCalls(
+            numberOfDepartures: $numberOfDepartures
+            numberOfDeparturesPerLineAndDestinationDisplay: 1
+            timeRange: 604800
+            includeCancelledTrips: true
+            arrivalDeparture: $arrivalDeparture
+        ) {
+            destinationDisplay {
+                frontText
+            }
+            serviceJourney {
+                line {
+                    id
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def board_mode(data: dict) -> str:
+    """Ankomsttavler enumererer ankomst-frontTexts, ellers avgang."""
+    return "arrivals" if data.get("isArrivals") else "departures"
+
+
+def classify_tile(tile: dict) -> str:
+    if tile.get("linesWithDirection") is not None:
+        return "already_migrated"
+    if tile.get("quays"):
+        return "quay"
+    if tile.get("whitelistedLines"):
+        return "stop_place_legacy"
+    return "show_all"
+
+
+def board_needs_migration(tiles: list) -> bool:
+    return any(classify_tile(t) in ("quay", "stop_place_legacy") for t in tiles)
+
+
+# ---------------------------------------------------------------------------
+# Fase A: scan + samle nødvendige API-oppslag
+# ---------------------------------------------------------------------------
+def scan_and_collect(db: firestore.Client) -> tuple:
+    """
+    Returnerer (stats, needed_lookups) der needed_lookups er et sett av
+    (quayId, mode) som må hentes fra journey-planner.
+    """
+    stats = {
+        "total_boards": 0,
+        "total_tiles": 0,
+        "quay": 0,
+        "stop_place_legacy": 0,
+        "show_all": 0,
+        "already_migrated": 0,
+    }
+    needed = set()
+
+    for doc_snap in stream_in_batches(db.collection(COLLECTION)):
+        stats["total_boards"] += 1
+        data = doc_snap.to_dict() or {}
+        mode = board_mode(data)
+        tiles = data.get("tiles") or []
+
+        for tile in tiles:
+            stats["total_tiles"] += 1
+            cls = classify_tile(tile)
+            stats[cls] += 1
+            if cls == "quay":
+                for quay in tile.get("quays") or []:
+                    quay_id = quay.get("id")
+                    if quay_id:
+                        needed.add((quay_id, mode))
+
+    return stats, needed
+
+
+def print_scan_summary(label: str, stats: dict, needed: set | None):
+    print(f"\n📊 Status {label} migrering:")
+    print(f"   Boards skannet    : {stats['total_boards']}")
+    print(f"   Fliser totalt     : {stats['total_tiles']}")
+    print(f"   quay              : {stats['quay']}")
+    print(f"   stop_place_legacy : {stats['stop_place_legacy']}")
+    print(f"   show_all          : {stats['show_all']}")
+    print(f"   already_migrated  : {stats['already_migrated']}")
+    if needed is not None:
+        print(f"   Unike quay-oppslag: {len(needed)}")
+
+
+# ---------------------------------------------------------------------------
+# Fase B: prefetch frontTexts per (quayId, mode) -- UTENFOR transaksjon
+# ---------------------------------------------------------------------------
+def fetch_quay_fronttexts(quay_id: str, mode: str) -> dict:
+    """Returnerer { lineId: set(frontText) } for en quay. Kaster ved API-feil."""
+    response = requests.post(
+        JOURNEY_PLANNER_URL,
+        headers={
+            "Content-Type": "application/json",
+            "ET-Client-Name": CLIENT_NAME,
+        },
+        json={
+            "query": QUAY_ESTIMATED_CALLS_QUERY,
+            "variables": {"quayId": quay_id, "arrivalDeparture": mode},
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    data = response.json().get("data") or {}
+    quay = data.get("quay") or {}
+    calls = quay.get("estimatedCalls") or []
+
+    line_to_fronttexts: dict = {}
+    for call in calls:
+        line = (call.get("serviceJourney") or {}).get("line") or {}
+        line_id = line.get("id")
+        front_text = (call.get("destinationDisplay") or {}).get("frontText")
+        if not line_id or not front_text:
+            continue
+        line_to_fronttexts.setdefault(line_id, set()).add(front_text)
+
+    return line_to_fronttexts
+
+
+def build_cache(needed: set) -> dict:
+    """{ (quayId, mode): { lineId: set(frontText) } }. Fail-open ved feil."""
+    cache = {}
+    total = len(needed)
+
+    with open(LOG_FILENAME, "a", encoding="utf-8") as log_file:
+        log_file.write(f"\n===== PREFETCH ({total} unike quay-oppslag) =====\n")
+        for i, (quay_id, mode) in enumerate(sorted(needed), start=1):
+            try:
+                fronttexts = fetch_quay_fronttexts(quay_id, mode)
+                cache[(quay_id, mode)] = fronttexts
+                num_fronttexts = sum(len(v) for v in fronttexts.values())
+                log_file.write(
+                    f"🔍 {quay_id} [{mode}]: {len(fronttexts)} linjer, "
+                    f"{num_fronttexts} frontTexts\n"
+                )
+                if not fronttexts:
+                    log_file.write(
+                        f"⚠️ {quay_id} [{mode}]: ingen frontTexts (fail-open)\n"
+                    )
+            except Exception as e:
+                cache[(quay_id, mode)] = {}
+                log_file.write(f"❌ {quay_id} [{mode}]: API-feil: {e}\n")
+
+            if i % 25 == 0:
+                log_file.flush()
+                print(f"   Prefetch {i}/{total} quay-oppslag...")
+
+            time.sleep(API_SLEEP_SECONDS)
+
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# Fase C: transform + transaksjonell skriv
+# ---------------------------------------------------------------------------
+def build_stop_place_legacy(tile: dict) -> list:
+    """Flis-nivå whitelistedLines -> hver linje med frontTexts: [] (alle retninger)."""
+    seen = []
+    for line_id in tile.get("whitelistedLines") or []:
+        if line_id not in seen:
+            seen.append(line_id)
+    return [{"lineId": line_id, "frontTexts": []} for line_id in seen]
+
+
+def build_quay_lines_with_direction(tile: dict, mode: str, cache: dict) -> list:
+    """Union av frontTexts per linje på tvers av flisens valgte quays."""
+    acc: dict = {}  # lineId -> set(frontText)
+    for quay in tile.get("quays") or []:
+        quay_map = cache.get((quay.get("id"), mode), {})
+        whitelisted = quay.get("whitelistedLines") or []
+        if whitelisted:
+            for line_id in whitelisted:
+                # tomt sett = fail-open [] (alle retninger)
+                acc.setdefault(line_id, set()).update(quay_map.get(line_id, set()))
+        else:
+            # tom quay-whitelist = alle linjer på plattformen
+            for line_id, fronttexts in quay_map.items():
+                acc.setdefault(line_id, set()).update(fronttexts)
+
+    return [
+        {"lineId": line_id, "frontTexts": sorted(fronttexts)}
+        for line_id, fronttexts in acc.items()
+    ]
+
+
+def transform_tiles(tiles: list, mode: str, cache: dict, log_file) -> tuple:
+    """Returnerer (new_tiles, antall_endrede_fliser)."""
+    new_tiles = copy.deepcopy(tiles)
+    changed = 0
+
+    for tile in new_tiles:
+        cls = classify_tile(tile)
+        if cls == "stop_place_legacy":
+            tile["linesWithDirection"] = build_stop_place_legacy(tile)
+            changed += 1
+        elif cls == "quay":
+            lines_with_direction = build_quay_lines_with_direction(tile, mode, cache)
+            tile["linesWithDirection"] = lines_with_direction
+            changed += 1
+            empty = [
+                entry["lineId"]
+                for entry in lines_with_direction
+                if not entry["frontTexts"]
+            ]
+            if empty:
+                log_file.write(
+                    f"   ⚠️ flis {tile.get('uuid', '?')}: {len(empty)} linje(r) "
+                    f"uten frontTexts (alle retninger): {empty}\n"
+                )
+        # show_all / already_migrated: urørt
+
+    return new_tiles, changed
+
+
+@firestore.transactional
+def migrate_board(transaction, board_ref, cache, log_file):
+    snapshot = board_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        log_file.write(f"☠️ Board finnes ikke: {board_ref.id}\n")
+        return False
+
+    data = snapshot.to_dict() or {}
+    tiles = data.get("tiles") or []
+
+    if not board_needs_migration(tiles):
+        return None  # None = ingen endring nødvendig
+
+    mode = board_mode(data)
+    new_tiles, changed = transform_tiles(tiles, mode, cache, log_file)
+    transaction.update(board_ref, {"tiles": new_tiles})
+    log_file.write(f"✅ {board_ref.id}: {changed} flis(er) migrert\n")
+    return True
+
+
+def migrate_all(db: firestore.Client, cache: dict):
+    collection_ref = db.collection(COLLECTION)
+    success_count = 0
+    skip_count = 0
+    fail_count = 0
+    total_count = 0
+
+    with open(LOG_FILENAME, "a", encoding="utf-8") as log_file:
+        log_file.write("\n===== SKRIV =====\n")
+        for i, doc_snap in enumerate(stream_in_batches(collection_ref)):
+            total_count += 1
+            board_id = doc_snap.id
+            log_file.write(f"\n-----> 🏁 Board: {board_id}\n")
+
+            try:
+                board_ref = db.collection(COLLECTION).document(board_id)
+                transaction = db.transaction()
+                result = migrate_board(transaction, board_ref, cache, log_file)
+
+                if result is True:
+                    success_count += 1
+                elif result is None:
+                    skip_count += 1
+                    log_file.write("⏭️ Ingenting å migrere, hopper over\n")
+                else:
+                    fail_count += 1
+
+            except Exception as e:
+                fail_count += 1
+                log_file.write(f"❌ Feil ved oppdatering av {board_id}: {str(e)}\n")
+
+            if i % 15 == 0 and i != 0:
+                log_file.flush()
+
+            if i % 100 == 0 and i != 0:
+                log_file.write(f"\n😴 Puster etter {i} dokumenter...\n\n")
+                time.sleep(1)
+
+        log_file.write(
+            f"\n🎉 Ferdig: {success_count} migrert, {skip_count} hoppet over, "
+            f"{fail_count} feilet, {total_count} totalt 🎉\n"
+        )
+        print(f"Migrering fullført. Se {LOG_FILENAME} for detaljer.")
+
+
+def stream_in_batches(collection_ref, batch_size=500):
+    """Generator that yields all documents in batches to avoid Firestore timeouts."""
+    last_doc = None
+    while True:
+        query = collection_ref.order_by("__name__").limit(batch_size)
+        if last_doc:
+            query = query.start_after(last_doc)
+        docs = list(query.stream())
+        if not docs:
+            break
+        yield from docs
+        last_doc = docs[-1]
+        print(f"📦 Prosesserte batch til dokument: {last_doc.id}")
+        time.sleep(1)
+
+
+def run():
+    db = init.dev()  # Bytt til init.prod() når klar for prod
+    print(f"Tilkoblet prosjekt: {db.project}")
+
+    print("\n🔍 Scanner databasen før migrering...")
+    stats, needed = scan_and_collect(db)
+    print_scan_summary("FØR", stats, needed)
+
+    if stats["quay"] == 0 and stats["stop_place_legacy"] == 0:
+        print("Ingenting å migrere.")
+        return
+
+    print(f"\n🌐 Henter frontTexts for {len(needed)} unike (quay, mode)-oppslag...")
+    cache = build_cache(needed)
+
+    migrate_all(db, cache)
+
+    print("\n🔍 Scanner databasen etter migrering...")
+    stats_after, _ = scan_and_collect(db)
+    print_scan_summary("ETTER", stats_after, None)
+
+
+if __name__ == "__main__":
+    run()

--- a/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
@@ -7,22 +7,28 @@ Description:
     filtrering. Feltet konsumeres av visningen (stopplass-nivå + klient-filter på
     (lineId, frontText)) og erstatter quay-basert filtrering.
 
-    Klassifisering per flis (presedens: linesWithDirection -> quays ->
+    Klassifisering per tile (presedens: linesWithDirection -> quays ->
     whitelistedLines -> show_all):
       - already_migrated : har linesWithDirection      -> urørt (idempotent)
       - quay             : quays ikke-tom              -> API-oppslag per quay
       - stop_place_legacy: tom quays + whitelistedLines -> frontTexts: [] per linje
       - show_all         : verken filter               -> ingen endring
 
-    For quay-fliser hentes frontTexts per (quay, linje) fra journey-planner
+    For quay-tileer hentes frontTexts per (quay, linje) fra journey-planner
     (samme QuayEstimatedCalls-query som admin bruker), unionert per linje på tvers
-    av flisens quays. Vi lagrer EKSPLISITTE frontTexts (ingen "alle retninger ->
-    []"-kollaps) for å bevare historiske retninger og slippe å hente alle quays
-    ved stoppet.
+    av tileens quays. Vi lagrer EKSPLISITTE frontTexts (ingen "alle retninger ->
+    []"-kollaps) for å bevare historiske retninger.
+
+    En quay med tom whitelistedLines betyr "alle linjer på plattformen" (kommer
+    typisk fra migrering 011: type=="quay"-tiles uten linjefilter). For å bevare
+    dette eksakt henter vi quayens KOMPLETTE linjeliste (quay.lines) i samme query,
+    ikke bare linjene som tilfeldigvis har avganger i vinduet — slik at sesong-/
+    dvale-linjer ikke mistes. frontTexts settes fra estimatedCalls (eller [] hvis
+    linja ikke har avganger i vinduet).
 
     Feilhåndtering av API-kall:
       - Hvert quay-oppslag prøves på nytt med backoff (API_MAX_RETRIES).
-      - Blir et oppslag stående å feile, settes IKKE linesWithDirection på fliser
+      - Blir et oppslag stående å feile, settes IKKE linesWithDirection på tileer
         som bruker den quayen — de forblir umigrerte og fanges opp ved en senere
         kjøring (idempotent). Vi skriver aldri ufullstendig retningsdata.
       - Et VELLYKKET oppslag som gir 0 frontTexts for en linje (linja har ingen
@@ -71,6 +77,9 @@ query QuayEstimatedCalls(
     $arrivalDeparture: ArrivalDeparture = departures
 ) {
     quay(id: $quayId) {
+        lines {
+            id
+        }
         estimatedCalls(
             numberOfDepartures: $numberOfDepartures
             numberOfDeparturesPerLineAndDestinationDisplay: 1
@@ -92,7 +101,7 @@ query QuayEstimatedCalls(
 """
 
 
-def board_mode(data: dict) -> str:
+def board_arrival_or_departure(data: dict) -> str:
     """Ankomsttavler enumererer ankomst-frontTexts, ellers avgang."""
     return "arrivals" if data.get("isArrivals") else "departures"
 
@@ -117,7 +126,7 @@ def board_needs_migration(tiles: list) -> bool:
 def scan_and_collect(db: firestore.Client) -> tuple:
     """
     Returnerer (stats, needed_lookups) der needed_lookups er et sett av
-    (quayId, mode) som må hentes fra journey-planner.
+    (quayId, arrival_or_departure) som må hentes fra journey-planner.
     """
     stats = {
         "total_boards": 0,
@@ -132,7 +141,7 @@ def scan_and_collect(db: firestore.Client) -> tuple:
     for doc_snap in stream_in_batches(db.collection(COLLECTION)):
         stats["total_boards"] += 1
         data = doc_snap.to_dict() or {}
-        mode = board_mode(data)
+        arrival_or_departure = board_arrival_or_departure(data)
         tiles = data.get("tiles") or []
 
         for tile in tiles:
@@ -143,7 +152,7 @@ def scan_and_collect(db: firestore.Client) -> tuple:
                 for quay in tile.get("quays") or []:
                     quay_id = quay.get("id")
                     if quay_id:
-                        needed.add((quay_id, mode))
+                        needed.add((quay_id, arrival_or_departure))
 
     return stats, needed
 
@@ -151,7 +160,7 @@ def scan_and_collect(db: firestore.Client) -> tuple:
 def print_scan_summary(label: str, stats: dict, needed: set | None):
     print(f"\n📊 Status {label} migrering:")
     print(f"   Boards skannet    : {stats['total_boards']}")
-    print(f"   Fliser totalt     : {stats['total_tiles']}")
+    print(f"   Tileer totalt     : {stats['total_tiles']}")
     print(f"   quay              : {stats['quay']}")
     print(f"   stop_place_legacy : {stats['stop_place_legacy']}")
     print(f"   show_all          : {stats['show_all']}")
@@ -161,11 +170,14 @@ def print_scan_summary(label: str, stats: dict, needed: set | None):
 
 
 # ---------------------------------------------------------------------------
-# Fase B: prefetch frontTexts per (quayId, mode) -- UTENFOR transaksjon
+# Fase B: prefetch frontTexts per (quayId, arrival_or_departure) -- UTENFOR transaksjon
 # ---------------------------------------------------------------------------
-def fetch_quay_fronttexts(quay_id: str, mode: str) -> dict:
+def fetch_quay_data(quay_id: str, arrival_or_departure: str) -> dict:
     """
-    Returnerer { lineId: set(frontText) } for en quay.
+    Returnerer { "all_lines": set(lineId), "fronttexts": { lineId: set(frontText) } }.
+      - all_lines : alle linjer quayen betjener (quay.lines) — komplett, uavhengig
+        av 7-dagersvinduet. Brukes for tom-whitelist-quays så ingen linje mistes.
+      - fronttexts: retninger observert i estimatedCalls (7-dagersvindu).
     Prøver på nytt med backoff; kaster siste feil når alle forsøk er brukt opp.
     """
     last_error = None
@@ -179,7 +191,10 @@ def fetch_quay_fronttexts(quay_id: str, mode: str) -> dict:
                 },
                 json={
                     "query": QUAY_ESTIMATED_CALLS_QUERY,
-                    "variables": {"quayId": quay_id, "arrivalDeparture": mode},
+                    "variables": {
+                        "quayId": quay_id,
+                        "arrivalDeparture": arrival_or_departure,
+                    },
                 },
                 timeout=API_TIMEOUT_SECONDS,
             )
@@ -192,18 +207,23 @@ def fetch_quay_fronttexts(quay_id: str, mode: str) -> dict:
 
             data = payload.get("data") or {}
             quay = data.get("quay") or {}
-            calls = quay.get("estimatedCalls") or []
 
-            line_to_fronttexts: dict = {}
-            for call in calls:
+            all_lines = {
+                line.get("id")
+                for line in (quay.get("lines") or [])
+                if line.get("id")
+            }
+
+            fronttexts: dict = {}
+            for call in quay.get("estimatedCalls") or []:
                 line = (call.get("serviceJourney") or {}).get("line") or {}
                 line_id = line.get("id")
                 front_text = (call.get("destinationDisplay") or {}).get("frontText")
                 if not line_id or not front_text:
                     continue
-                line_to_fronttexts.setdefault(line_id, set()).add(front_text)
+                fronttexts.setdefault(line_id, set()).add(front_text)
 
-            return line_to_fronttexts
+            return {"all_lines": all_lines, "fronttexts": fronttexts}
 
         except Exception as e:  # noqa: BLE001 - transient nettverks-/API-feil
             last_error = e
@@ -216,8 +236,8 @@ def fetch_quay_fronttexts(quay_id: str, mode: str) -> dict:
 def build_cache(needed: set) -> tuple:
     """
     Returnerer (cache, failed):
-      - cache:  { (quayId, mode): { lineId: set(frontText) } } for vellykkede oppslag
-      - failed: set av (quayId, mode) som feilet etter alle forsøk
+      - cache:  { (quayId, arrival_or_departure): { lineId: set(frontText) } } for vellykkede oppslag
+      - failed: set av (quayId, arrival_or_departure) som feilet etter alle forsøk
     """
     cache = {}
     failed = set()
@@ -225,20 +245,21 @@ def build_cache(needed: set) -> tuple:
 
     with open(LOG_FILENAME, "a", encoding="utf-8") as log_file:
         log_file.write(f"\n===== PREFETCH ({total} unike quay-oppslag) =====\n")
-        for i, (quay_id, mode) in enumerate(sorted(needed), start=1):
+        for i, (quay_id, arrival_or_departure) in enumerate(sorted(needed), start=1):
             try:
-                fronttexts = fetch_quay_fronttexts(quay_id, mode)
-                cache[(quay_id, mode)] = fronttexts
-                num_fronttexts = sum(len(v) for v in fronttexts.values())
+                quay_data = fetch_quay_data(quay_id, arrival_or_departure)
+                cache[(quay_id, arrival_or_departure)] = quay_data
+                num_lines = len(quay_data["all_lines"])
+                num_fronttexts = sum(len(v) for v in quay_data["fronttexts"].values())
                 log_file.write(
-                    f"🔍 {quay_id} [{mode}]: {len(fronttexts)} linjer, "
+                    f"🔍 {quay_id} [{arrival_or_departure}]: {num_lines} linjer, "
                     f"{num_fronttexts} frontTexts\n"
                 )
             except Exception as e:  # noqa: BLE001
-                failed.add((quay_id, mode))
+                failed.add((quay_id, arrival_or_departure))
                 log_file.write(
-                    f"❌ {quay_id} [{mode}]: API-feil etter {API_MAX_RETRIES} "
-                    f"forsøk: {e} — fliser som bruker denne quayen forblir umigrerte\n"
+                    f"❌ {quay_id} [{arrival_or_departure}]: API-feil etter {API_MAX_RETRIES} "
+                    f"forsøk: {e} — tileer som bruker denne quayen forblir umigrerte\n"
                 )
 
             if i % 25 == 0:
@@ -257,7 +278,7 @@ def build_cache(needed: set) -> tuple:
 # Fase C: transform (ren, uten I/O) + transaksjonell skriv
 # ---------------------------------------------------------------------------
 def build_stop_place_legacy(tile: dict) -> list:
-    """Flis-nivå whitelistedLines -> hver linje med frontTexts: [] (alle retninger)."""
+    """Tile-nivå whitelistedLines -> hver linje med frontTexts: [] (alle retninger)."""
     seen = []
     for line_id in tile.get("whitelistedLines") or []:
         if line_id not in seen:
@@ -265,20 +286,25 @@ def build_stop_place_legacy(tile: dict) -> list:
     return [{"lineId": line_id, "frontTexts": []} for line_id in seen]
 
 
-def build_quay_lines_with_direction(tile: dict, mode: str, cache: dict) -> list:
-    """Union av frontTexts per linje på tvers av flisens valgte quays."""
+def build_quay_lines_with_direction(tile: dict, arrival_or_departure: str, cache: dict) -> list:
+    """Union av frontTexts per linje på tvers av tilens valgte quays."""
     acc: dict = {}  # lineId -> set(frontText)
+    empty_quay = {"all_lines": set(), "fronttexts": {}}
     for quay in tile.get("quays") or []:
-        quay_map = cache.get((quay.get("id"), mode), {})
+        # Hent quay-data fra cache (prefetch-fase). Hvis oppslaget feilet, returneres tomt sett.
+        cached_quay_data = cache.get((quay.get("id"), arrival_or_departure), empty_quay)
+        cached_fronttexts = cached_quay_data["fronttexts"]
         whitelisted = quay.get("whitelistedLines") or []
         if whitelisted:
+            # for hver linje i whitelistedLines, sett union av frontTexts fra cache (eller [] hvis ingen)
             for line_id in whitelisted:
-                # tomt sett = vellykket oppslag uten frontTexts -> [] (alle retninger)
-                acc.setdefault(line_id, set()).update(quay_map.get(line_id, set()))
+                acc.setdefault(line_id, set()).update(cached_fronttexts.get(line_id, set()))
         else:
-            # tom quay-whitelist = alle linjer på plattformen
-            for line_id, fronttexts in quay_map.items():
-                acc.setdefault(line_id, set()).update(fronttexts)
+            # Hvis vi har tom quay-whitelist, vis alle linjer på plattformen. Disse typen tiles stammer fra migrering 011, der type=="quay" uten whitelistedLines betyr "alle linjer på plattformen".
+            # For å beholde alle linjer (ikke bare de med avganger neste 7 dager) bruker vi hele settet fra quay.lines i cache
+            # Legg til frontTexts fra cache  hvis linja har avganger i vinduet, ellers [] (alle retninger)
+            for line_id in cached_quay_data["all_lines"]:
+                acc.setdefault(line_id, set()).update(cached_fronttexts.get(line_id, set()))
 
     return [
         {"lineId": line_id, "frontTexts": sorted(fronttexts)}
@@ -286,11 +312,11 @@ def build_quay_lines_with_direction(tile: dict, mode: str, cache: dict) -> list:
     ]
 
 
-def transform_tiles(tiles: list, mode: str, cache: dict, failed: set) -> tuple:
+def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed: set) -> tuple:
     """
     Ren funksjon (ingen I/O — trygg ved transaksjons-retry).
     Returnerer (new_tiles, changed, deferred, log_lines).
-    Fliser hvis quay-oppslag feilet utsettes (ingen linesWithDirection).
+    Tileer hvis quay-oppslag feilet utsettes (ingen linesWithDirection).
     """
     new_tiles = copy.deepcopy(tiles)
     changed = 0
@@ -298,21 +324,21 @@ def transform_tiles(tiles: list, mode: str, cache: dict, failed: set) -> tuple:
     log_lines: list = []
 
     for tile in new_tiles:
-        cls = classify_tile(tile)
-        if cls == "stop_place_legacy":
+        tile_classification = classify_tile(tile)
+        if tile_classification == "stop_place_legacy":
             tile["linesWithDirection"] = build_stop_place_legacy(tile)
             changed += 1
-        elif cls == "quay":
+        elif tile_classification == "quay":
             quay_ids = [q.get("id") for q in tile.get("quays") or []]
-            if any((quay_id, mode) in failed for quay_id in quay_ids):
-                # Ufullstendig data -> ikke migrer flisa; tas ved neste kjøring.
+            if any((quay_id, arrival_or_departure) in failed for quay_id in quay_ids):
+                # Ufullstendig data -> ikke migrer tile
                 deferred += 1
                 log_lines.append(
-                    f"   ⏭️ flis {tile.get('uuid', '?')}: utsatt (API-feil på quay) "
+                    f"   ⏭️ tile {tile.get('uuid', '?')}: utsatt (API-feil på quay) "
                     f"— forblir umigrert"
                 )
                 continue
-            lines_with_direction = build_quay_lines_with_direction(tile, mode, cache)
+            lines_with_direction = build_quay_lines_with_direction(tile, arrival_or_departure, cache)
             tile["linesWithDirection"] = lines_with_direction
             changed += 1
             empty = [
@@ -322,7 +348,7 @@ def transform_tiles(tiles: list, mode: str, cache: dict, failed: set) -> tuple:
             ]
             if empty:
                 log_lines.append(
-                    f"   ⚠️ flis {tile.get('uuid', '?')}: {len(empty)} linje(r) "
+                    f"   ⚠️ tile {tile.get('uuid', '?')}: {len(empty)} linje(r) "
                     f"uten frontTexts (alle retninger): {empty}"
                 )
         # show_all / already_migrated: urørt
@@ -346,13 +372,13 @@ def migrate_board(transaction, board_ref, cache, failed):
     if not board_needs_migration(tiles):
         return {"status": "skip", "log_lines": []}
 
-    mode = board_mode(data)
+    arrival_or_departure = board_arrival_or_departure(data)
     new_tiles, changed, deferred, log_lines = transform_tiles(
-        tiles, mode, cache, failed
+        tiles, arrival_or_departure, cache, failed
     )
 
     if changed == 0:
-        # Alle migrerbare fliser ble utsatt (API-feil) -> ikke skriv.
+        # Alle migrerbare tileer ble utsatt (API-feil) -> ikke skriv.
         return {"status": "deferred", "deferred": deferred, "log_lines": log_lines}
 
     transaction.update(board_ref, {"tiles": new_tiles})
@@ -396,12 +422,12 @@ def migrate_all(db: firestore.Client, cache: dict, failed: set):
                         f", {result['deferred']} utsatt" if result["deferred"] else ""
                     )
                     log_file.write(
-                        f"✅ {board_id}: {result['changed']} flis(er) migrert{suffix}\n"
+                        f"✅ {board_id}: {result['changed']} tile(er) migrert{suffix}\n"
                     )
                 elif status == "deferred":
                     deferred_count += 1
                     log_file.write(
-                        f"⏭️ {board_id}: alle migrerbare fliser utsatt (API-feil) "
+                        f"⏭️ {board_id}: alle migrerbare tileer utsatt (API-feil) "
                         f"— umigrert, tas ved neste kjøring\n"
                     )
                 elif status == "skip":
@@ -462,10 +488,10 @@ def run():
         print("Ingenting å migrere.")
         return
 
-    print(f"\n🌐 Henter frontTexts for {len(needed)} unike (quay, mode)-oppslag...")
+    print(f"\n🌐 Henter frontTexts for {len(needed)} unike (quay, arrival_or_departure)-oppslag...")
     cache, failed = build_cache(needed)
     if failed:
-        print(f"⚠️ {len(failed)} quay-oppslag feilet — berørte fliser forblir umigrerte.")
+        print(f"⚠️ {len(failed)} quay-oppslag feilet — berørte tileer forblir umigrerte.")
 
     migrate_all(db, cache, failed)
 

--- a/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
@@ -334,7 +334,7 @@ def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed:
                 # Ufullstendig data -> ikke migrer tile
                 deferred += 1
                 log_lines.append(
-                    f"   ⏭️ tile {tile.get('uuid', '?')}: utsatt (API-feil på quay) "
+                    f"⏭️ tile {tile.get('uuid', '?')}: utsatt (API-feil på quay) "
                     f"— forblir umigrert"
                 )
                 continue
@@ -348,7 +348,7 @@ def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed:
             ]
             if empty:
                 log_lines.append(
-                    f"   ⚠️ tile {tile.get('uuid', '?')}: {len(empty)} linje(r) "
+                    f"⚠️ tile {tile.get('uuid', '?')}: {len(empty)} linje(r) "
                     f"uten frontTexts (alle retninger): {empty}"
                 )
         # show_all / already_migrated: urørt
@@ -411,10 +411,9 @@ def migrate_all(db: firestore.Client, cache: dict, failed: set):
                 status = result["status"]
 
                 # Logg ETTER commit (transaksjonscallbacken er side-effekt-fri).
-                if result["log_lines"]:
-                    log_file.write(f"\n-----> 🏁 Board: {board_id}\n")
-                    for line in result["log_lines"]:
-                        log_file.write(line + "\n")
+                # board_id på hver logglinje for å kunne søke i loggfilen og lettere slå opp i databasen
+                for line in result["log_lines"]:
+                    log_file.write(f"   board {board_id} · {line}\n")
 
                 if status == "ok":
                     success_count += 1

--- a/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
@@ -67,9 +67,8 @@ API_RETRY_BACKOFF_SECONDS = 2  # base for eksponentiell backoff (2, 4, 8 ...)
 API_TIMEOUT_SECONDS = 30
 LOG_FILENAME = "migration_017_log.txt"
 
-# Samme query som admin (tavla/src/graphql/queries/quayEstimatedCalls.graphql):
-# numberOfDeparturesPerLineAndDestinationDisplay: 1 enumererer distinkte
-# (linje, destinasjon)-par; timeRange 7 dager fanger sjeldne avganger.
+# Samme query som admin (tavla/src/graphql/queries/quayEstimatedCalls.graphql) pluss quay.lines.id 
+
 QUAY_ESTIMATED_CALLS_QUERY = """
 query QuayEstimatedCalls(
     $quayId: String!
@@ -146,9 +145,9 @@ def scan_and_collect(db: firestore.Client) -> tuple:
 
         for tile in tiles:
             stats["total_tiles"] += 1
-            cls = classify_tile(tile)
-            stats[cls] += 1
-            if cls == "quay":
+            tile_classification = classify_tile(tile)
+            stats[tile_classification] += 1
+            if tile_classification == "quay":
                 for quay in tile.get("quays") or []:
                     quay_id = quay.get("id")
                     if quay_id:
@@ -220,6 +219,7 @@ def fetch_quay_data(quay_id: str, arrival_or_departure: str) -> dict:
                 line_id = line.get("id")
                 front_text = (call.get("destinationDisplay") or {}).get("frontText")
                 if not line_id or not front_text:
+                    # Mangler frontText eller linjeId, ingorer denne avgangen
                     continue
                 fronttexts.setdefault(line_id, set()).add(front_text)
 
@@ -259,7 +259,7 @@ def build_cache(needed: set) -> tuple:
                 failed.add((quay_id, arrival_or_departure))
                 log_file.write(
                     f"❌ {quay_id} [{arrival_or_departure}]: API-feil etter {API_MAX_RETRIES} "
-                    f"forsøk: {e} — tileer som bruker denne quayen forblir umigrerte\n"
+                    f"forsøk: {e} — tiles som bruker denne quayen forblir umigrerte\n"
                 )
 
             if i % 25 == 0:
@@ -331,7 +331,7 @@ def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed:
         elif tile_classification == "quay":
             quay_ids = [q.get("id") for q in tile.get("quays") or []]
             if any((quay_id, arrival_or_departure) in failed for quay_id in quay_ids):
-                # Ufullstendig data -> ikke migrer tile
+                # Hvis noen av tileens quays feilet i prefetch-fasen, utsett migrering av denne tileen (ingen linesWithDirection settes).
                 deferred += 1
                 log_lines.append(
                     f"⏭️ tile {tile.get('uuid', '?')}: utsatt (API-feil på quay) "
@@ -349,9 +349,9 @@ def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed:
             if empty:
                 log_lines.append(
                     f"⚠️ tile {tile.get('uuid', '?')}: {len(empty)} linje(r) "
-                    f"uten frontTexts (alle retninger): {empty}"
+                    f"uten frontTexts (ingen avganger neste 7 dager). Viser alle retninger): {empty}"
                 )
-        # show_all / already_migrated: urørt
+        # kategori show_all eller already_migrated, gjør ingenting
 
     return new_tiles, changed, deferred, log_lines
 
@@ -360,7 +360,7 @@ def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed:
 def migrate_board(transaction, board_ref, cache, failed):
     """
     Side-effekt-fri: gjør kun read + (evt.) update, og returnerer et resultat som
-    kalleren logger ETTER commit. Firestore kan kjøre denne om igjen ved contention.
+    kalleren logger etter commit. Firestore kan kjøre denne om igjen ved contention.
     """
     snapshot = board_ref.get(transaction=transaction)
     if not snapshot.exists:
@@ -378,7 +378,7 @@ def migrate_board(transaction, board_ref, cache, failed):
     )
 
     if changed == 0:
-        # Alle migrerbare tileer ble utsatt (API-feil) -> ikke skriv.
+        # Alle migrerbare tiles ble utsatt (API-feil) -> ikke skriv.
         return {"status": "deferred", "deferred": deferred, "log_lines": log_lines}
 
     transaction.update(board_ref, {"tiles": new_tiles})
@@ -410,28 +410,34 @@ def migrate_all(db: firestore.Client, cache: dict, failed: set):
                 result = migrate_board(transaction, board_ref, cache, failed)
                 status = result["status"]
 
-                # Logg ETTER commit (transaksjonscallbacken er side-effekt-fri).
+                # Logg etter transaksjons commit
                 # board_id på hver logglinje for å kunne søke i loggfilen og lettere slå opp i databasen
                 for line in result["log_lines"]:
                     log_file.write(f"   board {board_id} · {line}\n")
 
                 if status == "ok":
+                    # Board ble oppdatert med linesWithDirection -> migrert
                     success_count += 1
-                    suffix = (
+
+                    # Hvis noen tiles ble utsatt, logg det også
+                    deferred_count_suffix = (
                         f", {result['deferred']} utsatt" if result["deferred"] else ""
                     )
                     log_file.write(
-                        f"✅ {board_id}: {result['changed']} tile(er) migrert{suffix}\n"
+                        f"✅ {board_id}: {result['changed']} tile(er) migrert{deferred_count_suffix}\n"
                     )
                 elif status == "deferred":
+                    # Alle migrerbare tileer ble utsatt (API-feil) -> ingen update, forblir umigrert
                     deferred_count += 1
                     log_file.write(
                         f"⏭️ {board_id}: alle migrerbare tileer utsatt (API-feil) "
                         f"— umigrert, tas ved neste kjøring\n"
                     )
                 elif status == "skip":
+                    # Ingen tiles som trengte migrering -> hopp over
                     skip_count += 1
                 elif status == "missing":
+                    # Board-dokumentet finnes ikke (kan ha blitt slettet etter scan-fasen)
                     fail_count += 1
                     log_file.write(f"☠️ Board finnes ikke: {board_id}\n")
 

--- a/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/017_migrate_quays_to_linesWithDirection.py
@@ -67,7 +67,10 @@ API_RETRY_BACKOFF_SECONDS = 2  # base for eksponentiell backoff (2, 4, 8 ...)
 API_TIMEOUT_SECONDS = 30
 LOG_FILENAME = "migration_017_log.txt"
 
-# Samme query som admin (tavla/src/graphql/queries/quayEstimatedCalls.graphql) pluss quay.lines.id 
+# Basert på admin sin QuayEstimatedCalls (tavla/src/graphql/queries/quayEstimatedCalls.graphql),
+# men utvidet med quay.lines.id og med timeRange 30 dager (admin bruker 7). 30 dager gir bedre
+# retnings-dekning for sesong-/sjelden trafikk uten målbar ekstra kostnad (verifisert empirisk),
+# og påvirker kun retnings-presisjon — hvilke linjer som lagres kommer fra quay.lines uansett.
 
 QUAY_ESTIMATED_CALLS_QUERY = """
 query QuayEstimatedCalls(
@@ -82,7 +85,7 @@ query QuayEstimatedCalls(
         estimatedCalls(
             numberOfDepartures: $numberOfDepartures
             numberOfDeparturesPerLineAndDestinationDisplay: 1
-            timeRange: 604800
+            timeRange: 2592000
             includeCancelledTrips: true
             arrivalDeparture: $arrivalDeparture
         ) {
@@ -175,8 +178,8 @@ def fetch_quay_data(quay_id: str, arrival_or_departure: str) -> dict:
     """
     Returnerer { "all_lines": set(lineId), "fronttexts": { lineId: set(frontText) } }.
       - all_lines : alle linjer quayen betjener (quay.lines) — komplett, uavhengig
-        av 7-dagersvinduet. Brukes for tom-whitelist-quays så ingen linje mistes.
-      - fronttexts: retninger observert i estimatedCalls (7-dagersvindu).
+        av tidsvinduet. Brukes for tom-whitelist-quays så ingen linje mistes.
+      - fronttexts: retninger observert i estimatedCalls (30-dagersvindu).
     Prøver på nytt med backoff; kaster siste feil når alle forsøk er brukt opp.
     """
     last_error = None
@@ -301,7 +304,7 @@ def build_quay_lines_with_direction(tile: dict, arrival_or_departure: str, cache
                 acc.setdefault(line_id, set()).update(cached_fronttexts.get(line_id, set()))
         else:
             # Hvis vi har tom quay-whitelist, vis alle linjer på plattformen. Disse typen tiles stammer fra migrering 011, der type=="quay" uten whitelistedLines betyr "alle linjer på plattformen".
-            # For å beholde alle linjer (ikke bare de med avganger neste 7 dager) bruker vi hele settet fra quay.lines i cache
+            # For å beholde alle linjer (ikke bare de med avganger neste 30 dager) bruker vi hele settet fra quay.lines i cache
             # Legg til frontTexts fra cache  hvis linja har avganger i vinduet, ellers [] (alle retninger)
             for line_id in cached_quay_data["all_lines"]:
                 acc.setdefault(line_id, set()).update(cached_fronttexts.get(line_id, set()))
@@ -349,7 +352,7 @@ def transform_tiles(tiles: list, arrival_or_departure: str, cache: dict, failed:
             if empty:
                 log_lines.append(
                     f"⚠️ tile {tile.get('uuid', '?')}: {len(empty)} linje(r) "
-                    f"uten frontTexts (ingen avganger neste 7 dager). Viser alle retninger): {empty}"
+                    f"uten frontTexts (ingen avganger neste 30 dager). Viser alle retninger): {empty}"
                 )
         # kategori show_all eller already_migrated, gjør ingenting
 
@@ -482,7 +485,7 @@ def stream_in_batches(collection_ref, batch_size=500):
 
 
 def run():
-    db = init.dev()  # Bytt til init.prod() når klar for prod
+    db = init.local()  # Bytt til init.prod() når klar for prod
     print(f"Tilkoblet prosjekt: {db.project}")
 
     print("\n🔍 Scanner databasen før migrering...")

--- a/tavla/migrations/scripts/test_017_migrate_quays_to_linesWithDirection.py
+++ b/tavla/migrations/scripts/test_017_migrate_quays_to_linesWithDirection.py
@@ -1,0 +1,190 @@
+"""
+Enhetstester for de rene transform-funksjonene i migrering 017.
+
+Tester klassifisering og transform uten nettverk/Firestore — `cache` og `failed`
+injiseres direkte. Sikkerhetsnett før en engangs prod-migrering som muterer alle
+boards.
+
+Kjør: 
+cd tavla/migrations
+./migration run scripts/test_017_migrate_quays_to_linesWithDirection.py
+
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+_spec = importlib.util.spec_from_file_location(
+    "migration_017",
+    os.path.join(SCRIPTS_DIR, "017_migrate_quays_to_linesWithDirection.py"),
+)
+migration = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migration)
+
+classify_tile = migration.classify_tile
+build_stop_place_legacy = migration.build_stop_place_legacy
+build_quay_lines_with_direction = migration.build_quay_lines_with_direction
+transform_tiles = migration.transform_tiles
+
+
+class ClassifyTile(unittest.TestCase):
+    def test_already_migrated_when_field_present_even_if_empty(self):
+        self.assertEqual(classify_tile({"linesWithDirection": []}), "already_migrated")
+        self.assertEqual(
+            classify_tile(
+                {
+                    "linesWithDirection": [{"lineId": "L1", "frontTexts": []}],
+                    "quays": [{"id": "Q1", "whitelistedLines": ["L1"]}],
+                }
+            ),
+            "already_migrated",
+        )
+
+    def test_quay_when_quays_nonempty(self):
+        self.assertEqual(
+            classify_tile({"quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}),
+            "quay",
+        )
+
+    def test_stop_place_legacy(self):
+        self.assertEqual(
+            classify_tile({"quays": [], "whitelistedLines": ["L1"]}),
+            "stop_place_legacy",
+        )
+
+    def test_show_all(self):
+        self.assertEqual(classify_tile({"quays": [], "whitelistedLines": []}), "show_all")
+        self.assertEqual(classify_tile({}), "show_all")
+
+    def test_quays_wins_over_whitelisted(self):
+        self.assertEqual(
+            classify_tile(
+                {
+                    "quays": [{"id": "Q1", "whitelistedLines": ["L1"]}],
+                    "whitelistedLines": ["L9"],
+                }
+            ),
+            "quay",
+        )
+
+
+class BuildStopPlaceLegacy(unittest.TestCase):
+    def test_dedup_and_empty_fronttexts(self):
+        tile = {"whitelistedLines": ["L1", "L2", "L1"]}
+        self.assertEqual(
+            build_stop_place_legacy(tile),
+            [{"lineId": "L1", "frontTexts": []}, {"lineId": "L2", "frontTexts": []}],
+        )
+
+
+class BuildQuayLinesWithDirection(unittest.TestCase):
+    def test_explicit_whitelist_uses_fronttexts(self):
+        tile = {"quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}
+        cache = {("Q1", "departures"): {"all_lines": {"L1", "L2"}, "fronttexts": {"L1": {"Nord"}}}}
+        self.assertEqual(
+            build_quay_lines_with_direction(tile, "departures", cache),
+            [{"lineId": "L1", "frontTexts": ["Nord"]}],
+        )
+
+    def test_explicit_whitelist_without_fronttexts_is_failopen(self):
+        tile = {"quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}
+        cache = {("Q1", "departures"): {"all_lines": {"L1"}, "fronttexts": {}}}
+        self.assertEqual(
+            build_quay_lines_with_direction(tile, "departures", cache),
+            [{"lineId": "L1", "frontTexts": []}],
+        )
+
+    def test_empty_whitelist_uses_all_lines(self):
+        tile = {"quays": [{"id": "Q1", "whitelistedLines": []}]}
+        cache = {("Q1", "departures"): {"all_lines": {"L1", "L2"}, "fronttexts": {"L1": {"Nord"}}}}
+        result = build_quay_lines_with_direction(tile, "departures", cache)
+        self.assertEqual(
+            {e["lineId"]: e["frontTexts"] for e in result},
+            {"L1": ["Nord"], "L2": []},
+        )
+
+    def test_union_across_quays(self):
+        tile = {
+            "quays": [
+                {"id": "Q1", "whitelistedLines": ["L1"]},
+                {"id": "Q2", "whitelistedLines": ["L1"]},
+            ]
+        }
+        cache = {
+            ("Q1", "departures"): {"all_lines": {"L1"}, "fronttexts": {"L1": {"Nord"}}},
+            ("Q2", "departures"): {"all_lines": {"L1"}, "fronttexts": {"L1": {"Sør"}}},
+        }
+        self.assertEqual(
+            build_quay_lines_with_direction(tile, "departures", cache),
+            [{"lineId": "L1", "frontTexts": ["Nord", "Sør"]}],
+        )
+
+    def test_fronttexts_sorted(self):
+        tile = {"quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}
+        cache = {
+            ("Q1", "departures"): {
+                "all_lines": {"L1"},
+                "fronttexts": {"L1": {"Storo", "Bergkrystallen"}},
+            }
+        }
+        self.assertEqual(
+            build_quay_lines_with_direction(tile, "departures", cache),
+            [{"lineId": "L1", "frontTexts": ["Bergkrystallen", "Storo"]}],
+        )
+
+
+class TransformTiles(unittest.TestCase):
+    def test_stop_place_legacy_sets_field(self):
+        tiles = [{"uuid": "t1", "quays": [], "whitelistedLines": ["L1"]}]
+        new_tiles, changed, deferred, _ = transform_tiles(tiles, "departures", {}, set())
+        self.assertEqual((changed, deferred), (1, 0))
+        self.assertEqual(new_tiles[0]["linesWithDirection"], [{"lineId": "L1", "frontTexts": []}])
+
+    def test_quay_sets_field(self):
+        tiles = [{"uuid": "t1", "quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}]
+        cache = {("Q1", "departures"): {"all_lines": {"L1"}, "fronttexts": {"L1": {"Nord"}}}}
+        new_tiles, changed, deferred, _ = transform_tiles(tiles, "departures", cache, set())
+        self.assertEqual((changed, deferred), (1, 0))
+        self.assertEqual(
+            new_tiles[0]["linesWithDirection"], [{"lineId": "L1", "frontTexts": ["Nord"]}]
+        )
+
+    def test_quay_with_failed_lookup_is_deferred_and_not_written(self):
+        tiles = [{"uuid": "t1", "quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}]
+        new_tiles, changed, deferred, _ = transform_tiles(
+            tiles, "departures", {}, {("Q1", "departures")}
+        )
+        self.assertEqual((changed, deferred), (0, 1))
+        self.assertNotIn("linesWithDirection", new_tiles[0])
+
+    def test_show_all_and_already_migrated_untouched(self):
+        tiles = [
+            {"uuid": "s", "quays": [], "whitelistedLines": []},
+            {
+                "uuid": "m",
+                "quays": [],
+                "linesWithDirection": [{"lineId": "L1", "frontTexts": []}],
+            },
+        ]
+        new_tiles, changed, deferred, _ = transform_tiles(tiles, "departures", {}, set())
+        self.assertEqual((changed, deferred), (0, 0))
+        self.assertNotIn("linesWithDirection", new_tiles[0])
+        self.assertEqual(
+            new_tiles[1]["linesWithDirection"], [{"lineId": "L1", "frontTexts": []}]
+        )
+
+    def test_original_tiles_not_mutated(self):
+        tiles = [{"uuid": "t1", "quays": [{"id": "Q1", "whitelistedLines": ["L1"]}]}]
+        cache = {("Q1", "departures"): {"all_lines": {"L1"}, "fronttexts": {"L1": {"Nord"}}}}
+        transform_tiles(tiles, "departures", cache, set())
+        self.assertNotIn("linesWithDirection", tiles[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!WARNING]
> **Draft** — skriptet er ikke kjørt ennå. Kjøres **etter** at datamodell (#2) og visning (#3) er i prod, og etter testing på emulator/dev.

## 🥅 Bakgrunn

Vi går over fra quay-basert linjefiltrering til `tiles[].linesWithDirection` ({ lineId, frontTexts }[]), som visningen filtrerer på (stopplass-nivå + klient-filter på (lineId, frontText)). Denne migreringen backfyller feltet på eksisterende tavler slik at de kan flyttes til den nye stien og gamle felt senere kan fjernes (018).


Kjørte en spørring på prod for å finne litt tall:
- 3 560 `quay`-tiles (trenger API-oppslag for migrering), 
- 726 `stop_place_legacy`, har `whitelistedLines` men ingen quays, 
- 3 283 `show_all`. 

Som gir: 2 154 unike quay-oppslag til journey-planner → ~10–20 min prefetch.


## ✨ Løsning

`migrations/scripts/017_migrate_quays_to_linesWithDirection.py`, etter 015-mønsteret:

### Klassifisering  per tile

|Klassifisering| Betingelse | Hvordan migrere|
|---|---|---|
|already_migrated  | har linesWithDirection  |ingen migrering, allerede migrert eller opprettet etter #2532  |
| quay  |tile.quays er ikke-tom  | henter `lineId`s fra `quay.whitelistedLines`, gjør API-oppslag for å finne frontTexts |
|stop_place_legacy |tom quays, men har tile.whitelistedLines  |  henter `lineId`s fra `quay.whitelistedLines`, setter frontTexts: [] per linje|
|show_all    | ingen tile.quays eller tile.whitelistedLines  | ingen migrering siden tilen ikke har noen filter|

### Migreringen i faser:
**Fase A:** Scanner alle board og kategoriserer hver tile som `already_migrated`, `quay`, `stop_place_legacy` eller `show_all`. Samler samtidig settet av unike (quayId, arrival_or_departure) som quay-tiles trenger API-oppslag for. 

**Fase B:** Henter linjer og frontTexter for alle (quayId, arrival_or_deparutre)-par fra fase A fra journey-planner. Har 3 retryes i tilfelle kall feiler. Samler resultatet i en cache som kan brukes for firebase transaksjonen. 

**Fase C:** Bygger nye tiles med det nye feltet, og så migrerer: `migrate_all` løkker over alle boards; per board kjører `migrate_board` inne i en transaksjon.

**Fase D:** Kjører Fase A-scanning på nytt, og skriver ETTER-sammendrag. 


### ✅ Sjekkliste

- [x] Testet på prod-data lokalt

🤖 Generated with [Claude Code](https://claude.com/claude-code)