### PR TITLE
🐛 Legger til manglende "open"-prop i custum-url modal

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger/components/CustomUrl/CustomUrl.tsx
@@ -80,6 +80,7 @@ function CustomUrl({
             </Tooltip>
             {open && (
                 <Modal
+                    open={open}
                     size="medium"
                     onDismiss={() => {
                         capture('custom_url_modal_closed', {


### PR DESCRIPTION
### 🥅 Bakgrunn

Ved oppgraderingen til @entur/modal v2 ble ikke `open`-propen lagt til i modalen for redigering av custom-url. 

### ✨ Løsning

- La til "open={open}" på modalen i "CustomUrl.tsx".
- Sjekket resten av kodebasen: dette er det eneste stedet hvor modalen ikke hadde fått lagt til `open` etter v2-oppgraderingen.

