### PR TITLE
📝 Rydder opp litt i readme og dokkumentasjon

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,10 @@
 Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all offentlig transport i Norge. Løsningen utvikles av Entur, og er helt gratis og tilgjengelig for alle. Logg inn på [tavla.entur.no](https://tavla.entur.no/) for å komme i gang! Abonner på oppdateringer til Tavla ved å klikke på “Watch” i menyen.
 
 > **Merk:** Dette repoet er admin-/konfigurasjonsappen der man oppretter og redigerer tavler. Selve tavle-visningen (det som vises på skjermene) rendres i et eget repo: [entur/tavla-visning](https://github.com/entur/tavla-visning).
-
-## Hva du kan gjøre
-
-- Lage skreddersydde tavler (velg stopp, rekkefølge, layout)
-- Få sanntidsoppdateringer (Redis pub/sub)
-- Se hvor mange tavler som er aktive
-- Autentisering og vedvarende data via Firebase (emulator lokalt)
-- Moderne og tilgjengelig grensesnitt (Entur designsystem)
+ 
 
 ## Struktur i repoet
+Dette repo består av tre tjenester: en backend i /backend, en frontend i /tavla og en liten redirect-tjeneste i /redirect. For lokal kjøring og oppsett, se i undermappene og deres egne readme-filer. 
 
 ```
 /
@@ -22,7 +16,7 @@ Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all off
 │  ├─ migrations/      Python-migrasjonsskript for Firestore
 │  └─ helm/            Deploy-konfigurasjon for frontend (Helm chart)
 ├─ redirect/           Liten Rust-tjeneste (redirect)
-├─ docs/               Dokumentasjon (database-skjema, GraphQL-lenker)
+├─ docs/               Dokumentasjon (database, GraphQL-lenker)
 └─ flake.nix           Valgfri Nix dev-miljøfil
 ```
 
@@ -35,15 +29,6 @@ Med «Tavla» kan du sette opp egne, spesialtilpassede avgangstavler for all off
 | Data/Auth | Firebase (emulator i utvikling)            |
 | Verktøy  | Yarn 4, GraphQL Codegen, Sentry            |
 
-## Oversikt: slik kjører du (høytnivå)
-
-1. Start Redis (master + replica) – se `backend/readme.md` for detaljer
-2. Start backend (`./run-local.sh`, eller `cargo run` med miljøvariabler satt)
-3. Start frontend (`yarn dev` eller `yarn dev:persist`)
-4. Sett `BACKEND_API_KEY` i frontend (`.env.local`)
-5. Test med `curl` mot backend
-
-Detaljer per delkomponent finnes i deres respektive README.
 
 ## Miljøvariabler (samlet oversikt)
 
@@ -69,7 +54,7 @@ Mappen [`docs/`](docs/) inneholder mer utfyllende dokumentasjon:
 - [`docs/graphql.md`](docs/graphql.md) – hvordan GraphQL og typegenerering (`graphql-codegen`) henger sammen: dataflyt, de tre genererte filene, og hvordan du legger til og bruker en spørring
 - [`docs/EXPLORER_LINKS.md`](docs/EXPLORER_LINKS.md) – alle GraphQL-spørringene mot Journey Planner v3, klare til å kjøres i GraphQL Explorer
 
-Se ellers `backend/readme.md` og `tavla/README.md` for komponentspesifikke detaljer.
+Se ellers `backend/readme.md` og `tavla/README.md`.
 
 ## Bidrag
 
@@ -87,15 +72,3 @@ Kode: EUPL-1.2 (se `LICENSE`)
 Fonter: Egen lisens (Nationale – https://playtype.com/typefaces/nationale/)
 Varemerker (logo, illustrasjoner, bilder): Kun for Entur.
 
-
-## Kort kom i gang (huskeliste)
-
-```
-redis (master + replica)
-cargo run (backend)
-yarn dev:persist (frontend)
-curl localhost:3001/active -H "Authorization: Bearer <key>"
-```
----
-
-Se mappene `backend/` og `tavla/` for mer detaljert informasjon.

--- a/tavla/README.md
+++ b/tavla/README.md
@@ -28,7 +28,7 @@ node -v
 # Skal vise v22.x
 ```
 
-### Kjøre i utvikling
+### Kjøre opp lokalt
 
 ```
 yarn dev          # uten persistering av lokal database
@@ -40,7 +40,9 @@ Tilgang:
 - App: http://localhost:3000
 - Firebase Emulator UI: http://127.0.0.1:4000/
 
-Dette repoet er admin-/konfigurasjonsappen. Selve tavle-visningen (det som rendres på skjermene) ligger i et eget repo. For å forhåndsvise tavler lokalt må du derfor også kjøre `tavla-visning`: https://github.com/entur/tavla-visning
+Dette repoet er admin-/konfigurasjonsappen. Selve tavle-visningen (det som rendres på skjermene) ligger i et eget repo. For å forhåndsvise tavler lokalt må du derfor også kjøre `tavla-visning`: https://github.com/entur/tavla-visning. 
+
+Når du skal opprette en bruker lokalt får du ikke en epost om å verifisere e-post, men en lenke du må klikke på i terminalen der appen kjører. 
 
 ### Miljøvariabler (lokalt minimum)
 
@@ -63,7 +65,7 @@ Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
 
 ### Backend-integrasjon
 
-Frontend kaller Rust-backenden med bearer-token (`BACKEND_API_KEY`). Sørg for at nøkkelen samsvarer med verdien backend-prosessen forventer. For å peke mot en lokal backend kan du midlertidig endre `getBackendUrl()` i `tavla/src/utils/backendUrl.ts` til å returnere `'http://127.0.0.1:3001'` (**ikke commit denne endringen**).
+Det er ikke nødvendig å kjøre opp backend lokalt for å kjøre frontend lokalt. For å peke lokal frontend mot en lokal backend kan du midlertidig endre `getBackendUrl()` i `tavla/src/utils/backendUrl.ts` til å returnere `'http://127.0.0.1:3001'`
 
 ### Git-konvensjoner (gitmoji-subsett)
 
@@ -93,31 +95,6 @@ bugfix/feil-i-refresh-endpoint
 rydding/refaktor-board-context
 ```
 
-### Migrasjonsskript (`tavla/migrations/`)
-
-Kjør fra `tavla/migrations/`. Migreringsscriptet tar inn ett av to argumenter – enten `setup` eller `run`:
-
-For å sette opp mijøet for første gang:
-
-```
-./migration setup
-```
-
-For å kjøre en migreringsfil, putt filen i /scripts mappen og kjør:
-
-```
-./migration run scripts/<filnavn>
-```
-
-#### Teste lokalt
-
-Du kan teste migreringsskriptene ved å kjøre de lokalt. Trenger du å skaffe deg litt ekte data, kan du "rollbacke" din lokale Firebase med data fra dev 🔥 Dette gjøres slik:
-
-1. Avslutt emulatoren (kill typ `yarn dev:persist`)
-2. Kjør `./migration run scripts/rollback_firestore.py local`
-3. Start emulatoren: `yarn dev:persist`
-
-Nå kan du kjøre migrasjonsskriptet ditt som om det var mot dev. Dette korter ned litt på utviklingstiden for migrasjonsskripter.
 
 ### Feilsøking
 


### PR DESCRIPTION
### 🥅 Bakgrunn
Tar en gjennomgagn av readme og dokumentasjon før oppstart av to nye, sånn at onboarding og oppstart skal gå smud. 

### ✨ Løsning
- Forenkler forklaring om backend for lokal kjøring
- Fjerner sekjson om migrering, dette er ikke nødvendig for første oppsett og ligger i /docs
- Fjerne informasjon om oppsett fra rot-readme, henvise til readme innenfor hver app (tavla, backen)


