### PR TITLE
💄Vis Quay-ID for kaier uten publicCode

### DIFF
--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -127,25 +127,20 @@ export function PlatformAndLines({
                             />
                         ))}
                     </div>
-                    <div className="flex flex-row flex-wrap items-baseline gap-x-2 font-semibold">
+                    <div className="flex flex-row flex-wrap items-center gap-x-2 font-semibold">
                         {title}
                         {quayCodeTooltip && (
-                            <span className="self-center">
-                                <Tooltip
-                                    content={
-                                        <span className="font-normal">
-                                            {quayCodeTooltip}
-                                        </span>
-                                    }
-                                    placement="top"
-                                    id={`tooltip-quay-code-${quayId}`}
-                                >
-                                    <ValidationInfoFilledIcon
-                                        size={20}
-                                        aria-labelledby={`tooltip-quay-code-${quayId}`}
-                                    />
-                                </Tooltip>
-                            </span>
+                            <Tooltip
+                                className="font-normal"
+                                content={quayCodeTooltip}
+                                placement="top"
+                                id={`tooltip-quay-code-${quayId}`}
+                            >
+                                <ValidationInfoFilledIcon
+                                    size={20}
+                                    aria-labelledby={`tooltip-quay-code-${quayId}`}
+                                />
+                            </Tooltip>
                         )}
                         {description && (
                             <span className="text-sm font-normal text-[#626493]">

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { Checkbox } from '@entur/form'
+import { ValidationInfoFilledIcon } from '@entur/icons'
 import { SkeletonRectangle } from '@entur/loader'
+import { Tooltip } from '@entur/tooltip'
 import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
 import {
     getColorMode,
@@ -41,6 +43,7 @@ export function PlatformAndLines({
     groupKey,
     title,
     description,
+    quayCodeTooltip,
     lines,
     trackingLocation,
     fallbackTransportModes: fallbackModes,
@@ -53,6 +56,7 @@ export function PlatformAndLines({
     groupKey: string
     title: string
     description: string | null
+    quayCodeTooltip?: string | null
     lines: LineWithFrontText[]
     trackingLocation: EventProps<'stop_place_edit_interaction'>['location']
     fallbackTransportModes: TTransportMode[]
@@ -125,6 +129,24 @@ export function PlatformAndLines({
                     </div>
                     <div className="flex flex-row flex-wrap items-baseline gap-x-2 font-semibold">
                         {title}
+                        {quayCodeTooltip && (
+                            <span className="self-center">
+                                <Tooltip
+                                    content={
+                                        <span className="font-normal">
+                                            {quayCodeTooltip}
+                                        </span>
+                                    }
+                                    placement="top"
+                                    id={`tooltip-quay-code-${quayId}`}
+                                >
+                                    <ValidationInfoFilledIcon
+                                        size={20}
+                                        aria-labelledby={`tooltip-quay-code-${quayId}`}
+                                    />
+                                </Tooltip>
+                            </span>
+                        )}
                         {description && (
                             <span className="text-sm font-normal text-[#626493]">
                                 {description}

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -255,6 +255,9 @@ export function SetVisibleLines({
             quay.name && quay.publicCode
                 ? `${quayModes[0] === 'metro' || quayModes[0] === 'rail' ? 'Spor' : 'Plattform'} ${quay.publicCode}`
                 : quay.name || 'Ukjent'
+        const description = quay.publicCode
+            ? quay.description
+            : [quay.description, quay.id].filter(Boolean).join(' · ')
         return (
             <PlatformAndLines
                 key={quay.id}
@@ -262,7 +265,7 @@ export function SetVisibleLines({
                 quayId={quay.id}
                 groupKey={quay.publicCode || quay.id}
                 title={title}
-                description={quay.description}
+                description={description}
                 lines={quay.lines}
                 trackingLocation={trackingLocation}
                 fallbackTransportModes={quayModes}

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -255,9 +255,9 @@ export function SetVisibleLines({
             quay.name && quay.publicCode
                 ? `${quayModes[0] === 'metro' || quayModes[0] === 'rail' ? 'Spor' : 'Plattform'} ${quay.publicCode}`
                 : quay.name || 'Ukjent'
-        const description = quay.publicCode
-            ? quay.description
-            : [quay.description, quay.id].filter(Boolean).join(' · ')
+        const quayCodeTooltip = quay.publicCode
+            ? null
+            : `Plattformkode: ${quay.id}`
         return (
             <PlatformAndLines
                 key={quay.id}
@@ -265,7 +265,8 @@ export function SetVisibleLines({
                 quayId={quay.id}
                 groupKey={quay.publicCode || quay.id}
                 title={title}
-                description={description}
+                description={quay.description}
+                quayCodeTooltip={quayCodeTooltip}
                 lines={quay.lines}
                 trackingLocation={trackingLocation}
                 fallbackTransportModes={quayModes}


### PR DESCRIPTION
### 🥅 Bakgrunn

- Ønske fra fylkesoperatør (FRAM) at kaier uten public code skulle ha eget kjennetegn (quay-id) slik at det blir lettere å filtrere på linjer og plattformer


### ✨ Løsning

- Legge til quay-id for plattformer uten public code

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
|<img width="1221" height="385" alt="Screenshot 2026-07-14 at 12 47 48" src="https://github.com/user-attachments/assets/a8be5da4-2fc4-4fdb-8bfd-bf58cbfb3849" /> | <img width="1018" height="329" alt="Screenshot 2026-08-10 at 14 01 00" src="https://github.com/user-attachments/assets/375add0d-187d-46d1-a9e6-80c72375b015" /> |



### ✅ Sjekkliste

- [x] Testet i Chrome


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
