### PR TITLE
🔒 Fjern immutable- og protobufjs-pinnene som blokkerer sikkerhetsfikser

### DIFF
--- a/tavla/package.json
+++ b/tavla/package.json
@@ -98,8 +98,6 @@
     "resolutions": {
         "basic-ftp": "5.3.1",
         "minimatch": "9.0.7",
-        "immutable": "3.8.3",
-        "protobufjs": "7.6.3",
         "dompurify": "3.4.13"
     }
 }

--- a/tavla/yarn.lock
+++ b/tavla/yarn.lock
@@ -4030,13 +4030,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/inquire@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@protobufjs/inquire@npm:1.1.2"
-  checksum: 10/259756489c75a751552df60d18f82503d2534855646397b96b91cf15807fa852e99bd9eb73dabb64da37aec7913844032ecb031a4326d82aae622f5e4c2f8a17
-  languageName: node
-  linkType: hard
-
 "@protobufjs/path@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/path@npm:1.1.2"
@@ -8577,10 +8570,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.8.3":
-  version: 3.8.3
-  resolution: "immutable@npm:3.8.3"
-  checksum: 10/29db366d4dff83b0b296150c351b08db24837005909a71c123d860c1d2a40605f19a3ecd56d1e96be9799e947ddf7906897a28fa2e81f0b8c63c652b6bfe5550
+"immutable@npm:^5.1.5":
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10/dc61ea6f79897320a048f193dec703dff25ad7bb633c3a0294677d2f258764c88da06e7c2b53d1aa51b6657c98d9f1c7341f49735b9b802fe6e834122cf78dcd
   languageName: node
   linkType: hard
 
@@ -11290,9 +11283,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.6.3":
-  version: 7.6.3
-  resolution: "protobufjs@npm:7.6.3"
+"protobufjs@npm:^7.2.2, protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3, protobufjs@npm:^7.5.4":
+  version: 7.6.6
+  resolution: "protobufjs@npm:7.6.6"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -11300,13 +11293,12 @@ __metadata:
     "@protobufjs/eventemitter": "npm:^1.1.1"
     "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.2"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.3.2"
-  checksum: 10/80c05985e8d7b9657bc7c2e72dea3b20be96209d6f4a550f7849dd9ed73adb3f698b9d876e3a6329828051572e4af253f9b53f56e09fbc009651a26338e5da8b
+  checksum: 10/a894f38c793a0d741f77a7fbf8595141618e8c1cb3433637d2d0309ea9baca59bd9c44ec95f46ee839d063de5d5ae1bc78ef8d474359866af52ee4ceef7fec4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🥅 Bakgrunn

Under ukens dependency-triage (uke 36): fire av sju pinner sto også i varsellista — to av dem her i `tavla`.

Begge lå i `resolutions` og hindret Dependabot i å oppdatere pakkene. Det er verdt å være presis på hvorfor det er lett å overse: symptomet ser ikke ut som et symptom. Dependabot lager rett og slett *ingen* PR, fordi pinnen overstyrer den, og varselet blir bare liggende. Resultatet var tre varsler som ikke kunne lukkes, alle over 30-dagersfristen:

| Varsel | Pakke | Pinnet | Fiks krever | Alder |
| --- | --- | --- | --- | --- |
| [#507](https://github.com/entur/tavla/security/dependabot/507) (CVE-2026-59879) | immutable | 3.8.3 | 4.3.9 | 41 dager |
| [#508](https://github.com/entur/tavla/security/dependabot/508) (CVE-2026-59880) | immutable | 3.8.3 | 4.3.9 | 41 dager |
| [#493](https://github.com/entur/tavla/security/dependabot/493) (CVE-2026-59877) | protobufjs | 7.6.3 | 7.6.5 | 42 dager |

`immutable` ble pinnet i #2330 (mars), `protobufjs` i #2433 (mai) og hevet i #2514 (juli). At `protobufjs`-pinnen allerede har måttet heves én gang, og så forfalt igjen etter to måneder, er selve mønsteret denne PR-en prøver å bryte.

### ✨ Løsning

- Fjernet `immutable` og `protobufjs` fra `resolutions` i `tavla/package.json`
- Oppdatert `yarn.lock` — begge resolverer nå til **én** trygg kopi hver:
  - **immutable 5.1.9** — eneste konsument er `@ardatan/relay-compiler@13.0.0`, som selv deklarerer `^5.1.5`. Pinnen tvang den altså til 3.8.3, en versjon den ikke sier den støtter. At det har fungert var flaks, ikke design.
  - **protobufjs 7.6.6** — seks konsumentranges (`^7.2.2`, `^7.2.5`, `^7.3.2`, `^7.4.0`, `^7.5.3`, `^7.5.4`) konvergerer til én oppføring.

**Hvorfor fjerne og ikke heve?** Å heve pinnen til en ny eksakt versjon fikser varselet, men lar mekanismen stå — og da forfaller den igjen ved neste CVE, slik `protobufjs` allerede har gjort. Fjerning gir Dependabot ansvaret tilbake permanent. Beslutningsrekkefølgen er `fjern → eksakt + audit`, og begge kom ut 🟢 KAN FJERNES i vurderingen.

**Reell risiko var lav i begge tilfeller** — `relay-compiler` kjører bare under `yarn generate` på våre egne `.graphql`-filer, og `protobufjs` parser bibliotekets egne `.proto`-filer under `@google-cloud/pubsub` (ingen app-kode importerer pubsub direkte). Men lav risiko er grunnen til at fjerningen er trygg å gjennomføre, ikke grunn til å la varslene ligge over fristen.

De tre gjenværende pinnene (`basic-ftp`, `minimatch`, `dompurify`) har ingen åpne varsler og er urørt.

### 🔍 Verifisert

- `yarn install --immutable` ✅ (lockfilen er konsistent)
- `yarn typecheck` ✅
- `yarn test` ✅ 19/19
- `biome check app src` ✅ 221 filer, ingen funn
- Én kopi av hver pakke i lockfilen, begge utenfor alle sårbare intervall


### ✅ Sjekkliste

- [ ] Testet i Chrome
