### PR TITLE
🐛 Fjerne localhost logging til posthog

### DIFF
--- a/tavla/README.md
+++ b/tavla/README.md
@@ -46,8 +46,10 @@ Når du skal opprette en bruker lokalt får du ikke en epost om å verifisere e-
 
 ### Miljøvariabler (lokalt minimum)
 
-Lag `.env.local`og kopier innnholdet fra teamets passord-manager.
-Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
+- Lag `.env.local`og kopier innnholdet fra teamets passord-manager.[(https://entur.1password.eu/)](https://entur.1password.eu/)
+    - Finn Team-Tavla
+    - Kopier over innholdet fra `.env.local`
+- Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
 
 ### Vanlige kommandoer
 

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -54,6 +54,8 @@ const basePostHogOptions: Partial<PostHogConfig> = {
             return null
         }
         if (hostname === 'tavla.dev.entur.no') {
+            // biome-ignore lint/suspicious/noConsole: Intentional logging for testing in environment
+            console.log('PostHog event (blokkert, tavla.dev.entur.no):', event)
             return null
         }
         return event

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -47,7 +47,13 @@ const basePostHogOptions: Partial<PostHogConfig> = {
     before_send: (event) => {
         if (typeof window === 'undefined') return event
         const hostname = window.location.hostname
-        if (hostname === 'localhost' || hostname === '127.0.0.1') {
+        const isLocal = hostname === 'localhost' || hostname === '127.0.0.1'
+        if (isLocal) {
+            // biome-ignore lint/suspicious/noConsole: Intentional logging for local development
+            console.log('PostHog event (blokkert, localhost):', event)
+            return null
+        }
+        if (hostname === 'tavla.dev.entur.no') {
             return null
         }
         return event

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -44,6 +44,14 @@ const basePostHogOptions: Partial<PostHogConfig> = {
     capture_pageview: false,
     autocapture: false,
     opt_out_capturing_by_default: true,
+    before_send: (event) => {
+        if (typeof window === 'undefined') return event
+        const hostname = window.location.hostname
+        if (hostname === 'localhost' || hostname === '127.0.0.1') {
+            return null
+        }
+        return event
+    },
     // debug: true, // Used to test if PostHog turns on only with consent
 }
 

--- a/tavla/app/posthog/usePosthogTracking.ts
+++ b/tavla/app/posthog/usePosthogTracking.ts
@@ -23,14 +23,7 @@ export function usePosthogTracking() {
                 return
             }
 
-            const isLocalDevelopment =
-                window !== undefined && window.location.hostname === 'localhost'
             const properties = args[0] ?? undefined
-
-            if (isLocalDevelopment) {
-                // biome-ignore lint/suspicious/noConsole: Intentional logging for local development
-                console.log('PostHog event:', event, properties)
-            }
 
             if (posthog.has_opted_in_capturing()) {
                 posthog.capture(event, properties)


### PR DESCRIPTION
### 🥅 Bakgrunn

Det har per nå vært slik at handlinger utført lokalt i utvikling har blitt fanget opp og sendt til posthog på lik linje som produksjon. Dette fører til uheldige tall i posthog som ikke nødvendigvis reflekterer faktisk bruk av brukere.

### ✨ Løsning

- Alle posthog-logger sjekkes for tilhørende hostname før en logg eventuelt sendes. 
- Når denne er localhost eller 127.0.0.1 logges det i console og det sendes ikke til posthog
- Når denne er tilhørende tavla.dev.entur.no logges det ikke og sendes ikke til posthog. 
    - Tror ikke disse har blitt sendt per nå, men så at det lå noen historiske logger fra dev i posthog, så for å unngå dette i fremtiden la jeg også dette til. 

### 📸 Bilder

Ingen endringer i GUI

### ✅ Sjekkliste

- [ ] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
