### PR TITLE
💄 Bruke logo fra Entur Linje i Navbar og Footer

### DIFF
--- a/tavla/app/_components/Footer.tsx
+++ b/tavla/app/_components/Footer.tsx
@@ -1,10 +1,9 @@
 'use client'
 import { GithubIcon } from '@entur/icons'
+import { Logo } from '@entur/menu'
 import { Link as EnturLink, Heading3, Paragraph } from '@entur/typography'
 import DeleteAccount from 'app/(innlogget)/components/DeleteAccount/DeleteAccount'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
-import TavlaLogo from 'assets/logos/Tavla-white.svg'
-import Image from 'next/image'
 import Link from 'next/link'
 import { showUC_UI as showUserCentricsUI } from './ConsentHandler'
 
@@ -13,7 +12,7 @@ function Footer({ loggedIn }: { loggedIn: boolean }) {
     return (
         <footer className="eds-contrast">
             <div className="container pb-20 pt-16">
-                <Image src={TavlaLogo} alt="Entur Tavla logo" />
+                <Logo productName="Tavla" size="small" alt="Entur Tavla logo" />
                 <div className="flex flex-col justify-between sm:flex-row">
                     <div className="not-italic">
                         <Heading3 as="h2">Entur AS</Heading3>

--- a/tavla/app/_components/Navbar.tsx
+++ b/tavla/app/_components/Navbar.tsx
@@ -13,9 +13,19 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
     return (
         <nav className="container flex flex-row items-center justify-between gap-3 py-8">
             <Logo
+                href="/"
+                alt="Gå tilbake til forsiden"
+                className="flex md:hidden"
+                size="small"
+                onClick={() =>
+                    capture('go_to_home_page', { location: 'nav_bar' })
+                }
+            />
+            <Logo
                 productName="Tavla"
                 href="/"
                 alt="Gå tilbake til forsiden"
+                className="hidden md:flex"
                 onClick={() =>
                     capture('go_to_home_page', { location: 'nav_bar' })
                 }

--- a/tavla/app/_components/Navbar.tsx
+++ b/tavla/app/_components/Navbar.tsx
@@ -1,9 +1,7 @@
 'use client'
-import { TopNavigationItem } from '@entur/menu'
+import { Logo, TopNavigationItem } from '@entur/menu'
 import { Login } from 'app/(innlogget)/components/Login/Login'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
-import TavlaLogoBlue from 'assets/logos/Tavla-blue.svg'
-import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MobileNavbar } from './MobileNavbar'
@@ -14,18 +12,15 @@ function Navbar({ loggedIn }: { loggedIn: boolean }) {
 
     return (
         <nav className="container flex flex-row items-center justify-between gap-3 py-8">
-            <Link
+            <Logo
+                productName="Tavla"
                 href="/"
+                alt="Gå tilbake til forsiden"
                 onClick={() =>
                     capture('go_to_home_page', { location: 'nav_bar' })
                 }
-            >
-                <Image
-                    src={TavlaLogoBlue}
-                    height={32}
-                    alt="Gå tilbake til forsiden"
-                />
-            </Link>
+            />
+
             <div className="flex shrink-0 flex-row items-center gap-4">
                 <div className="flex flex-row sm:gap-10">
                     {loggedIn ? (


### PR DESCRIPTION
### 🥅 Bakgrunn
Logoer i Navbar og Topbar har tidligere vært egne svg-filer i repoet, men det finnes nå en Logo-komponent i Entur Linje.

### ✨ Løsning

Byttet ut logoen i Topbar og Footer til å bruke Logo-komponenten fra Entur Linje. Footer-logoen er satt til size="small" som er litt større den den som var der før.

### 📸 Bilder

**Før i Topbar:**
<img width="1180" height="155" alt="image" src="https://github.com/user-attachments/assets/3656ab8e-1480-4e8f-b76e-69df73630663" />

**Før i Footer:**
<img width="1180" height="293" alt="image" src="https://github.com/user-attachments/assets/83d60710-bd95-4355-9322-528ac9f09270" />

**Etter i Topbar:**
<img width="1089" height="132" alt="image" src="https://github.com/user-attachments/assets/cddd8c33-a1c8-4547-9416-0b5d542e113e" />

**Etter i Footer:**
<img width="1089" height="298" alt="image" src="https://github.com/user-attachments/assets/3388b7b5-f1af-48c0-9a72-74bc2da4c2a0" />

**Før i mobil:**
<img width="435" height="166" alt="image" src="https://github.com/user-attachments/assets/096a80e2-a9cd-4b98-a42d-44250bb3d556" />

**Etter i mobil:**
<img width="435" height="166" alt="image" src="https://github.com/user-attachments/assets/cc5084e5-a06b-48b1-a294-9e1ff41a781b" />


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Lagt på aktuell posthog-tracking
- [x] Husket og testet UU
- [x] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
