### PR TITLE
✨ Legg til mulighet for å velge engelsk språk på tavla

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -23,6 +23,7 @@ import { getBoard, updateBoard } from 'src/firebase'
 import type {
     BoardDB,
     BoardFontSize,
+    BoardLanguage,
     BoardTheme,
     LocationDB,
     TransportPalette,
@@ -46,6 +47,7 @@ export async function saveSettings(data: FormData) {
 
     const hideClock = data.get('clock') === null
     const hideLogo = data.get('logo') === null
+    const language: BoardLanguage = data.get('language') === null ? 'nb' : 'en'
 
     const locationRaw = data.get('newLocation') as string
     const location: LocationDB | undefined = locationRaw
@@ -102,6 +104,7 @@ export async function saveSettings(data: FormData) {
             tiles,
             hideClock,
             hideLogo,
+            language,
         })
 
         revalidatePath(`/tavler/${bid}/rediger`)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/Settings/actions.ts
@@ -44,10 +44,10 @@ export async function saveSettings(data: FormData) {
     const theme = data.get('theme') as BoardTheme
     const font = data.get('font') as BoardFontSize
     const transportPalette = data.get('transportPalette') as TransportPalette
+    const language = data.get('language') as BoardLanguage
 
     const hideClock = data.get('clock') === null
     const hideLogo = data.get('logo') === null
-    const language: BoardLanguage = data.get('language') === null ? 'nb' : 'en'
 
     const locationRaw = data.get('newLocation') as string
     const location: LocationDB | undefined = locationRaw
@@ -104,7 +104,7 @@ export async function saveSettings(data: FormData) {
             tiles,
             hideClock,
             hideLogo,
-            language,
+            language: language ?? 'nb',
         })
 
         revalidatePath(`/tavler/${bid}/rediger`)

--- a/tavla/app/_components/TableSettings/ChoiceChipGroupGeneral.tsx
+++ b/tavla/app/_components/TableSettings/ChoiceChipGroupGeneral.tsx
@@ -9,10 +9,10 @@ type ChoiceChipProps<T> = {
     defaultValue: T
     name: string
     ariaLabel: string
-    onChange: (value: string) => void
+    onChange: (value: T) => void
 }
 
-function ChoiceChipGroupGeneral<T extends string>({
+export function ChoiceChipGroupGeneral<T extends string>({
     label,
     options,
     defaultValue,
@@ -46,5 +46,3 @@ function ChoiceChipGroupGeneral<T extends string>({
         </div>
     )
 }
-
-export { ChoiceChipGroupGeneral }

--- a/tavla/app/_components/TableSettings/ElementsSelect.tsx
+++ b/tavla/app/_components/TableSettings/ElementsSelect.tsx
@@ -4,7 +4,7 @@ import { FilterChip } from '@entur/chip'
 import { Heading4, Paragraph } from '@entur/typography'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 
-export type Elements = 'clock' | 'logo' | 'language'
+export type Elements = 'clock' | 'logo'
 
 function ElementSelect({
     selectedElements = [],
@@ -49,20 +49,6 @@ function ElementSelect({
                     defaultChecked={selectedElements.includes('logo')}
                 >
                     Logo
-                </FilterChip>
-                <FilterChip
-                    name="language"
-                    value="en"
-                    onChange={() => {
-                        capture('board_settings_changed', {
-                            setting: 'element_select',
-                            value: 'language',
-                        })
-                        onChange()
-                    }}
-                    defaultChecked={selectedElements.includes('language')}
-                >
-                    Engelsk
                 </FilterChip>
             </div>
         </div>

--- a/tavla/app/_components/TableSettings/ElementsSelect.tsx
+++ b/tavla/app/_components/TableSettings/ElementsSelect.tsx
@@ -4,7 +4,7 @@ import { FilterChip } from '@entur/chip'
 import { Heading4, Paragraph } from '@entur/typography'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 
-export type Elements = 'clock' | 'logo'
+export type Elements = 'clock' | 'logo' | 'language'
 
 function ElementSelect({
     selectedElements = [],
@@ -49,6 +49,20 @@ function ElementSelect({
                     defaultChecked={selectedElements.includes('logo')}
                 >
                     Logo
+                </FilterChip>
+                <FilterChip
+                    name="language"
+                    value="en"
+                    onChange={() => {
+                        capture('board_settings_changed', {
+                            setting: 'element_select',
+                            value: 'language',
+                        })
+                        onChange()
+                    }}
+                    defaultChecked={selectedElements.includes('language')}
+                >
+                    Engelsk
                 </FilterChip>
             </div>
         </div>

--- a/tavla/app/_components/TableSettings/FontSelect.tsx
+++ b/tavla/app/_components/TableSettings/FontSelect.tsx
@@ -3,7 +3,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import type { BoardFontSize } from 'types/db-types/boards'
 import { ChoiceChipGroupGeneral } from './ChoiceChipGroupGeneral'
 
-function FontSelect({
+export function FontSelect({
     font = 'medium',
     onChange,
 }: {
@@ -26,12 +26,10 @@ function FontSelect({
             onChange={(value) => {
                 capture('board_settings_changed', {
                     setting: 'font',
-                    value: value as 'small' | 'medium' | 'large',
+                    value,
                 })
                 onChange()
             }}
         />
     )
 }
-
-export { FontSelect }

--- a/tavla/app/_components/TableSettings/LanguageSelect.tsx
+++ b/tavla/app/_components/TableSettings/LanguageSelect.tsx
@@ -3,7 +3,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import type { BoardLanguage } from 'types/db-types/boards'
 import { ChoiceChipGroupGeneral } from './ChoiceChipGroupGeneral'
 
-function LanguageSelect({
+export function LanguageSelect({
     language = 'nb',
     onChange,
 }: {
@@ -23,7 +23,7 @@ function LanguageSelect({
             onChange={(value) => {
                 capture('board_settings_changed', {
                     setting: 'language',
-                    value: value as BoardLanguage,
+                    value,
                 })
 
                 onChange()
@@ -33,5 +33,3 @@ function LanguageSelect({
         />
     )
 }
-
-export { LanguageSelect }

--- a/tavla/app/_components/TableSettings/LanguageSelect.tsx
+++ b/tavla/app/_components/TableSettings/LanguageSelect.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
+import type { BoardLanguage } from 'types/db-types/boards'
+import { ChoiceChipGroupGeneral } from './ChoiceChipGroupGeneral'
+
+function LanguageSelect({
+    language = 'nb',
+    onChange,
+}: {
+    language?: BoardLanguage
+    onChange: () => void
+}) {
+    const { capture } = usePosthogTracking()
+
+    return (
+        <ChoiceChipGroupGeneral<BoardLanguage>
+            label="Velg språk"
+            options={[
+                { value: 'nb', label: 'Norsk' },
+                { value: 'en', label: 'Engelsk' },
+            ]}
+            defaultValue={language}
+            onChange={(value) => {
+                capture('board_settings_changed', {
+                    setting: 'language',
+                    value: value as BoardLanguage,
+                })
+
+                onChange()
+            }}
+            name="language"
+            ariaLabel="Språk"
+        />
+    )
+}
+
+export { LanguageSelect }

--- a/tavla/app/_components/TableSettings/SettingsForm.tsx
+++ b/tavla/app/_components/TableSettings/SettingsForm.tsx
@@ -7,6 +7,7 @@ import type { BoardDB } from 'types/db-types/boards'
 import { ElementSelect, type Elements } from './ElementsSelect'
 import { FontSelect } from './FontSelect'
 import { InfoMessage } from './InfoMessage'
+import { LanguageSelect } from './LanguageSelect'
 import { ThemeSelect } from './ThemeSelect'
 import { Title } from './Title'
 import { TransportPaletteSelect } from './TransportPaletteSelect'
@@ -17,7 +18,6 @@ const getSelectedElements = (board: BoardDB): Elements[] => {
     const elements: Elements[] = []
     if (!board.hideClock) elements.push('clock')
     if (!board.hideLogo) elements.push('logo')
-    if (board.language === 'en') elements.push('language')
     return elements
 }
 
@@ -92,6 +92,10 @@ function SettingsForm({
                         />
                         <ElementSelect
                             selectedElements={getSelectedElements(board)}
+                            onChange={handleChange}
+                        />
+                        <LanguageSelect
+                            language={board.language}
                             onChange={handleChange}
                         />
                     </div>

--- a/tavla/app/_components/TableSettings/SettingsForm.tsx
+++ b/tavla/app/_components/TableSettings/SettingsForm.tsx
@@ -17,6 +17,7 @@ const getSelectedElements = (board: BoardDB): Elements[] => {
     const elements: Elements[] = []
     if (!board.hideClock) elements.push('clock')
     if (!board.hideLogo) elements.push('logo')
+    if (board.language === 'en') elements.push('language')
     return elements
 }
 

--- a/tavla/app/_components/TableSettings/ThemeSelect.tsx
+++ b/tavla/app/_components/TableSettings/ThemeSelect.tsx
@@ -3,7 +3,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import type { BoardTheme } from 'types/db-types/boards'
 import { ChoiceChipGroupGeneral } from './ChoiceChipGroupGeneral'
 
-function ThemeSelect({
+export function ThemeSelect({
     theme = 'dark',
     onChange,
 }: {
@@ -23,7 +23,7 @@ function ThemeSelect({
             onChange={(value) => {
                 capture('board_settings_changed', {
                     setting: 'theme',
-                    value: value as 'light' | 'dark',
+                    value,
                 })
 
                 onChange()
@@ -33,5 +33,3 @@ function ThemeSelect({
         />
     )
 }
-
-export { ThemeSelect }

--- a/tavla/app/_hooks/useSaveBoardInLocalStorage.ts
+++ b/tavla/app/_hooks/useSaveBoardInLocalStorage.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import type {
     BoardDB,
     BoardFontSize,
+    BoardLanguage,
     BoardTheme,
     LocationDB,
     TransportPalette,
@@ -51,6 +52,7 @@ export function useSaveBoardInLocalStorage(): {
             const transportPalette = data.get(
                 'transportPalette',
             ) as TransportPalette
+            const language = data.get('language') as BoardLanguage
             const hideClock = data.get('clock') === null
             const hideLogo = data.get('logo') === null
             const footer = data.get('infoMessage') as string
@@ -78,6 +80,7 @@ export function useSaveBoardInLocalStorage(): {
                 },
                 theme: theme ?? 'dark',
                 transportPalette: transportPalette ?? 'default',
+                language: language ?? 'nb',
                 hideClock,
                 hideLogo,
                 footer: footerHasText ? { footer } : undefined,

--- a/tavla/app/posthog/events.ts
+++ b/tavla/app/posthog/events.ts
@@ -298,6 +298,7 @@ export type EventMap = {
             | 'changed'
             | 'clock'
             | 'logo'
+            | 'language'
     }
 
     /* FAQ */

--- a/tavla/app/posthog/events.ts
+++ b/tavla/app/posthog/events.ts
@@ -281,6 +281,7 @@ export type EventMap = {
             | 'board_location'
             | 'info_message'
             | 'element_select'
+            | 'language'
         value:
             | 'combined'
             | 'separate'
@@ -298,7 +299,8 @@ export type EventMap = {
             | 'changed'
             | 'clock'
             | 'logo'
-            | 'language'
+            | 'nb'
+            | 'en'
     }
 
     /* FAQ */

--- a/tavla/migrations/scripts/018_set_default_language.py
+++ b/tavla/migrations/scripts/018_set_default_language.py
@@ -1,0 +1,167 @@
+"""
+Purpose: Sett language = "nb" på boards som mangler feltet
+
+Description:
+    Itererer gjennom alle boards og setter language til "nb" (norsk bokmål)
+    på boards der feltet ikke eksisterer. Boards som allerede har feltet
+    (uavhengig av verdi) hoppes over.
+
+    "nb" er riktig default siden alle boards frem til nå har vært norske,
+    og er samme verdi som saveSettings-handlingen i tavla-admin faller
+    tilbake til når "language" ikke er satt i skjemaet.
+
+Usage:
+    ./migration run scripts/018_set_default_language.py
+
+Date: 2026-07-14
+Author: Maiken
+"""
+
+import time
+
+import init
+from google.cloud import firestore
+
+COLLECTION = "boards"
+FIELD = "language"
+DEFAULT_VALUE = "nb"
+
+
+def board_is_missing_field(data: dict) -> bool:
+    return FIELD not in data
+
+
+def scan_missing(db: firestore.Client) -> dict:
+    """
+    Les gjennom alle boards og tell hvor mange som mangler language.
+    Returnerer:
+        {
+            "total_boards": int,
+            "missing_boards": int,
+        }
+    """
+    total_boards = 0
+    missing_boards = 0
+
+    for doc_snap in stream_in_batches(db.collection(COLLECTION)):
+        total_boards += 1
+        data = doc_snap.to_dict()
+        if board_is_missing_field(data):
+            missing_boards += 1
+
+    return {
+        "total_boards": total_boards,
+        "missing_boards": missing_boards,
+    }
+
+
+def print_scan_summary(label: str, scan: dict):
+    print(f"\n📊 Status {label} migrering:")
+    print(f"   Totalt boards skannet  : {scan['total_boards']}")
+    print(f"   Boards uten language   : {scan['missing_boards']}")
+    if scan["missing_boards"] == 0:
+        print("   ✅ Ingen boards mangler feltet\n")
+    else:
+        print()
+
+
+@firestore.transactional
+def migrate_board(transaction, board_ref, log_file):
+    snapshot = board_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        log_file.write(f"☠️ Board finnes ikke: {board_ref.id}\n")
+        return False
+
+    data = snapshot.to_dict()
+
+    if not board_is_missing_field(data):
+        return None  # None = ingen endring nødvendig
+
+    transaction.update(board_ref, {FIELD: DEFAULT_VALUE})
+    log_file.write(f"✅ {board_ref.id}: language satt til {DEFAULT_VALUE}\n")
+    return True
+
+
+def stream_in_batches(collection_ref, batch_size=500):
+    """Generator that yields all documents in batches to avoid Firestore timeouts."""
+    last_doc = None
+    while True:
+        query = collection_ref.order_by("__name__").limit(batch_size)
+        if last_doc:
+            query = query.start_after(last_doc)
+        docs = list(query.stream())
+        if not docs:
+            break
+        yield from docs
+        last_doc = docs[-1]
+        print(f"📦 Prosesserte batch til dokument: {last_doc.id}")
+        time.sleep(1)
+
+
+def migrate_all(db: firestore.Client):
+    collection_ref = db.collection(COLLECTION)
+    success_count = 0
+    skip_count = 0
+    fail_count = 0
+    total_count = 0
+
+    log_filename = "migration_018_log.txt"
+
+    with open(log_filename, "a", encoding="utf-8") as log_file:
+        for i, doc_snap in enumerate(stream_in_batches(collection_ref)):
+            total_count += 1
+            board_id = doc_snap.id
+            log_file.write(f"\n-----> 🏁 Board: {board_id}\n")
+
+            try:
+                board_ref = db.collection(COLLECTION).document(board_id)
+                transaction = db.transaction()
+                result = migrate_board(transaction, board_ref, log_file)
+
+                if result is True:
+                    success_count += 1
+                elif result is None:
+                    skip_count += 1
+                    log_file.write("⏭️ language allerede definert, hopper over\n")
+                else:
+                    fail_count += 1
+
+            except Exception as e:
+                fail_count += 1
+                log_file.write(f"❌ Feil ved oppdatering av {board_id}: {str(e)}\n")
+
+            if i % 15 == 0 and i != 0:
+                log_file.flush()
+
+            if i % 100 == 0 and i != 0:
+                log_file.write(f"\n😴 Puster etter {i} dokumenter...\n\n")
+                time.sleep(1)
+
+        log_file.write(
+            f"\n🎉 Ferdig: {success_count} oppdatert, {skip_count} hoppet over, "
+            f"{fail_count} feilet, {total_count} totalt 🎉\n"
+        )
+        print(f"Migrering fullført. Se {log_filename} for detaljer.")
+
+
+def run():
+    db = init.dev()  # Bytt til init.prod() når klar for prod
+    print(f"Tilkoblet prosjekt: {db.project}")
+
+    print("\n🔍 Scanner databasen før migrering...")
+    before = scan_missing(db)
+    print_scan_summary("FØR", before)
+
+    if before["missing_boards"] == 0:
+        print("Ingen boards mangler language — migrering ikke nødvendig.")
+        return
+
+    migrate_all(db)
+
+    print("\n🔍 Scanner databasen etter migrering...")
+    after = scan_missing(db)
+    print_scan_summary("ETTER", after)
+
+
+if __name__ == "__main__":
+    run()

--- a/tavla/migrations/scripts/018_set_default_language.py
+++ b/tavla/migrations/scripts/018_set_default_language.py
@@ -145,9 +145,8 @@ def migrate_all(db: firestore.Client):
 
 
 def run():
-    db = init.dev()  # Bytt til init.prod() når klar for prod
+    db = init.prod() 
     print(f"Tilkoblet prosjekt: {db.project}")
-
     print("\n🔍 Scanner databasen før migrering...")
     before = scan_missing(db)
     print_scan_summary("FØR", before)

--- a/tavla/src/types/db-types/boards.ts
+++ b/tavla/src/types/db-types/boards.ts
@@ -96,6 +96,8 @@ const boardMetaSchema = z.object({
 
 const boardThemeSchema = z.enum(['dark', 'light'])
 
+const boardLanguageSchema = z.enum(['nb', 'en'])
+
 const boardFooterSchema = z.object({
     footer: z.string().optional(),
 })
@@ -122,6 +124,7 @@ export const BoardDBSchema = z.object({
     customUrl: z.string().optional(),
     isAnonymousBoard: z.boolean().optional(),
     isArrivals: z.boolean().optional(),
+    language: boardLanguageSchema.optional(),
 })
 
 export type BoardDB = z.infer<typeof BoardDBSchema>
@@ -129,6 +132,8 @@ export type BoardDB = z.infer<typeof BoardDBSchema>
 export type BoardFooter = z.infer<typeof boardFooterSchema>
 
 export type BoardTheme = z.infer<typeof boardThemeSchema>
+
+export type BoardLanguage = z.infer<typeof boardLanguageSchema>
 
 export type TransportPalette = z.infer<typeof transportPaletteSchema>
 


### PR DESCRIPTION
### 🥅 Bakgrunn

- Tilgjengeliggjøre norsk kollektivtransport for turister fra utlandet på tavla!

### ✨ Løsning

- Legge til engelsk badge under "Vis Elementer" på innstillinger
- Lagt til language-felt ('nb'/'en') i BoardDB-skjemaet, og lagring av valgt språk via innstillingene
- Migrasjonsscript 'migrations/scripts/018_set_default_language.py' som setter language: "nb" på eksisterende boards som mangler feltet.


### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="697" height="610" alt="Screenshot 2026-07-16 at 13 53 20" src="https://github.com/user-attachments/assets/e4569896-7e1e-413e-97b0-c88efa2f6a68" /> | <img width="526" height="471" alt="Screenshot 2026-08-05 at 10 32 46" src="https://github.com/user-attachments/assets/36f72a3a-52e3-4085-8cf4-2ba1bef0c355" />
 |

| Script kjørt på lokal database (kopi av dev)   | 
| ----- | 
| <img width="400" alt="Screenshot 2026-07-16 at 13 33 15" src="https://github.com/user-attachments/assets/d2dc6407-5317-4834-92ed-3c464a559893" /> |


### ✅ Sjekkliste

- [ ] Testet i Chrome




