### PR TITLE
✨ Kunne velge språk på Tavla

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/ChoiceChipPicker.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/ChoiceChipPicker.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { ChoiceChip, ChoiceChipGroup } from '@entur/chip'
-import { Heading4, Label, Paragraph } from '@entur/typography'
+import { Paragraph } from '@entur/typography'
 import { useState } from 'react'
 
 type ChoiceChipProps<T> = {

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/ChoiceChipPicker.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/ChoiceChipPicker.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { ChoiceChip, ChoiceChipGroup } from '@entur/chip'
+import { Heading4, Label, Paragraph } from '@entur/typography'
+import { useState } from 'react'
+
+type ChoiceChipProps<T> = {
+    label: string
+    options: { value: T; label: string }[]
+    defaultValue: T
+    name: string
+    ariaLabel: string
+    onChange: (value: T) => void
+}
+
+export function ChoiceChipPicker<T extends string>({
+    label,
+    options,
+    defaultValue,
+    name,
+    ariaLabel,
+    onChange,
+}: ChoiceChipProps<T>) {
+    const [selectedValue, setSelectedValue] = useState<T>(defaultValue)
+
+    const handleChange = (value: T) => {
+        setSelectedValue(value)
+        onChange(value)
+    }
+
+    return (
+        <div className="flex flex-col gap-1">
+            <Paragraph className="mb-2">{label}</Paragraph>
+            <ChoiceChipGroup
+                className="mb-2 h-full"
+                name={name}
+                value={selectedValue}
+                onChange={(e) => handleChange(e.target.value as T)}
+                aria-label={ariaLabel}
+            >
+                {options.map((option) => (
+                    <ChoiceChip key={option.value} value={option.value}>
+                        {option.label}
+                    </ChoiceChip>
+                ))}
+            </ChoiceChipGroup>
+        </div>
+    )
+}

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardSidebar.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardSidebar.tsx
@@ -3,6 +3,7 @@ import { Heading4 } from '@entur/typography'
 import type { BoardDB } from 'types/db-types/boards'
 import { AddStopPlaceTile } from './AddStopPlace/AddStopPlaceTile'
 import { EditInfoMessage } from './EditInfoMessage/EditInfoMessage'
+import { EditLanguage } from './EditLanguage/EditLanguage'
 import { EditTheme } from './EditTheme/EditTheme'
 import { EditViewType } from './EditViewType/EditViewType'
 import { TileList } from './TileList/TileList'
@@ -25,6 +26,10 @@ export function EditBoardSidebar({ board }: { board: BoardDB }) {
 
             <EditSection title="Hva vil du vise på tavla?">
                 <EditInfoMessage bid={board.id} infoMessage={board.footer} />
+                <EditLanguage
+                    bid={board.id}
+                    language={board.language ?? 'nb'}
+                />
             </EditSection>
         </div>
     )

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/EditLanguage.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/EditLanguage.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { FeedbackText } from '@entur/form'
-import { ChoiceChipGroupGeneral } from 'app/_components/TableSettings/ChoiceChipGroupGeneral'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import { startTransition, useActionState } from 'react'
 import { ChoiceChipPicker } from '../ChoiceChipPicker'

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/EditLanguage.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/EditLanguage.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { FeedbackText } from '@entur/form'
+import { ChoiceChipGroupGeneral } from 'app/_components/TableSettings/ChoiceChipGroupGeneral'
+import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
+import { startTransition, useActionState } from 'react'
+import { ChoiceChipPicker } from '../ChoiceChipPicker'
+import { type LanguageState, saveLanguage } from './actions'
+import type { LanguageValue } from './validation'
+
+function EditLanguage({
+    bid,
+    language,
+}: {
+    bid: string
+    language: LanguageValue
+}) {
+    const { capture } = usePosthogTracking()
+
+    async function handleSave(_prevState: LanguageState, value: LanguageValue) {
+        const result = await saveLanguage(bid, value)
+
+        if (result?.status === 'success') {
+            capture('board_settings_changed', {
+                location: 'edit_board_page',
+                setting: 'language',
+                value: value,
+            })
+        }
+
+        return result
+    }
+
+    const [state, action] = useActionState(handleSave, null)
+
+    const error = state?.status === 'error' ? state.message : undefined
+
+    function handleChange(value: LanguageValue) {
+        startTransition(() => {
+            action(value)
+        })
+    }
+
+    return (
+        <>
+            <ChoiceChipPicker<LanguageValue>
+                label="Velg språk"
+                options={[
+                    { value: 'nb', label: 'Norsk' },
+                    { value: 'en', label: 'Engelsk' },
+                ]}
+                defaultValue={language}
+                name="language"
+                ariaLabel="Språk"
+                onChange={handleChange}
+            />
+            {error && <FeedbackText variant="negative">{error}</FeedbackText>}
+        </>
+    )
+}
+
+export { EditLanguage }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/actions.ts
@@ -1,0 +1,49 @@
+'use server'
+import * as Sentry from '@sentry/nextjs'
+import {
+    initializeAdminApp,
+    userCanEditBoard,
+} from 'app/(innlogget)/utils/firebase'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { updateBoard } from 'src/firebase'
+import { logToGcp } from 'utils/logging'
+import { type LanguageValue, languageSchema } from './validation'
+
+initializeAdminApp()
+
+export type LanguageState =
+    | { status: 'success' }
+    | { status: 'error'; message: string }
+    | null
+
+export async function saveLanguage(
+    bid: string,
+    value: LanguageValue,
+): Promise<LanguageState> {
+    if (!(await userCanEditBoard(bid))) redirect('/')
+    logToGcp('info', 'action:saveLanguage invoked', { bid })
+
+    const parsed = languageSchema.safeParse(value)
+    if (!parsed.success)
+        return {
+            status: 'error',
+            message: parsed.error.issues[0]?.message ?? 'Ugyldig språk',
+        }
+
+    try {
+        await updateBoard(bid, { language: parsed.data })
+    } catch (error) {
+        logToGcp(
+            'error',
+            `Failed to save language: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
+        )
+        Sentry.captureException(error, { extra: { boardID: bid } })
+        return { status: 'error', message: 'Noe gikk galt. Prøv igjen.' }
+    }
+
+    revalidatePath(`/tavler/${bid}/rediger-beta`)
+
+    return { status: 'success' }
+}

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/validation.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditLanguage/validation.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod'
+
+export const languageSchema = z.enum(['nb', 'en'])
+export type LanguageValue = z.infer<typeof languageSchema>


### PR DESCRIPTION
### 🥅 Bakgrunn
> Som en admin
Ønsker jeg å kunne velge mellom norsk og engelsk på Tavla
Slik at ikke norsktalende reisene forstår hva som står på tavla

### ✨ Løsning

- Opprettet funksjonalitet for å endre språk på betasiden med gjeldene praksiser for koden
- Lagt til ChoiceChipPicker som en ny versjon av ChoiceChipGroupGeneral med styling i stil med beta-siden, 

### 📸 Bilder

| Før   | Etter |
| ----- | -----|
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/5e6bcb08-33a1-4e22-b842-52dc3fed7231" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/4eba9cb0-0197-4464-b334-2ca5873641a6" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Lagt på aktuell posthog-tracking
- [ ] Husket og testet UU
- [ ] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
