### PR TITLE
🔒 Fjern tar-pinnen så Dependabot kan vedlikeholde den igjen

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -98,7 +98,6 @@
     "resolutions": {
         "basic-ftp": "5.3.1",
         "minimatch": "9.0.7",
-        "tar": "7.5.11",
         "immutable": "3.8.3",
         "protobufjs": "7.6.3",
         "dompurify": "3.4.13"

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -12859,16 +12859,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.11":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:^7.5.11, tar@npm:^7.5.4":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/fb2e77ee858a73936c68e066f4a602d428d6f812e6da0cc1e14a41f99498e4f7fd3535e355fa15157240a5538aa416026cfa6306bb0d1d1c1abf314b1f878e9a
+  checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🥅 Bakgrunn

`resolutions`-blokka i `tavla/package.json` har pinnet `tar` til `7.5.11` siden mars ([#2330](https://github.com/entur/tavla/pull/2330)). Pinnen var trygg da den ble satt, men det har siden kommet seks sikkerhetsvarsler mot nettopp den versjonen — og fordi en eksakt pin overstyrer alt, kan ikke Dependabot lage en PR for dem. Varslene har derfor bare ligget åpne i fem måneder.

Varslene som lukkes:

| Varsel | Alvorlighet | Sårbarhet | Fikset i |
| --- | --- | --- | --- |
| [#497](https://github.com/entur/tavla/security/dependabot/497) | 🔴 **Kritisk** | `CVE-2026-59873` — dekomprimerings-DoS via ubegrenset input. En liten «gzip-bombe» fyller disken og kveler CPU-en, fordi `node-tar` ikke håndhever en øvre grense på dekomprimert datamengde eller antall entries. | 7.5.19 |
| [#496](https://github.com/entur/tavla/security/dependabot/496) | 🟠 Høy | `CVE-2026-59874` — negativ entry-størrelse gir uendelig løkke i `replace`. | 7.5.18 |
| [#532](https://github.com/entur/tavla/security/dependabot/532) | 🟡 Moderat | Ukontrollert rekursjon i `mapHas`/`filesFilter` gir stack overflow som ikke kan fanges. | 7.5.21 |
| [#498](https://github.com/entur/tavla/security/dependabot/498) | 🟡 Moderat | `CVE-2026-59871` — prosesskrasj via type-forvirring på numeriske PAX-stier. | 7.5.18 |
| [#495](https://github.com/entur/tavla/security/dependabot/495) | 🟡 Moderat | `CVE-2026-59875` — ufanget exception via NUL-byte i PAX `path`/`linkpath`. | 7.5.16 |
| [#460](https://github.com/entur/tavla/security/dependabot/460) | 🟡 Moderat | `CVE-2026-53655` — PAX size-override på GNU long-name-headere gir tolkningsforskjell mellom parsere (file smuggling). | 7.5.16 |

`tar` er ikke en direkte avhengighet — den hentes transitivt inn av dev-verktøykjeden (blant annet `firebase-tools`, som bruker den til å pakke ut emulator-nedlastinger). Reell eksponering er derfor begrenset til utviklermaskiner og CI, ikke prod. Men alle seks fiksene ligger innenfor `7.5.x`, så det er ingen grunn til å la dem stå.

### ✨ Løsning

Fjerner `tar` fra `resolutions`



**Verifisert lokalt:** `yarn install --immutable` (lockfil konsistent), `yarn typecheck` (rent), `yarn test` (19/19) og `yarn build` (fullfører).


### ✅ Sjekkliste
- [ ] Testet i Chrome, Firefox og Safari
