### PR TITLE
💄Fikse responsivitet på mobil

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
@@ -100,7 +100,7 @@ function CustomUrl({
                         <Paragraph margin="none">
                             <b>Original lenke:</b>
                         </Paragraph>
-                        <Paragraph className="whitespace-nowrap">
+                        <Paragraph className="break-all">
                             {baseUrl}/{bid}
                         </Paragraph>
                         <Paragraph margin="none">
@@ -109,7 +109,7 @@ function CustomUrl({
                         <div className="font-mono rounded-lg p-1 flex flex-row items-center">
                             <Paragraph
                                 margin="none"
-                                className="whitespace-nowrap select-none"
+                                className="shrink-0 select-none"
                             >
                                 {baseUrl}/
                             </Paragraph>

--- a/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/page.tsx
@@ -106,7 +106,7 @@ export default async function EditPage(props: TProps) {
                     <div className="flex items-center gap-2">
                         <Paragraph
                             margin="none"
-                            className="border rounded px-2 py-1 font-mono bg-tintLight"
+                            className="border rounded px-2 py-1 font-mono bg-tintLight break-all"
                         >
                             {boardLink}
                         </Paragraph>

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -211,11 +211,11 @@ export function TileCard({
             <TileContext.Provider value={tile}>
                 <div className="flex flex-row">
                     <div
-                        className={`flex w-full flex-col gap-2 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between ${
+                        className={`flex w-full min-w-0 flex-col gap-2 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between ${
                             isOpen ? 'rounded-t' : 'rounded'
                         }`}
                     >
-                        <div className="flex flex-row items-center gap-4">
+                        <div className="flex min-w-0 flex-row items-center gap-4">
                             <Heading3
                                 margin="none"
                                 className="break-words min-w-0"

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -211,12 +211,15 @@ export function TileCard({
             <TileContext.Provider value={tile}>
                 <div className="flex flex-row">
                     <div
-                        className={`flex w-full items-center justify-between bg-white px-6 py-4 ${
+                        className={`flex w-full flex-col gap-2 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between ${
                             isOpen ? 'rounded-t' : 'rounded'
                         }`}
                     >
                         <div className="flex flex-row items-center gap-4">
-                            <Heading3 margin="none">
+                            <Heading3
+                                margin="none"
+                                className="break-words min-w-0"
+                            >
                                 {tile.displayName ?? tile.name}
                             </Heading3>
                             <section

--- a/tavla/app/_components/TileSelector/TileSelector.tsx
+++ b/tavla/app/_components/TileSelector/TileSelector.tsx
@@ -182,7 +182,7 @@ function TileSelector({
                 <SearchableDropdown
                     noMatchesText="Ingen stoppesteder funnet"
                     items={searchStopPlaces}
-                    label="Stoppested, adresse eller sted*"
+                    label="Stoppested eller adresse*"
                     clearable
                     prepend={<SearchIcon aria-hidden />}
                     selectedItem={selectedStopPlace}


### PR DESCRIPTION
### 🥅 Bakgrunn


### ✨ Løsning

- Små fixes på stylingen så teksten ikke går utenfor bredden på skjermen på mobil

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="424" height="863" alt="image" src="https://github.com/user-attachments/assets/9446ec16-f259-4193-9b34-3e7a545ce722" /> | <img width="408" height="838" alt="Skjermbilde 2026-07-22 kl  15 27 44" src="https://github.com/user-attachments/assets/6a72fda8-3941-467e-ae09-094e798966a7" /> |




### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
