### PR TITLE
✨ Endre tekststørrelse på Tavla

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardSidebar.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardSidebar.tsx
@@ -2,6 +2,7 @@
 import { Heading4 } from '@entur/typography'
 import type { BoardDB } from 'types/db-types/boards'
 import { AddStopPlaceTile } from './AddStopPlace/AddStopPlaceTile'
+import { EditFontSize } from './EditFontSize/EditFontSize'
 import { EditInfoMessage } from './EditInfoMessage/EditInfoMessage'
 import { EditTheme } from './EditTheme/EditTheme'
 import { EditViewType } from './EditViewType/EditViewType'
@@ -21,6 +22,10 @@ export function EditBoardSidebar({ board }: { board: BoardDB }) {
                     hasCombinedTiles={board.isCombinedTiles}
                 />
                 <EditTheme bid={board.id} theme={board.theme ?? 'dark'} />
+                <EditFontSize
+                    bid={board.id}
+                    fontSize={board.meta.fontSize ?? 'medium'}
+                />
             </EditSection>
 
             <EditSection title="Hva vil du vise på tavla?">

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditFontSize/EditFontSize.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditFontSize/EditFontSize.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { FeedbackText } from '@entur/form'
+import { ChoiceChipGroupGeneral } from 'app/_components/TableSettings/ChoiceChipGroupGeneral'
+import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
+import { startTransition, useActionState } from 'react'
+import { type FontSizeState, saveFontSize } from './actions'
+import type { FontSizeValue } from './validation'
+
+function EditFontSize({
+    bid,
+    fontSize,
+}: {
+    bid: string
+    fontSize: FontSizeValue
+}) {
+    const { capture } = usePosthogTracking()
+
+    async function handleSave(_prevState: FontSizeState, value: FontSizeValue) {
+        const result = await saveFontSize(bid, value)
+
+        if (result?.status === 'success') {
+            capture('board_settings_changed', {
+                location: 'edit_board_page',
+                setting: 'font',
+                value: value,
+            })
+        }
+
+        return result
+    }
+
+    const [state, action] = useActionState(handleSave, null)
+
+    const error = state?.status === 'error' ? state.message : undefined
+
+    function handleChange(value: FontSizeValue) {
+        startTransition(() => {
+            action(value)
+        })
+    }
+
+    return (
+        <>
+            <ChoiceChipGroupGeneral<FontSizeValue>
+                label="Tekststørrelse"
+                options={[
+                    { value: 'small', label: 'Liten' },
+                    { value: 'medium', label: 'Medium' },
+                    { value: 'large', label: 'Stor' },
+                ]}
+                defaultValue={fontSize}
+                name="font"
+                ariaLabel="Tekststørrelse"
+                onChange={handleChange}
+            />
+            {error && <FeedbackText variant="negative">{error}</FeedbackText>}
+        </>
+    )
+}
+
+export { EditFontSize }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditFontSize/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditFontSize/actions.ts
@@ -1,0 +1,50 @@
+'use server'
+import * as Sentry from '@sentry/nextjs'
+import {
+    initializeAdminApp,
+    userCanEditBoard,
+} from 'app/(innlogget)/utils/firebase'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { updateBoard } from 'src/firebase'
+import { logToGcp } from 'utils/logging'
+import { type FontSizeValue, fontSizeSchema } from './validation'
+
+initializeAdminApp()
+
+export type FontSizeState =
+    | { status: 'success' }
+    | { status: 'error'; message: string }
+    | null
+
+export async function saveFontSize(
+    bid: string,
+    value: FontSizeValue,
+): Promise<FontSizeState> {
+    if (!(await userCanEditBoard(bid))) redirect('/')
+    logToGcp('info', 'action:saveFontSize invoked', { bid })
+
+    const parsed = fontSizeSchema.safeParse(value)
+    if (!parsed.success)
+        return {
+            status: 'error',
+            message:
+                parsed.error.issues[0]?.message ?? 'Ugyldig tekststørrelse',
+        }
+
+    try {
+        await updateBoard(bid, { 'meta.fontSize': parsed.data })
+    } catch (error) {
+        logToGcp(
+            'error',
+            `Failed to save fontSize: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
+        )
+        Sentry.captureException(error, { extra: { boardID: bid } })
+        return { status: 'error', message: 'Noe gikk galt. Prøv igjen.' }
+    }
+
+    revalidatePath(`/tavler/${bid}/rediger-beta`)
+
+    return { status: 'success' }
+}

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditFontSize/validation.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditFontSize/validation.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod'
+
+export const fontSizeSchema = z.enum(['small', 'medium', 'large'])
+export type FontSizeValue = z.infer<typeof fontSizeSchema>


### PR DESCRIPTION
### 🥅 Bakgrunn

>Som en admin
>Ønsker jeg å kunne endre tekststørrelse på Tavla 
>Slik at jeg kan tilpasse tavlen til omgivelsene den står i 

### ✨ Løsning

- la til chips for de tre mulige skriftstørrelsene

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="650" height="369" alt="image" src="https://github.com/user-attachments/assets/8b9c25b0-93e4-402c-97d9-98bbdea49926" /> | <img width="403" height="369" alt="image" src="https://github.com/user-attachments/assets/5803a492-2b7d-4180-ad8f-ef937e8d5951" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Lagt på aktuell posthog-tracking
- [x] Husket og testet UU
- [x] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
