### PR TITLE
📝 Oppdaterer database.md til å veilede ved feilmelding

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -163,6 +163,11 @@ Ved behov for en sikkerhetskopi, for eksempel før en større migrering eller en
 ./migration run scripts/backup_firebase.py prod
 ```
 
+> NB! Sett riktig aktivt prosjekt før du kjører backupen dersom du får feilmelding:
+> ```bash
+> gcloud config set project ent-tavla-prd  
+> ```
+
 For **dev**:
 
 ```bash


### PR DESCRIPTION
### 🥅 Bakgrunn

- Når man skal skrive til prod-databasen kan det dukke opp en feilmelding om at man ikke har tilgang til prosjektet i firestore: 

```shell
ERROR: (gcloud.firestore.export) PERMISSION_DENIED: Service account does not have access to Google Cloud Storage file: /tavla-firestore-backups-prd. See https://cloud.google.com/datastore/docs/export-import-entities/#permissions for a list of permissions needed. This command is authenticated as [maiken.lie@entur.org](mailto:maiken.lie@entur.org) which is the active account specified by the [core/account] property.
:x: Backup command failed: None
```  



### ✨ Løsning

- Legger til en setning i database.md om hvilken kommando man kan kjøre for å "sette" riktig prosjekt


### ✅ Sjekkliste
- [x] Oppdatert dokumentasjon (hvis relevant)

