### PR TITLE
🔒 Dedupliser dompurify til 3.4.13

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -101,6 +101,6 @@
         "tar": "7.5.11",
         "immutable": "3.8.3",
         "protobufjs": "7.6.3",
-        "dompurify": "3.4.12"
+        "dompurify": "3.4.13"
     }
 }

--- a/tavla/package.json
+++ b/tavla/package.json
@@ -100,6 +100,7 @@
         "minimatch": "9.0.7",
         "tar": "7.5.11",
         "immutable": "3.8.3",
-        "protobufjs": "7.6.3"
+        "protobufjs": "7.6.3",
+        "dompurify": "3.4.12"
     }
 }

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -6745,18 +6745,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "dompurify@npm:3.3.2"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10/3ca02559677ce6d9583a500f21ffbb6b9e88f1af99f69fa0d0d9442cddbac98810588c869f8b435addb5115492d6e49870024bca322169b941bafedb99c7f281
-  languageName: node
-  linkType: hard
-
 "dot-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "dot-case@npm:3.0.4"


### PR DESCRIPTION
### 🥅 Bakgrunn

`posthog-js` krever `dompurify@^3.3.2`, som gjorde at yarn løste en egen, gammel og sårbar dompurify-kopi i tillegg til vår direkte `3.4.13`-avhengighet. Flere åpne Dependabot-sikkerhetsvarsler (sanitizer-bypass-varianter) pekte mot denne separate 3.3.2-kopien, ikke mot vår egen oppdaterte versjon.

### ✨ Løsning

- Legger `dompurify: "3.4.13"` til i `resolutions`-blokken i `tavla/package.json`, slik at alle forbrukere (inkludert posthog-js) tvinges til samme, oppdaterte versjon

Dette lukker de gjenværende åpne dompurify-alertene som skyldtes den doble kopien. Ett varsel (GHSA-x4vx-rjvf-j5p4) har ingen patchet versjon publisert av DOMPurify ennå og forblir åpent uavhengig av denne endringen.

### ✅ Sjekkliste

- [x] Testet i Chrome