### PR TITLE
:children_crossing: Splitte linjer med ulik front-text

### DIFF
--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -14,6 +14,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import type { BoardTileDB } from 'src/types/db-types/boards'
 import type { TTransportMode } from 'src/types/graphql-schema'
 import type { LineWithFrontText } from './types'
+import { generateQuayLineFrontTextKey } from './utils'
 
 function PublicCode({ line }: { line: LineWithFrontText }) {
     if (!line.publicCode) return null
@@ -28,13 +29,6 @@ function PublicCode({ line }: { line: LineWithFrontText }) {
             {line.publicCode}
         </div>
     )
-}
-
-function DisplayName({ line }: { line: LineWithFrontText }) {
-    if (line.frontTexts) {
-        return <>{line.frontTexts.join(' / ')}</>
-    }
-    return <SkeletonRectangle width="6rem" height="1rem" />
 }
 
 export function PlatformAndLines({
@@ -67,13 +61,16 @@ export function PlatformAndLines({
     const { capture } = usePosthogTracking()
 
     const selectedLinesInGroup = lines.filter((l) =>
-        selectedLineIds.has(`${quayId}||${l.id}`),
+        (l.frontTexts ?? []).some((frontText) =>
+            selectedLineIds.has(
+                generateQuayLineFrontTextKey(quayId, l.id, frontText),
+            ),
+        ),
     )
     const isAllSelected =
         lines.length > 0 && selectedLinesInGroup.length === lines.length
     const isNoneSelected = selectedLinesInGroup.length === 0
     const isIndeterminate = !isAllSelected && !isNoneSelected
-    const showLines = !isNoneSelected
 
     const compareLineFragment = (
         a: LineWithFrontText,
@@ -161,7 +158,15 @@ export function PlatformAndLines({
                             action: checked ? 'select_all' : 'cleared',
                         })
                         onToggleGroup(
-                            lines.map((l) => `${quayId}||${l.id}`),
+                            lines.flatMap((l) =>
+                                (l.frontTexts ?? []).map((frontText) =>
+                                    generateQuayLineFrontTextKey(
+                                        quayId,
+                                        l.id,
+                                        frontText,
+                                    ),
+                                ),
+                            ),
                             checked,
                         )
                     }}
@@ -170,30 +175,52 @@ export function PlatformAndLines({
             {[...lines]
                 .sort(compareLineFragment)
                 .filter(filterLineFragment)
-                .map((line) => (
-                    <Checkbox
-                        key={line.id}
-                        value={`${quayId}||${line.id}`}
-                        checked={selectedLineIds.has(`${quayId}||${line.id}`)}
-                        className={`pl-3 ${showLines ? '' : 'hidden'}`}
-                        name={`${tile.uuid}-lines`}
-                        data-transport-mode={line.transportMode}
-                        onChange={() => {
-                            capture('stop_place_edit_interaction', {
-                                location: trackingLocation,
-                                field: 'lines',
-                                column_value: 'none',
-                                action: 'changed',
-                            })
-                            onToggleLine(`${quayId}||${line.id}`)
-                        }}
-                    >
-                        <div className="flex flex-row items-center gap-2">
-                            <PublicCode line={line} />
-                            <DisplayName line={line} />
-                        </div>
-                    </Checkbox>
-                ))}
+                .flatMap((line) =>
+                    (line.frontTexts ?? []).map((frontText) => (
+                        <Checkbox
+                            key={generateQuayLineFrontTextKey(
+                                quayId,
+                                line.id,
+                                frontText,
+                            )}
+                            value={generateQuayLineFrontTextKey(
+                                quayId,
+                                line.id,
+                                frontText,
+                            )}
+                            checked={selectedLineIds.has(
+                                generateQuayLineFrontTextKey(
+                                    quayId,
+                                    line.id,
+                                    frontText,
+                                ),
+                            )}
+                            className={`pl-3`}
+                            name={`${tile.uuid}-lines`}
+                            data-transport-mode={line.transportMode}
+                            onChange={() => {
+                                capture('stop_place_edit_interaction', {
+                                    location: trackingLocation,
+                                    field: 'lines',
+                                    column_value: 'none',
+                                    action: 'changed',
+                                })
+                                onToggleLine(
+                                    generateQuayLineFrontTextKey(
+                                        quayId,
+                                        line.id,
+                                        frontText,
+                                    ),
+                                )
+                            }}
+                        >
+                            <div className="flex flex-row items-center gap-2">
+                                <PublicCode line={line} />
+                                {frontText}
+                            </div>
+                        </Checkbox>
+                    )),
+                )}
         </div>
     )
 }

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -59,16 +59,26 @@ export function PlatformAndLines({
 }) {
     const { capture } = usePosthogTracking()
 
-    const selectedLinesInGroup = lines.filter((l) =>
-        frontTextsOrDefault(l.frontTexts).some((frontText) =>
-            selectedLineIds.has(
+    const filterLineFragment = (line: LineWithFrontText) => {
+        return !line.frontTexts || line.frontTexts.length > 0
+    }
+
+    const allKeysInGroup = lines
+        .filter(filterLineFragment)
+        .flatMap((l) =>
+            frontTextsOrDefault(l.frontTexts).map((frontText) =>
                 generateQuayLineFrontTextKey(quayId, l.id, frontText),
             ),
-        ),
+        )
+
+    const selectedKeysInGroup = allKeysInGroup.filter((key) =>
+        selectedLineIds.has(key),
     )
+
     const isAllSelected =
-        lines.length > 0 && selectedLinesInGroup.length === lines.length
-    const isNoneSelected = selectedLinesInGroup.length === 0
+        allKeysInGroup.length > 0 &&
+        selectedKeysInGroup.length === allKeysInGroup.length
+    const isNoneSelected = selectedKeysInGroup.length === 0
     const isIndeterminate = !isAllSelected && !isNoneSelected
 
     const compareLineFragment = (
@@ -88,10 +98,6 @@ export function PlatformAndLines({
         return codeA.localeCompare(codeB, undefined, {
             numeric: true,
         })
-    }
-
-    const filterLineFragment = (line: LineWithFrontText) => {
-        return !line.frontTexts || line.frontTexts.length > 0
     }
 
     const transportModesFromLines = getTransportModesFromLines(lines)

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -181,50 +181,38 @@ export function PlatformAndLines({
                 .sort(compareLineFragment)
                 .filter(filterLineFragment)
                 .flatMap((line) =>
-                    line.frontTexts.map((frontText) => (
-                        <Checkbox
-                            key={generateQuayLineFrontTextKey(
-                                quayId,
-                                line.id,
-                                frontText,
-                            )}
-                            value={generateQuayLineFrontTextKey(
-                                quayId,
-                                line.id,
-                                frontText,
-                            )}
-                            checked={selectedLineIds.has(
-                                generateQuayLineFrontTextKey(
-                                    quayId,
-                                    line.id,
-                                    frontText,
-                                ),
-                            )}
-                            className="pl-3"
-                            name={`${tile.uuid}-lines`}
-                            data-transport-mode={line.transportMode}
-                            onChange={() => {
-                                capture('stop_place_edit_interaction', {
-                                    location: trackingLocation,
-                                    field: 'lines',
-                                    column_value: 'none',
-                                    action: 'changed',
-                                })
-                                onToggleLine(
-                                    generateQuayLineFrontTextKey(
-                                        quayId,
-                                        line.id,
-                                        frontText,
-                                    ),
-                                )
-                            }}
-                        >
-                            <div className="flex flex-row items-center gap-2">
-                                <PublicCode line={line} />
-                                {frontText}
-                            </div>
-                        </Checkbox>
-                    )),
+                    line.frontTexts.map((frontText) => {
+                        const key = generateQuayLineFrontTextKey(
+                            quayId,
+                            line.id,
+                            frontText,
+                        )
+
+                        return (
+                            <Checkbox
+                                key={key}
+                                value={key}
+                                checked={selectedLineIds.has(key)}
+                                className="pl-3"
+                                name={`${tile.uuid}-lines`}
+                                data-transport-mode={line.transportMode}
+                                onChange={() => {
+                                    capture('stop_place_edit_interaction', {
+                                        location: trackingLocation,
+                                        field: 'lines',
+                                        column_value: 'none',
+                                        action: 'changed',
+                                    })
+                                    onToggleLine(key)
+                                }}
+                            >
+                                <div className="flex flex-row items-center gap-2">
+                                    <PublicCode line={line} />
+                                    {frontText}
+                                </div>
+                            </Checkbox>
+                        )
+                    }),
                 )}
         </div>
     )

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -200,7 +200,7 @@ export function PlatformAndLines({
                                     frontText,
                                 ),
                             )}
-                            className={`pl-3`}
+                            className="pl-3"
                             name={`${tile.uuid}-lines`}
                             data-transport-mode={line.transportMode}
                             onChange={() => {

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -13,7 +13,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import type { BoardTileDB } from 'src/types/db-types/boards'
 import type { TTransportMode } from 'src/types/graphql-schema'
 import type { LineWithFrontText } from './types'
-import { generateQuayLineFrontTextKey } from './utils'
+import { frontTextsOrDefault, generateQuayLineFrontTextKey } from './utils'
 
 function PublicCode({ line }: { line: LineWithFrontText }) {
     if (!line.publicCode) return null
@@ -60,7 +60,7 @@ export function PlatformAndLines({
     const { capture } = usePosthogTracking()
 
     const selectedLinesInGroup = lines.filter((l) =>
-        (l.frontTexts ?? []).some((frontText) =>
+        frontTextsOrDefault(l.frontTexts).some((frontText) =>
             selectedLineIds.has(
                 generateQuayLineFrontTextKey(quayId, l.id, frontText),
             ),
@@ -158,12 +158,13 @@ export function PlatformAndLines({
                         })
                         onToggleGroup(
                             lines.flatMap((l) =>
-                                (l.frontTexts ?? []).map((frontText) =>
-                                    generateQuayLineFrontTextKey(
-                                        quayId,
-                                        l.id,
-                                        frontText,
-                                    ),
+                                frontTextsOrDefault(l.frontTexts).map(
+                                    (frontText) =>
+                                        generateQuayLineFrontTextKey(
+                                            quayId,
+                                            l.id,
+                                            frontText,
+                                        ),
                                 ),
                             ),
                             checked,
@@ -175,7 +176,7 @@ export function PlatformAndLines({
                 .sort(compareLineFragment)
                 .filter(filterLineFragment)
                 .flatMap((line) =>
-                    (line.frontTexts ?? []).map((frontText) => (
+                    frontTextsOrDefault(line.frontTexts).map((frontText) => (
                         <Checkbox
                             key={generateQuayLineFrontTextKey(
                                 quayId,

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { Checkbox } from '@entur/form'
 import { ValidationInfoFilledIcon } from '@entur/icons'
-import { SkeletonRectangle } from '@entur/loader'
 import { Tooltip } from '@entur/tooltip'
 import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
 import {

--- a/tavla/app/_components/TileCard/PlatformAndLines.tsx
+++ b/tavla/app/_components/TileCard/PlatformAndLines.tsx
@@ -13,7 +13,7 @@ import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import type { BoardTileDB } from 'src/types/db-types/boards'
 import type { TTransportMode } from 'src/types/graphql-schema'
 import type { LineWithFrontText } from './types'
-import { frontTextsOrDefault, generateQuayLineFrontTextKey } from './utils'
+import { generateQuayLineFrontTextKey } from './utils'
 
 function PublicCode({ line }: { line: LineWithFrontText }) {
     if (!line.publicCode) return null
@@ -66,7 +66,7 @@ export function PlatformAndLines({
     const allKeysInGroup = lines
         .filter(filterLineFragment)
         .flatMap((l) =>
-            frontTextsOrDefault(l.frontTexts).map((frontText) =>
+            l.frontTexts.map((frontText) =>
                 generateQuayLineFrontTextKey(quayId, l.id, frontText),
             ),
         )
@@ -164,13 +164,12 @@ export function PlatformAndLines({
                         })
                         onToggleGroup(
                             lines.flatMap((l) =>
-                                frontTextsOrDefault(l.frontTexts).map(
-                                    (frontText) =>
-                                        generateQuayLineFrontTextKey(
-                                            quayId,
-                                            l.id,
-                                            frontText,
-                                        ),
+                                l.frontTexts.map((frontText) =>
+                                    generateQuayLineFrontTextKey(
+                                        quayId,
+                                        l.id,
+                                        frontText,
+                                    ),
                                 ),
                             ),
                             checked,
@@ -182,7 +181,7 @@ export function PlatformAndLines({
                 .sort(compareLineFragment)
                 .filter(filterLineFragment)
                 .flatMap((line) =>
-                    frontTextsOrDefault(line.frontTexts).map((frontText) => (
+                    line.frontTexts.map((frontText) => (
                         <Checkbox
                             key={generateQuayLineFrontTextKey(
                                 quayId,

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -27,7 +27,7 @@ import { SetVisibleLines } from './components/SetVisibleLines'
 import { TileArrows } from './components/TileArrows'
 import { TileContext } from './context'
 import { useLines } from './useLines'
-import { parseTileFormData } from './utils'
+import { countSelectableQuayLineKeys, parseTileFormData } from './utils'
 
 export function TileCard({
     board,
@@ -68,7 +68,6 @@ export function TileCard({
     ) => {
         const {
             columns: parsedColumns,
-            count,
             offset,
             displayName,
             quayLineKeys,
@@ -80,11 +79,15 @@ export function TileCard({
             return getFormFeedbackForError('board/tiles-name-missing')
         }
 
-        if (quayLineKeys.length === 0 && count !== null && count > 0) {
+        const totalSelectableKeys = countSelectableQuayLineKeys(
+            quaysWithFilteredLines,
+        )
+
+        if (quayLineKeys.length === 0 && totalSelectableKeys > 0) {
             return getFormFeedbackForError('board/tiles-no-lines-selected')
         }
 
-        const allSelected = quayLineKeys.length === count
+        const allSelected = quayLineKeys.length === totalSelectableKeys
 
         const newQuays = allSelected
             ? []

--- a/tavla/app/_components/TileCard/TileCard.tsx
+++ b/tavla/app/_components/TileCard/TileCard.tsx
@@ -93,7 +93,11 @@ export function TileCard({
                       id: q.id,
                       whitelistedLines: q.lines
                           .filter((l) =>
-                              quayLineKeys.includes(`${q.id}||${l.id}`),
+                              quayLineKeys.some(
+                                  (key) =>
+                                      key === `${q.id}||${l.id}` ||
+                                      key.startsWith(`${q.id}||${l.id}||`),
+                              ),
                           )
                           .map((l) => l.id),
                   }))

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -10,7 +10,6 @@ import { PlatformAndLines } from '../PlatformAndLines'
 import type { QuayWithFrontText } from '../types'
 import {
     deriveLinesWithDirection,
-    frontTextsOrDefault,
     generateQuayLineFrontTextKey,
     getInitialCheckedLineIds,
     transportModeNames,
@@ -216,7 +215,7 @@ export function SetVisibleLines({
         const keysOnAllQuays: string[] = []
         for (const quay of quays) {
             const quayIsActive = quay.lines.some((l) =>
-                frontTextsOrDefault(l.frontTexts).some((frontText) =>
+                l.frontTexts.some((frontText) =>
                     checkedLineIds.has(
                         generateQuayLineFrontTextKey(quay.id, l.id, frontText),
                     ),
@@ -225,9 +224,7 @@ export function SetVisibleLines({
 
             for (const line of quay.lines) {
                 if (line.transportMode === mode) {
-                    for (const frontText of frontTextsOrDefault(
-                        line.frontTexts,
-                    )) {
+                    for (const frontText of line.frontTexts) {
                         const key = generateQuayLineFrontTextKey(
                             quay.id,
                             line.id,
@@ -259,7 +256,7 @@ export function SetVisibleLines({
         quays.some((q) =>
             q.lines.some((l) => {
                 if (l.transportMode !== mode) return false
-                return frontTextsOrDefault(l.frontTexts).some((frontText) =>
+                return l.frontTexts.some((frontText) =>
                     checkedLineIds.has(
                         generateQuayLineFrontTextKey(q.id, l.id, frontText),
                     ),

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -10,6 +10,7 @@ import { PlatformAndLines } from '../PlatformAndLines'
 import type { QuayWithFrontText } from '../types'
 import {
     deriveLinesWithDirection,
+    frontTextsOrDefault,
     generateQuayLineFrontTextKey,
     getInitialCheckedLineIds,
     transportModeNames,
@@ -214,23 +215,19 @@ export function SetVisibleLines({
         const keysOnActiveQuays: string[] = []
         const keysOnAllQuays: string[] = []
         for (const quay of quays) {
-            const quayIsActive = quay.lines.some((l) => {
-                const frontTexts = l.frontTexts?.length
-                    ? l.frontTexts
-                    : [undefined]
-                return frontTexts.some((frontText) =>
+            const quayIsActive = quay.lines.some((l) =>
+                frontTextsOrDefault(l.frontTexts).some((frontText) =>
                     checkedLineIds.has(
                         generateQuayLineFrontTextKey(quay.id, l.id, frontText),
                     ),
-                )
-            })
+                ),
+            )
 
             for (const line of quay.lines) {
                 if (line.transportMode === mode) {
-                    const frontTexts = line.frontTexts?.length
-                        ? line.frontTexts
-                        : [undefined]
-                    for (const frontText of frontTexts) {
+                    for (const frontText of frontTextsOrDefault(
+                        line.frontTexts,
+                    )) {
                         const key = generateQuayLineFrontTextKey(
                             quay.id,
                             line.id,
@@ -262,10 +259,7 @@ export function SetVisibleLines({
         quays.some((q) =>
             q.lines.some((l) => {
                 if (l.transportMode !== mode) return false
-                const frontTexts = l.frontTexts?.length
-                    ? l.frontTexts
-                    : [undefined]
-                return frontTexts.some((frontText) =>
+                return frontTextsOrDefault(l.frontTexts).some((frontText) =>
                     checkedLineIds.has(
                         generateQuayLineFrontTextKey(q.id, l.id, frontText),
                     ),

--- a/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
+++ b/tavla/app/_components/TileCard/components/SetVisibleLines.tsx
@@ -10,6 +10,7 @@ import { PlatformAndLines } from '../PlatformAndLines'
 import type { QuayWithFrontText } from '../types'
 import {
     deriveLinesWithDirection,
+    generateQuayLineFrontTextKey,
     getInitialCheckedLineIds,
     transportModeNames,
 } from '../utils'
@@ -213,15 +214,32 @@ export function SetVisibleLines({
         const keysOnActiveQuays: string[] = []
         const keysOnAllQuays: string[] = []
         for (const quay of quays) {
-            const quayIsActive = quay.lines.some((l) =>
-                checkedLineIds.has(`${quay.id}||${l.id}`),
-            )
+            const quayIsActive = quay.lines.some((l) => {
+                const frontTexts = l.frontTexts?.length
+                    ? l.frontTexts
+                    : [undefined]
+                return frontTexts.some((frontText) =>
+                    checkedLineIds.has(
+                        generateQuayLineFrontTextKey(quay.id, l.id, frontText),
+                    ),
+                )
+            })
 
             for (const line of quay.lines) {
                 if (line.transportMode === mode) {
-                    keysOnAllQuays.push(`${quay.id}||${line.id}`)
-                    if (quayIsActive) {
-                        keysOnActiveQuays.push(`${quay.id}||${line.id}`)
+                    const frontTexts = line.frontTexts?.length
+                        ? line.frontTexts
+                        : [undefined]
+                    for (const frontText of frontTexts) {
+                        const key = generateQuayLineFrontTextKey(
+                            quay.id,
+                            line.id,
+                            frontText,
+                        )
+                        keysOnAllQuays.push(key)
+                        if (quayIsActive) {
+                            keysOnActiveQuays.push(key)
+                        }
                     }
                 }
             }
@@ -242,11 +260,17 @@ export function SetVisibleLines({
 
     const isModeSelected = (mode: TTransportMode) =>
         quays.some((q) =>
-            q.lines.some(
-                (l) =>
-                    l.transportMode === mode &&
-                    checkedLineIds.has(`${q.id}||${l.id}`),
-            ),
+            q.lines.some((l) => {
+                if (l.transportMode !== mode) return false
+                const frontTexts = l.frontTexts?.length
+                    ? l.frontTexts
+                    : [undefined]
+                return frontTexts.some((frontText) =>
+                    checkedLineIds.has(
+                        generateQuayLineFrontTextKey(q.id, l.id, frontText),
+                    ),
+                )
+            }),
         )
 
     const renderQuay = (quay: QuayWithFrontText) => {

--- a/tavla/app/_components/TileCard/types.ts
+++ b/tavla/app/_components/TileCard/types.ts
@@ -4,7 +4,7 @@ import type { TLinesFragment } from 'types/operations'
 type LineFragment = TLinesFragment['lines'][number]
 
 export type LineWithFrontText = LineFragment & {
-    frontTexts?: string[]
+    frontTexts: string[]
 }
 
 export type QuayWithFrontText = Omit<TQuay, 'lines'> & {

--- a/tavla/app/_components/TileCard/useLines.ts
+++ b/tavla/app/_components/TileCard/useLines.ts
@@ -85,35 +85,23 @@ function useLines(
                 const json = await res.json()
                 const quays: TQuay[] = json.data?.stopPlace?.quays ?? []
 
-                setQuays(
-                    quays.map((q) => ({
-                        ...q,
-                        lines: q.lines.map((l) => ({
-                            ...l,
-                            frontTexts: undefined,
-                        })),
-                    })),
-                )
-
-                await Promise.all(
+                const quaysWithFrontTexts = await Promise.all(
                     quays.map(async (quay) => {
                         const frontTexts = await getFrontTextsForQuay(
                             quay.id,
                             isArrival,
                         )
-                        const quayWithFrontTexts = addFrontTextToQuay(
-                            quay,
-                            frontTexts,
-                        )
-                        setQuays((prev) =>
-                            (prev ?? []).map((q) =>
-                                q.id === quay.id
-                                    ? { ...q, lines: quayWithFrontTexts }
-                                    : q,
-                            ),
-                        )
+
+                        const lines = addFrontTextToQuay(quay, frontTexts)
+
+                        return {
+                            ...quay,
+                            lines,
+                        }
                     }),
                 )
+
+                setQuays(quaysWithFrontTexts)
             })
         }
 

--- a/tavla/app/_components/TileCard/utils.test.ts
+++ b/tavla/app/_components/TileCard/utils.test.ts
@@ -26,7 +26,7 @@ describe('deriveLinesWithDirection', () => {
             quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }]),
             quay('Q2', [{ id: 'L1', frontTexts: ['Sør'] }]),
         ]
-        expect(deriveLinesWithDirection(quays, ['Q1||L1'])).toEqual([
+        expect(deriveLinesWithDirection(quays, ['Q1||L1||Nord'])).toEqual([
             { lineId: 'L1', frontTexts: ['Nord'] },
         ])
     })
@@ -36,9 +36,9 @@ describe('deriveLinesWithDirection', () => {
             quay('Q1', [{ id: 'L1', frontTexts: ['Nord'] }]),
             quay('Q2', [{ id: 'L1', frontTexts: ['Sør'] }]),
         ]
-        expect(deriveLinesWithDirection(quays, ['Q1||L1', 'Q2||L1'])).toEqual([
-            { lineId: 'L1', frontTexts: [] },
-        ])
+        expect(
+            deriveLinesWithDirection(quays, ['Q1||L1||Nord', 'Q2||L1||Sør']),
+        ).toEqual([{ lineId: 'L1', frontTexts: [] }])
     })
 
     it('gir frontTexts: [] ("alle retninger", fail-open) for en valgt linje som mangler frontText-data, i stedet for å droppe linja', () => {
@@ -60,7 +60,7 @@ describe('deriveLinesWithDirection', () => {
                 { id: 'L2', frontTexts: ['Vest'] },
             ]),
         ]
-        const result = deriveLinesWithDirection(quays, ['Q1||L1'])
+        const result = deriveLinesWithDirection(quays, ['Q1||L1||Nord'])
         expect(result).toHaveLength(1)
         expect(result[0]?.lineId).toBe('L1')
     })
@@ -70,9 +70,12 @@ describe('deriveLinesWithDirection', () => {
             quay('Q1', [{ id: 'L1', frontTexts: ['Storo', 'Bergkrystallen'] }]),
             quay('Q2', [{ id: 'L1', frontTexts: ['Sinsen'] }]),
         ]
-        expect(deriveLinesWithDirection(quays, ['Q1||L1'])).toEqual([
-            { lineId: 'L1', frontTexts: ['Bergkrystallen', 'Storo'] },
-        ])
+        expect(
+            deriveLinesWithDirection(quays, [
+                'Q1||L1||Storo',
+                'Q1||L1||Bergkrystallen',
+            ]),
+        ).toEqual([{ lineId: 'L1', frontTexts: ['Bergkrystallen', 'Storo'] }])
     })
 })
 

--- a/tavla/app/_components/TileCard/utils.test.ts
+++ b/tavla/app/_components/TileCard/utils.test.ts
@@ -10,7 +10,7 @@ import {
 /* Minimal fixture — deriveLinesWithDirection bruker kun quay.id og lines[].id/frontTexts, så vi caster forbi resten av TQuay-feltene.*/
 function quay(
     id: string,
-    lines: Array<{ id: string; frontTexts?: string[] }>,
+    lines: Array<{ id: string; frontTexts: string[] }>,
 ): QuayWithFrontText {
     return { id, lines } as unknown as QuayWithFrontText
 }
@@ -131,7 +131,12 @@ function adminTile(
 describe('getInitialCheckedLineIds (read-back-presedens)', () => {
     it('for quay lagret med en ikke-tom whitelistedLines returneres kun de linjene', () => {
         const tile = adminTile([{ id: 'Q1', whitelistedLines: ['L1'] }])
-        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        const quays = [
+            quay('Q1', [
+                { id: 'L1', frontTexts: [] },
+                { id: 'L2', frontTexts: [] },
+            ]),
+        ]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
             new Set(['Q1||L1']),
         )
@@ -139,7 +144,12 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
 
     it('for quay lagret med tom whitelistedLines tolkes [] som "alle linjer på quayen" og alle linjer returneres', () => {
         const tile = adminTile([{ id: 'Q1', whitelistedLines: [] }])
-        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        const quays = [
+            quay('Q1', [
+                { id: 'L1', frontTexts: [] },
+                { id: 'L2', frontTexts: [] },
+            ]),
+        ]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
             new Set(['Q1||L1', 'Q1||L2']),
         )
@@ -147,7 +157,10 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
 
     it('tile har en quay med whitelistedLines, på stoppet finnes det flere quays som ikke er lagret på tile. Da returneres kun kombinasjon av lagret quay og linje', () => {
         const tile = adminTile([{ id: 'Q1', whitelistedLines: ['L1'] }])
-        const quays = [quay('Q1', [{ id: 'L1' }]), quay('Q2', [{ id: 'L3' }])]
+        const quays = [
+            quay('Q1', [{ id: 'L1', frontTexts: [] }]),
+            quay('Q2', [{ id: 'L3', frontTexts: [] }]),
+        ]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
             new Set(['Q1||L1']),
         )
@@ -156,9 +169,18 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
     it('når ingen quays lagret, men deprekert tile.whitelistedLines er satt så returneres alle kombinasjoner quay og valgt linje', () => {
         const tile = adminTile([], ['L1'])
         const quays = [
-            quay('Q1', [{ id: 'L1' }, { id: 'L2' }]),
-            quay('Q2', [{ id: 'L1' }, { id: 'L3' }]),
-            quay('Q3', [{ id: 'L2' }, { id: 'L3' }]),
+            quay('Q1', [
+                { id: 'L1', frontTexts: [] },
+                { id: 'L2', frontTexts: [] },
+            ]),
+            quay('Q2', [
+                { id: 'L1', frontTexts: [] },
+                { id: 'L3', frontTexts: [] },
+            ]),
+            quay('Q3', [
+                { id: 'L2', frontTexts: [] },
+                { id: 'L3', frontTexts: [] },
+            ]),
         ]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
             new Set(['Q1||L1', 'Q2||L1']),
@@ -167,7 +189,12 @@ describe('getInitialCheckedLineIds (read-back-presedens)', () => {
 
     it('verken quays eller tile.whitelistedLines er satt så alle kombinasjoner returneres', () => {
         const tile = adminTile([])
-        const quays = [quay('Q1', [{ id: 'L1' }, { id: 'L2' }])]
+        const quays = [
+            quay('Q1', [
+                { id: 'L1', frontTexts: [] },
+                { id: 'L2', frontTexts: [] },
+            ]),
+        ]
         expect(getInitialCheckedLineIds(tile, quays)).toEqual(
             new Set(['Q1||L1', 'Q1||L2']),
         )

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -170,6 +170,23 @@ export function deriveLinesWithDirection(
     })
 }
 
+export function countSelectableQuayLineKeys(
+    quays: QuayWithFrontText[],
+): number {
+    return quays.reduce(
+        (sum, quay) =>
+            sum +
+            quay.lines
+                .filter((l) => !l.frontTexts || l.frontTexts.length > 0)
+                .reduce(
+                    (lineSum, l) =>
+                        lineSum + frontTextsOrDefault(l.frontTexts).length,
+                    0,
+                ),
+        0,
+    )
+}
+
 export function getInitialCheckedLineIds(
     tile: BoardTileDB,
     quays: QuayWithFrontText[],

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -86,11 +86,21 @@ export function parseTileFormData(data: FormData): TileFormValues {
     }
 }
 
+export function generateQuayLineFrontTextKey(
+    quayId: string,
+    lineId: string,
+    frontText?: string | null,
+): string {
+    return frontText
+        ? `${quayId}||${lineId}||${frontText}`
+        : `${quayId}||${lineId}`
+}
+
 /**
  *
  * @param quays The quays with all lines and frontTexts
- * @param selectedQuayLineKeys The currently selected quay-line pairs, in the
- * form of `${quayId}||${lineId}`.
+ * @param selectedQuayLineKeys The currently selected quay-line(-frontText) pairs, in the
+ * form of `${quayId}||${lineId}` or `${quayId}||${lineId}||${frontText}` for lines with known directions
  *
  * @returns A list of lines with their selected directions (frontTexts). If all
  * known directions of a line are selected, the line is returned with an empty
@@ -104,6 +114,7 @@ export function deriveLinesWithDirection(
     const selectedLineIds = new Set(selectedQuayLineKeys)
     const selectedFrontTexts = new Map<string, Set<string>>()
     const knownFrontTexts = new Map<string, Set<string>>()
+    const linesWithAnySelection = new Set<string>()
 
     for (const quay of quays) {
         for (const line of quay.lines) {
@@ -113,21 +124,36 @@ export function deriveLinesWithDirection(
             for (const frontText of frontTexts) known.add(frontText)
             knownFrontTexts.set(line.id, known)
 
-            if (selectedLineIds.has(`${quay.id}||${line.id}`)) {
-                const chosen =
-                    selectedFrontTexts.get(line.id) ?? new Set<string>()
-                for (const frontText of frontTexts) chosen.add(frontText)
-                selectedFrontTexts.set(line.id, chosen)
+            const frontTextsOrFallback = frontTexts.length
+                ? frontTexts
+                : [undefined]
+            for (const frontText of frontTextsOrFallback) {
+                const key = generateQuayLineFrontTextKey(
+                    quay.id,
+                    line.id,
+                    frontText,
+                )
+
+                if (!selectedLineIds.has(key)) continue
+
+                linesWithAnySelection.add(line.id)
+                if (frontText) {
+                    const chosen =
+                        selectedFrontTexts.get(line.id) ?? new Set<string>()
+                    chosen.add(frontText)
+                    selectedFrontTexts.set(line.id, chosen)
+                }
             }
         }
     }
 
-    return Array.from(selectedFrontTexts.entries()).map(([lineId, chosen]) => {
+    return Array.from(linesWithAnySelection).map((lineId) => {
         const known = knownFrontTexts.get(lineId) ?? new Set<string>()
+        const chosen = selectedFrontTexts.get(lineId) ?? new Set<string>()
         const allDirectionsChosen =
-            known.size > 0 &&
-            chosen.size >= known.size &&
-            Array.from(known).every((frontText) => chosen.has(frontText))
+            known.size === 0 ||
+            (chosen.size >= known.size &&
+                Array.from(known).every((frontText) => chosen.has(frontText)))
 
         return {
             lineId,
@@ -135,6 +161,7 @@ export function deriveLinesWithDirection(
         }
     })
 }
+
 export function getInitialCheckedLineIds(
     tile: BoardTileDB,
     quays: QuayWithFrontText[],
@@ -146,21 +173,67 @@ export function getInitialCheckedLineIds(
         const savedQuay = tile.quays?.find((q) => q.id === quay.id)
         if (savedQuay) {
             if (savedQuay.whitelistedLines.length === 0) {
-                for (const l of quay.lines) set.add(`${quay.id}||${l.id}`)
+                for (const l of quay.lines) {
+                    const frontTexts = l.frontTexts?.length
+                        ? l.frontTexts
+                        : [undefined]
+                    for (const frontText of frontTexts) {
+                        set.add(
+                            generateQuayLineFrontTextKey(
+                                quay.id,
+                                l.id,
+                                frontText,
+                            ),
+                        )
+                    }
+                }
             } else {
-                for (const lineId of savedQuay.whitelistedLines)
-                    set.add(`${quay.id}||${lineId}`)
+                for (const lineId of savedQuay.whitelistedLines) {
+                    const line = quay.lines.find((l) => l.id === lineId)
+                    const frontTexts = line?.frontTexts?.length
+                        ? line.frontTexts
+                        : [undefined]
+                    for (const frontText of frontTexts) {
+                        set.add(
+                            generateQuayLineFrontTextKey(
+                                quay.id,
+                                lineId,
+                                frontText,
+                            ),
+                        )
+                    }
+                }
             }
         } else if (hasQuayFilter) {
             // Per-quay filter exists but this quay has no entry: nothing selected
         } else if (tile.whitelistedLines && tile.whitelistedLines.length > 0) {
             for (const l of quay.lines) {
                 if (tile.whitelistedLines?.includes(l.id)) {
-                    set.add(`${quay.id}||${l.id}`)
+                    const frontTexts = l.frontTexts?.length
+                        ? l.frontTexts
+                        : [undefined]
+                    for (const frontText of frontTexts) {
+                        set.add(
+                            generateQuayLineFrontTextKey(
+                                quay.id,
+                                l.id,
+                                frontText,
+                            ),
+                        )
+                    }
                 }
             }
         } else {
-            for (const l of quay.lines) set.add(`${quay.id}||${l.id}`)
+            for (const l of quay.lines) {
+                const frontTexts = l.frontTexts?.length
+                    ? l.frontTexts
+                    : [undefined]
+                for (const frontText of frontTexts) {
+                    set.add(
+                        generateQuayLineFrontTextKey(quay.id, l.id, frontText),
+                    )
+                }
+            }
         }
     }
 

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -97,17 +97,6 @@ export function generateQuayLineFrontTextKey(
 }
 
 /**
- * Directions (frontTexts) a line runs in, or a single `undefined` placeholder
- * when no directions are known — so callers can still generate one
- * quay-line(-frontText) key for the line.
- */
-export function frontTextsOrDefault(
-    frontTexts: string[] | undefined,
-): (string | undefined)[] {
-    return frontTexts?.length ? frontTexts : [undefined]
-}
-
-/**
  *
  * @param quays The quays with all lines and frontTexts
  * @param selectedQuayLineKeys The currently selected quay-line(-frontText) pairs, in the
@@ -129,13 +118,21 @@ export function deriveLinesWithDirection(
 
     for (const quay of quays) {
         for (const line of quay.lines) {
-            const frontTexts = line.frontTexts ?? []
+            const frontTexts = line.frontTexts
+
+            if (frontTexts.length === 0) {
+                const key = generateQuayLineFrontTextKey(quay.id, line.id)
+                if (selectedLineIds.has(key)) {
+                    linesWithAnySelection.add(line.id)
+                }
+                continue
+            }
 
             const known = knownFrontTexts.get(line.id) ?? new Set<string>()
             for (const frontText of frontTexts) known.add(frontText)
             knownFrontTexts.set(line.id, known)
 
-            for (const frontText of frontTextsOrDefault(line.frontTexts)) {
+            for (const frontText of frontTexts) {
                 const key = generateQuayLineFrontTextKey(
                     quay.id,
                     line.id,
@@ -176,15 +173,32 @@ export function countSelectableQuayLineKeys(
     return quays.reduce(
         (sum, quay) =>
             sum +
-            quay.lines
-                .filter((l) => !l.frontTexts || l.frontTexts.length > 0)
-                .reduce(
-                    (lineSum, l) =>
-                        lineSum + frontTextsOrDefault(l.frontTexts).length,
-                    0,
-                ),
+            quay.lines.reduce(
+                (lineSum, l) => lineSum + (l.frontTexts.length || 1),
+                0,
+            ),
         0,
     )
+}
+
+/**
+ * Adds a quay-line(-frontText) key to the set. If the line has no known directions,
+ * the key is added without a frontText. If the line has known directions, a key
+ * is added for each frontText.
+ */
+function addLineKeys(
+    set: Set<string>,
+    quayId: string,
+    lineId: string,
+    frontTexts: string[] | undefined,
+): void {
+    if (!frontTexts || frontTexts.length === 0) {
+        set.add(generateQuayLineFrontTextKey(quayId, lineId))
+        return
+    }
+    for (const frontText of frontTexts) {
+        set.add(generateQuayLineFrontTextKey(quayId, lineId, frontText))
+    }
 }
 
 export function getInitialCheckedLineIds(
@@ -199,30 +213,13 @@ export function getInitialCheckedLineIds(
         if (savedQuay) {
             if (savedQuay.whitelistedLines.length === 0) {
                 for (const l of quay.lines) {
-                    for (const frontText of frontTextsOrDefault(l.frontTexts)) {
-                        set.add(
-                            generateQuayLineFrontTextKey(
-                                quay.id,
-                                l.id,
-                                frontText,
-                            ),
-                        )
-                    }
+                    addLineKeys(set, quay.id, l.id, l.frontTexts)
                 }
             } else {
                 for (const lineId of savedQuay.whitelistedLines) {
                     const line = quay.lines.find((l) => l.id === lineId)
-                    for (const frontText of frontTextsOrDefault(
-                        line?.frontTexts,
-                    )) {
-                        set.add(
-                            generateQuayLineFrontTextKey(
-                                quay.id,
-                                lineId,
-                                frontText,
-                            ),
-                        )
-                    }
+                    if (!line) continue
+                    addLineKeys(set, quay.id, line.id, line.frontTexts)
                 }
             }
         } else if (hasQuayFilter) {
@@ -230,24 +227,12 @@ export function getInitialCheckedLineIds(
         } else if (tile.whitelistedLines && tile.whitelistedLines.length > 0) {
             for (const l of quay.lines) {
                 if (tile.whitelistedLines?.includes(l.id)) {
-                    for (const frontText of frontTextsOrDefault(l.frontTexts)) {
-                        set.add(
-                            generateQuayLineFrontTextKey(
-                                quay.id,
-                                l.id,
-                                frontText,
-                            ),
-                        )
-                    }
+                    addLineKeys(set, quay.id, l.id, l.frontTexts)
                 }
             }
         } else {
             for (const l of quay.lines) {
-                for (const frontText of frontTextsOrDefault(l.frontTexts)) {
-                    set.add(
-                        generateQuayLineFrontTextKey(quay.id, l.id, frontText),
-                    )
-                }
+                addLineKeys(set, quay.id, l.id, l.frontTexts)
             }
         }
     }

--- a/tavla/app/_components/TileCard/utils.ts
+++ b/tavla/app/_components/TileCard/utils.ts
@@ -97,6 +97,17 @@ export function generateQuayLineFrontTextKey(
 }
 
 /**
+ * Directions (frontTexts) a line runs in, or a single `undefined` placeholder
+ * when no directions are known — so callers can still generate one
+ * quay-line(-frontText) key for the line.
+ */
+export function frontTextsOrDefault(
+    frontTexts: string[] | undefined,
+): (string | undefined)[] {
+    return frontTexts?.length ? frontTexts : [undefined]
+}
+
+/**
  *
  * @param quays The quays with all lines and frontTexts
  * @param selectedQuayLineKeys The currently selected quay-line(-frontText) pairs, in the
@@ -124,10 +135,7 @@ export function deriveLinesWithDirection(
             for (const frontText of frontTexts) known.add(frontText)
             knownFrontTexts.set(line.id, known)
 
-            const frontTextsOrFallback = frontTexts.length
-                ? frontTexts
-                : [undefined]
-            for (const frontText of frontTextsOrFallback) {
+            for (const frontText of frontTextsOrDefault(line.frontTexts)) {
                 const key = generateQuayLineFrontTextKey(
                     quay.id,
                     line.id,
@@ -174,10 +182,7 @@ export function getInitialCheckedLineIds(
         if (savedQuay) {
             if (savedQuay.whitelistedLines.length === 0) {
                 for (const l of quay.lines) {
-                    const frontTexts = l.frontTexts?.length
-                        ? l.frontTexts
-                        : [undefined]
-                    for (const frontText of frontTexts) {
+                    for (const frontText of frontTextsOrDefault(l.frontTexts)) {
                         set.add(
                             generateQuayLineFrontTextKey(
                                 quay.id,
@@ -190,10 +195,9 @@ export function getInitialCheckedLineIds(
             } else {
                 for (const lineId of savedQuay.whitelistedLines) {
                     const line = quay.lines.find((l) => l.id === lineId)
-                    const frontTexts = line?.frontTexts?.length
-                        ? line.frontTexts
-                        : [undefined]
-                    for (const frontText of frontTexts) {
+                    for (const frontText of frontTextsOrDefault(
+                        line?.frontTexts,
+                    )) {
                         set.add(
                             generateQuayLineFrontTextKey(
                                 quay.id,
@@ -209,10 +213,7 @@ export function getInitialCheckedLineIds(
         } else if (tile.whitelistedLines && tile.whitelistedLines.length > 0) {
             for (const l of quay.lines) {
                 if (tile.whitelistedLines?.includes(l.id)) {
-                    const frontTexts = l.frontTexts?.length
-                        ? l.frontTexts
-                        : [undefined]
-                    for (const frontText of frontTexts) {
+                    for (const frontText of frontTextsOrDefault(l.frontTexts)) {
                         set.add(
                             generateQuayLineFrontTextKey(
                                 quay.id,
@@ -225,10 +226,7 @@ export function getInitialCheckedLineIds(
             }
         } else {
             for (const l of quay.lines) {
-                const frontTexts = l.frontTexts?.length
-                    ? l.frontTexts
-                    : [undefined]
-                for (const frontText of frontTexts) {
+                for (const frontText of frontTextsOrDefault(l.frontTexts)) {
                     set.add(
                         generateQuayLineFrontTextKey(quay.id, l.id, frontText),
                     )

--- a/tavla/next-env.d.ts
+++ b/tavla/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-e2e/dev/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tavla/next-env.d.ts
+++ b/tavla/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
### 🥅 Bakgrunn

Tidligere grupperte vi de linjene som går fra samme plattform med avganger som har samme linje-id. På noen stoppesteder så går begge retninger for en linje på samme plattform, og dermed er det ikke mulig å kun vise disse linjene i en retning.

Tidligere kollapset også et kort dersom ingen av rutene var valgt, det er nå endret til å alltid være likt, uavhengig av hva som har blitt valgt.

### ✨ Løsning

- Ved å utnytte det at FrontTexts er tilgjengelig, kommer det nå opp en linje + checkbox per (quay + linje + fronttext)
- Logikk for toggling av quay og transport-mode fulgte det også en del endringer i logikk
- Endringer i type for frontTexts slik at dette aldri er null/undefined, men heller en tom liste, for å unngå unødvendig mye kode for å sjekke om frontTexts har verdi

Logikken for lagring til firestore er uendret, da denne allerede hadde støtte for å sette retning med frontTexts

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="1391" height="487" alt="image" src="https://github.com/user-attachments/assets/34483e7e-678f-4d73-8877-73b9b4a348c7" /> | <img width="1382" height="583" alt="image" src="https://github.com/user-attachments/assets/e26d8eb0-37d8-4568-bcda-a5c281b0f795" /> |
| <img width="687" height="84" alt="image" src="https://github.com/user-attachments/assets/a191a886-930f-45a0-8d95-fd78db105c12" /> | <img width="687" height="223" alt="image" src="https://github.com/user-attachments/assets/1631e62c-ecaf-4e8e-a683-78681ae492ac" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>

Legg til et stoppested som har ulike avganger med samme linje fra samme quay, eks. Asker stasjon. Legg til og se at alle quays og linjer er merket fra start. Deretter endre markeringer og se at det blir korrekt resultat i tavla-visningen.

Test både med linje, platform, og transport mode.


