### PR TITLE
🐛 Utvid avgangsvinduet i linjevelgeren

### DIFF
--- a/docs/EXPLORER_LINKS.md
+++ b/docs/EXPLORER_LINKS.md
@@ -181,7 +181,7 @@ Alle spørringene Tavla bruker mot [Journey Planner v3](https://api.entur.io/jou
 
 **Kildefil:** [`tavla/src/graphql/queries/quayEstimatedCalls.graphql`](../tavla/src/graphql/queries/quayEstimatedCalls.graphql)
 
-**Beskrivelse:** Henter alle estimerte avganger eller ankomster for en perrong i løpet av én uke. Brukes til å bygge linje-/destinasjonsfiltre. Med `arrivalDeparture`-variabelen (`departures` som standard, eller `arrivals`) kan man hente linjer basert på ankomster i stedet for avganger — brukes for ankomsttavler.
+**Beskrivelse:** Henter estimerte avganger eller ankomster for en perrong innenfor et fast tidsvindu på 30 dager. Brukes til å bygge linje-/destinasjonsfiltre. `numberOfDepartures` er et tak på rå avganger hentet før `numberOfDeparturesPerLineAndDestinationDisplay` deduplikerer, og avgjør derfor i praksis hvor langt fram i tid spørringen rekker. Med `arrivalDeparture`-variabelen (`departures` som standard, eller `arrivals`) kan man hente linjer basert på ankomster i stedet for avganger — brukes for ankomsttavler.
 
 **Fragmenter:** ingen
 
@@ -189,12 +189,11 @@ Alle spørringene Tavla bruker mot [Journey Planner v3](https://api.entur.io/jou
 ```json
 {
   "quayId": "NSR:Quay:107371",
-  "numberOfDepartures": 200,
   "arrivalDeparture": "departures"
 }
 ```
 
-**[Åpne i GraphQL Explorer](https://api.entur.io/graphql-explorer/journey-planner-v3?query=query%20QuayEstimatedCalls%28%0A%20%20%20%20%24quayId%3A%20String%21%0A%20%20%20%20%24numberOfDepartures%3A%20Int%20%3D%20200%0A%20%20%20%20%24arrivalDeparture%3A%20ArrivalDeparture%20%3D%20departures%0A%29%20%7B%0A%20%20%20%20quay%28id%3A%20%24quayId%29%20%7B%0A%20%20%20%20%20%20%20%20estimatedCalls%28%0A%20%20%20%20%20%20%20%20%20%20%20%20numberOfDepartures%3A%20%24numberOfDepartures%0A%20%20%20%20%20%20%20%20%20%20%20%20numberOfDeparturesPerLineAndDestinationDisplay%3A%201%0A%20%20%20%20%20%20%20%20%20%20%20%20timeRange%3A%20604800%0A%20%20%20%20%20%20%20%20%20%20%20%20includeCancelledTrips%3A%20true%0A%20%20%20%20%20%20%20%20%20%20%20%20arrivalDeparture%3A%20%24arrivalDeparture%0A%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20destinationDisplay%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20frontText%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20serviceJourney%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D&operationName=QuayEstimatedCalls&variables=%7B%22quayId%22%3A%22NSR%3AQuay%3A107371%22%2C%22numberOfDepartures%22%3A200%2C%22arrivalDeparture%22%3A%22departures%22%7D)**
+**[Åpne i GraphQL Explorer](https://api.entur.io/graphql-explorer/journey-planner-v3?query=query%20QuayEstimatedCalls%28%0A%20%20%20%20%24quayId%3A%20String%21%0A%20%20%20%20%24arrivalDeparture%3A%20ArrivalDeparture%20%3D%20departures%0A%29%20%7B%0A%20%20%20%20quay%28id%3A%20%24quayId%29%20%7B%0A%20%20%20%20%20%20%20%20estimatedCalls%28%0A%20%20%20%20%20%20%20%20%20%20%20%20numberOfDepartures%3A%201000%0A%20%20%20%20%20%20%20%20%20%20%20%20numberOfDeparturesPerLineAndDestinationDisplay%3A%201%0A%20%20%20%20%20%20%20%20%20%20%20%20timeRange%3A%202592000%0A%20%20%20%20%20%20%20%20%20%20%20%20includeCancelledTrips%3A%20true%0A%20%20%20%20%20%20%20%20%20%20%20%20arrivalDeparture%3A%20%24arrivalDeparture%0A%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20destinationDisplay%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20frontText%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20serviceJourney%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D&operationName=QuayEstimatedCalls&variables=%7B%22quayId%22%3A%22NSR%3AQuay%3A107371%22%2C%22arrivalDeparture%22%3A%22departures%22%7D)**
 
 ---
 

--- a/tavla/src/graphql/index.ts
+++ b/tavla/src/graphql/index.ts
@@ -210,12 +210,12 @@ export const QuayEditQuery = new TypedDocumentString(`
   }
 }`) as unknown as TypedDocumentString<Types.TQuayEditQuery, Types.TQuayEditQueryVariables>;
 export const QuayEstimatedCallsQuery = new TypedDocumentString(`
-    query QuayEstimatedCalls($quayId: String!, $numberOfDepartures: Int = 200, $arrivalDeparture: ArrivalDeparture = departures) {
+    query QuayEstimatedCalls($quayId: String!, $arrivalDeparture: ArrivalDeparture = departures) {
   quay(id: $quayId) {
     estimatedCalls(
-      numberOfDepartures: $numberOfDepartures
+      numberOfDepartures: 1000
       numberOfDeparturesPerLineAndDestinationDisplay: 1
-      timeRange: 604800
+      timeRange: 2592000
       includeCancelledTrips: true
       arrivalDeparture: $arrivalDeparture
     ) {

--- a/tavla/src/graphql/queries/quayEstimatedCalls.graphql
+++ b/tavla/src/graphql/queries/quayEstimatedCalls.graphql
@@ -1,13 +1,12 @@
 query QuayEstimatedCalls(
     $quayId: String!
-    $numberOfDepartures: Int = 200
     $arrivalDeparture: ArrivalDeparture = departures
 ) {
     quay(id: $quayId) {
         estimatedCalls(
-            numberOfDepartures: $numberOfDepartures
+            numberOfDepartures: 1000
             numberOfDeparturesPerLineAndDestinationDisplay: 1
-            timeRange: 604800
+            timeRange: 2592000
             includeCancelledTrips: true
             arrivalDeparture: $arrivalDeparture
         ) {

--- a/tavla/src/types/operations.ts
+++ b/tavla/src/types/operations.ts
@@ -344,7 +344,6 @@ export type TQuayEditQuery = {
 
 export type TQuayEstimatedCallsQueryVariables = Exact<{
     quayId: string
-    numberOfDepartures?: number | null | undefined
     arrivalDeparture?: Types.TArrivalDeparture | null | undefined
 }>
 


### PR DESCRIPTION
### 🥅 Bakgrunn

Linjevelgeren i tile-redigering hentet for få avganger til å se alle linjer og retninger som faktisk betjener en plattform.

Årsaken er at `numberOfDepartures` er et tak på **rå** avganger hentet *før* `numberOfDeparturesPerLineAndDestinationDisplay` deduplikerer. Det er derfor den, ikke `timeRange`, som i praksis avgjør hvor langt fram i tid spørringen rekker. Med `numberOfDepartures: 200` rakk spørringen bare ~1,8 døgn på travle plattformer — godt innenfor det gamle 7-dagersvinduet, som dermed aldri ble nådd.

Konsekvensen er at linjer og retninger som ikke rakk å bli observert ved lagring, aldri havner i `linesWithDirection`. Siden visningen filtrerer på `(lineId, frontText)`, blir reelle avganger da filtrert bort fra tavla. Det er en stillegående feil der passasjerer mister avganger.

Dette kom fram under undersøkelsen av en supportsak om Trondheim S, der en tile viste nabo-plattformens avganger.

### ✨ Løsning

- Hev `numberOfDepartures` fra 200 til 1000
- Utvid `timeRange` fra 7 til 30 dager (604800 → 2592000)
- Inline begge verdiene framfor å eksponere dem som variabler, siden det ikke sendes inn ulike verdier for dem
- Regenerer GraphQL-typer og `docs/EXPLORER_LINKS.md`

**Målinger som ligger bak verdiene:**

| Stoppested | Endring | Effekt |
| --- | --- | --- |
| Trondheim S pl. 11 (`NSR:Quay:71412`) | `n` 200 → 1000 | +3 linjer, +16 (linje, frontText)-par. `timeRange` var uvirksom. |
| Oslo S (35 quays) | `timeRange` 7d → 30d | +8 linjer, +18 par. Taket bandt ikke her. |

Begge parameterne binder altså, avhengig av trafikktetthet per quay — derfor er begge hevet.

Veggtid er uendret: ~0,5s for 35 samtidige kall både før og etter, siden dedupliseringen holder responsen liten uansett. Målt også på `n=2000`, som bare ga 2 par ekstra — gevinsten flater ut rundt 1000.

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="703" height="495" alt="image" src="https://github.com/user-attachments/assets/12fed339-1db7-4cd9-8e63-b53e21113713" /> | <img width="697" height="548" alt="image" src="https://github.com/user-attachments/assets/736b4f4d-a227-4121-9958-86301e6bc3b6" /> |
|<img width="696" height="601" alt="image" src="https://github.com/user-attachments/assets/9aec4cf6-5a99-4076-9f00-14c5159157e8" />|<img width="694" height="799" alt="image" src="https://github.com/user-attachments/assets/b28188b3-89c1-4a40-bf0d-d72e5b464299" />|
|<img width="703" height="637" alt="image" src="https://github.com/user-attachments/assets/0325e8ad-1c29-44a9-8020-a4e320c56565" />|<img width="695" height="638" alt="image" src="https://github.com/user-attachments/assets/1bf2a2c0-7efb-4b19-81e8-7d9e5d05c45e" />|

### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)

---

**Til reviewer:** Endringen påvirker kun nye lagringer — eksisterende `linesWithDirection` er urørt til en tile lagres på nytt. `numberOfDepartures` kan ikke bare fjernes; schema-defaulten er 5, som gir ~12 minutters horisont.
