### PR TITLE
🐛 Fjerner localhost logging fra posthog

### DIFF
--- a/tavla/README.md
+++ b/tavla/README.md
@@ -46,8 +46,10 @@ Når du skal opprette en bruker lokalt får du ikke en epost om å verifisere e-
 
 ### Miljøvariabler (lokalt minimum)
 
-Lag `.env.local`og kopier innnholdet fra teamets passord-manager.
-Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
+- Lag `.env.local`og kopier innnholdet fra teamets passord-manager.[(https://entur.1password.eu/)](https://entur.1password.eu/)
+    - Finn Team-Tavla
+    - Kopier over innholdet fra `.env.local`
+- Sentry- og PostHog-variabler er valgfrie og trengs ikke for lokal kjøring.
 
 ### Vanlige kommandoer
 

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -54,6 +54,8 @@ const basePostHogOptions: Partial<PostHogConfig> = {
             return null
         }
         if (hostname === 'tavla.dev.entur.no') {
+            // biome-ignore lint/suspicious/noConsole: Intentional logging for testing in environment
+            console.log('PostHog event (blokkert, tavla.dev.entur.no):', event)
             return null
         }
         return event

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -53,9 +53,6 @@ const basePostHogOptions: Partial<PostHogConfig> = {
             console.log('PostHog event (blokkert, localhost):', event)
             return null
         }
-        if (hostname === 'tavla.dev.entur.no') {
-            return null
-        }
         return event
     },
     // debug: true, // Used to test if PostHog turns on only with consent

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -47,7 +47,13 @@ const basePostHogOptions: Partial<PostHogConfig> = {
     before_send: (event) => {
         if (typeof window === 'undefined') return event
         const hostname = window.location.hostname
-        if (hostname === 'localhost' || hostname === '127.0.0.1') {
+        const isLocal = hostname === 'localhost' || hostname === '127.0.0.1'
+        if (isLocal) {
+            // biome-ignore lint/suspicious/noConsole: Intentional logging for local development
+            console.log('PostHog event (blokkert, localhost):', event)
+            return null
+        }
+        if (hostname === 'tavla.dev.entur.no') {
             return null
         }
         return event

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -54,8 +54,6 @@ const basePostHogOptions: Partial<PostHogConfig> = {
             return null
         }
         if (hostname === 'tavla.dev.entur.no') {
-            // biome-ignore lint/suspicious/noConsole: Intentional logging for testing in environment
-            console.log('PostHog event (blokkert, tavla.dev.entur.no):', event)
             return null
         }
         return event

--- a/tavla/app/_components/ConsentHandler.tsx
+++ b/tavla/app/_components/ConsentHandler.tsx
@@ -44,6 +44,14 @@ const basePostHogOptions: Partial<PostHogConfig> = {
     capture_pageview: false,
     autocapture: false,
     opt_out_capturing_by_default: true,
+    before_send: (event) => {
+        if (typeof window === 'undefined') return event
+        const hostname = window.location.hostname
+        if (hostname === 'localhost' || hostname === '127.0.0.1') {
+            return null
+        }
+        return event
+    },
     // debug: true, // Used to test if PostHog turns on only with consent
 }
 

--- a/tavla/app/posthog/usePosthogTracking.ts
+++ b/tavla/app/posthog/usePosthogTracking.ts
@@ -23,14 +23,7 @@ export function usePosthogTracking() {
                 return
             }
 
-            const isLocalDevelopment =
-                window !== undefined && window.location.hostname === 'localhost'
             const properties = args[0] ?? undefined
-
-            if (isLocalDevelopment) {
-                // biome-ignore lint/suspicious/noConsole: Intentional logging for local development
-                console.log('PostHog event:', event, properties)
-            }
 
             if (posthog.has_opted_in_capturing()) {
                 posthog.capture(event, properties)

--- a/tavla/next-env.d.ts
+++ b/tavla/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-e2e/dev/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tavla/next-env.d.ts
+++ b/tavla/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
### 🥅 Bakgrunn

Det har per nå vært slik at handlinger utført lokalt i utvikling har blitt fanget opp og sendt til posthog på lik linje som produksjon. Dette fører til uheldige tall i posthog som ikke nødvendigvis reflekterer faktisk bruk av brukere.

### ✨ Løsning

Fant ut at feilen ikke var at localhost:3001 ikke ble fjernet, men at det samme også gjaldt for localhost:3000. Feilen lå heller i at dersom man ikke har lagt inn `NEXT_PUBLIC_POSTHOG_TOKEN` ville uansett ikke kallene bli sendt til posthog. 

- Alle posthog-events sjekkes i `before_send` opp mot tilhørende hostname før en logg eventuelt sendes. 
- Når denne er localhost eller 127.0.0.1 logges det i console og det sendes ikke til posthog

### 📸 Bilder

Se at loggen i console er markert som blokkert

**Etter i lokalt**
<img width="1624" height="987" alt="image" src="https://github.com/user-attachments/assets/9b01399b-c1af-45c4-9c1e-b51fe571a117" />

**Etter i posthog**
https://eu.posthog.com/project/2663/activity/explore#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person_display_name%20--%20Person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%5D%2C%22orderBy%22%3A%5B%22timestamp%5Cn%20DESC%22%5D%2C%22after%22%3A%22-24h%22%2C%22properties%22%3A%5B%5D%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%2C%22showPropertyFilter%22%3Atrue%7D

<img width="3552" height="1522" alt="image" src="https://github.com/user-attachments/assets/259727c5-f977-4710-9aa6-0125e2f027b2" />


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [ ] Lagt på aktuell posthog-tracking (ikke aktuell)
- [ ] Husket og testet UU (ikke aktuell)
- [ ] Oppdatert dokumentasjon (hvis relevant) 


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
