### PR TITLE
✨ Velge farger på transportmidlene på Tavla

### DIFF
--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardBeta.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardBeta.tsx
@@ -12,10 +12,7 @@ export function EditBoardBeta({
     boardLink: string
 }) {
     return (
-        <div
-            data-transport-palette={board.transportPalette}
-            className="flex flex-col gap-12 lg:flex-row lg:items-start"
-        >
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-start">
             <section className="flex min-w-0 flex-1 flex-col gap-12 lg:sticky lg:top-[15vh] lg:self-start">
                 <div data-theme={board.theme ?? 'dark'}>
                     <Preview boardLink={boardLink} />

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardSidebar.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditBoardSidebar.tsx
@@ -6,6 +6,7 @@ import { EditFontSize } from './EditFontSize/EditFontSize'
 import { EditInfoMessage } from './EditInfoMessage/EditInfoMessage'
 import { EditLanguage } from './EditLanguage/EditLanguage'
 import { EditTheme } from './EditTheme/EditTheme'
+import { EditTransportPalette } from './EditTransportPalette/EditTransportPalette'
 import { EditViewType } from './EditViewType/EditViewType'
 import { TileList } from './TileList/TileList'
 import { WalkingDistanceForm } from './WalkingDistance/WalkingDistance'
@@ -28,6 +29,7 @@ export function EditBoardSidebar({ board }: { board: BoardDB }) {
                     bid={board.id}
                     fontSize={board.meta.fontSize ?? 'medium'}
                 />
+                <EditTransportPalette board={board} />
             </EditSection>
 
             <EditSection title="Hva vil du vise på tavla?">

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditElements/EditElements.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditElements/EditElements.tsx
@@ -4,7 +4,7 @@ import { FilterChip } from '@entur/chip'
 import { FeedbackText } from '@entur/form'
 import { Paragraph } from '@entur/typography'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
-import { startTransition, useActionState, useState } from 'react'
+import { startTransition, useActionState } from 'react'
 import { type ElementsState, saveElements } from './actions'
 import type { ElementsValue } from './validation'
 

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
@@ -3,11 +3,6 @@ import { FeedbackText, Radio, RadioGroup } from '@entur/form'
 import { Paragraph } from '@entur/typography'
 import { transportModeNames } from 'app/_components/TileCard/utils'
 import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
-import {
-    generateTransportPalettes,
-    getTransportColorDescription,
-    useAllowedPalettes,
-} from 'app/_utils/colorPalettes'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import {
     startTransition,
@@ -18,6 +13,11 @@ import {
 } from 'react'
 import type { BoardDB } from 'types/db-types/boards'
 import type { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
+import {
+    generateTransportPalettes,
+    getTransportColorDescription,
+    useAllowedPalettes,
+} from '../utils/colorPalette'
 import { saveTransportPalette, type TransportPaletteState } from './actions'
 import type { TransportPaletteValue } from './validation'
 
@@ -32,7 +32,6 @@ const transportModes: { mode: TTransportMode; submode?: TTransportSubmode }[] =
         { mode: 'water' },
     ]
 
-//trakk ut funksjon for å vise preview av fargene og ikonene
 function TransportPalettePreview({
     palette,
     theme,
@@ -93,8 +92,6 @@ function TransportPalettePreview({
         </div>
     )
 }
-
-//Dette følger samme designpattern som de andre nye komponentene, men må legge på litt ekstra
 
 function EditTransportPalette({ board }: { board: BoardDB }) {
     const { capture } = usePosthogTracking()
@@ -182,7 +179,3 @@ function EditTransportPalette({ board }: { board: BoardDB }) {
 }
 
 export { EditTransportPalette }
-
-//4. Lav prioritet / valgfritt: availablePalettes (linje 97) regnes ut på nytt ved hver rendering (ikke useMemo-et),
-// som gjør at useEffect-en på linje 103 kjører oftere enn strengt tatt nødvendig. Dette er arvet fra gamle TransportPaletteSelect.tsx
-// og ikke noe du har innført — grei å la stå, men nevner den i tilfelle du vil stramme den til.

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
@@ -1,8 +1,6 @@
 'use client'
 import { FeedbackText, Radio, RadioGroup } from '@entur/form'
 import { Paragraph } from '@entur/typography'
-import { transportModeNames } from 'app/_components/TileCard/utils'
-import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
 import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
 import {
     startTransition,
@@ -12,86 +10,13 @@ import {
     useState,
 } from 'react'
 import type { BoardDB } from 'types/db-types/boards'
-import type { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
 import {
     generateTransportPalettes,
-    getTransportColorDescription,
     useAllowedPalettes,
 } from '../utils/colorPalette'
 import { saveTransportPalette, type TransportPaletteState } from './actions'
+import { TransportPalettePreview } from './TransportPalettePreview'
 import type { TransportPaletteValue } from './validation'
-
-const busAndTrainModes: TTransportMode[] = ['bus', 'coach', 'rail']
-
-const transportModes: { mode: TTransportMode; submode?: TTransportSubmode }[] =
-    [
-        { mode: 'air' },
-        { mode: 'metro' },
-        { mode: 'tram' },
-        { mode: 'water', submode: 'internationalCarFerry' },
-        { mode: 'water' },
-    ]
-
-function TransportPalettePreview({
-    palette,
-    theme,
-    iconClassName,
-}: {
-    palette: { value: TransportPaletteValue; label: string }
-    theme: BoardDB['theme']
-    iconClassName: string
-}) {
-    return (
-        <div
-            className="flex max-w-max flex-col rounded-md bg-secondary px-3 py-3"
-            data-theme={theme ?? 'dark'}
-            data-transport-palette={palette.value}
-        >
-            <div className="grid grid-cols-8 gap-1.5">
-                {busAndTrainModes.map((mode) => {
-                    const colorDescription = getTransportColorDescription(
-                        palette.value,
-                        mode,
-                    )
-                    return (
-                        <div
-                            className="max-w-min"
-                            key={mode}
-                            aria-label={`${transportModeNames(mode)}${colorDescription ? `, ${colorDescription}` : ''}`}
-                            role="img"
-                        >
-                            <TransportIcon
-                                transportMode={mode}
-                                background
-                                className={iconClassName}
-                            />
-                        </div>
-                    )
-                })}
-                {transportModes.map((mode) => {
-                    const colorDescription = getTransportColorDescription(
-                        palette.value,
-                        mode.mode,
-                    )
-                    return (
-                        <div
-                            key={mode.submode ?? mode.mode}
-                            role="img"
-                            aria-label={`${transportModeNames(mode.mode)}${colorDescription ? `, ${colorDescription}` : ''}`}
-                        >
-                            <TransportIcon
-                                transportMode={mode.mode}
-                                transportSubmode={mode.submode}
-                                background
-                                className={iconClassName}
-                            />
-                        </div>
-                    )
-                })}
-            </div>
-        </div>
-    )
-}
 
 function EditTransportPalette({ board }: { board: BoardDB }) {
     const { capture } = usePosthogTracking()

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
@@ -1,0 +1,188 @@
+'use client'
+import { FeedbackText, Radio, RadioGroup } from '@entur/form'
+import { Paragraph } from '@entur/typography'
+import { transportModeNames } from 'app/_components/TileCard/utils'
+import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
+import {
+    generateTransportPalettes,
+    getTransportColorDescription,
+    useAllowedPalettes,
+} from 'app/_utils/colorPalettes'
+import { usePosthogTracking } from 'app/posthog/usePosthogTracking'
+import {
+    startTransition,
+    useActionState,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react'
+import type { BoardDB } from 'types/db-types/boards'
+import type { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
+import { saveTransportPalette, type TransportPaletteState } from './actions'
+import type { TransportPaletteValue } from './validation'
+
+const busAndTrainModes: TTransportMode[] = ['bus', 'coach', 'rail']
+
+const transportModes: { mode: TTransportMode; submode?: TTransportSubmode }[] =
+    [
+        { mode: 'air' },
+        { mode: 'metro' },
+        { mode: 'tram' },
+        { mode: 'water', submode: 'internationalCarFerry' },
+        { mode: 'water' },
+    ]
+
+//trakk ut funksjon for å vise preview av fargene og ikonene
+function TransportPalettePreview({
+    palette,
+    theme,
+    iconClassName,
+}: {
+    palette: { value: TransportPaletteValue; label: string }
+    theme: BoardDB['theme']
+    iconClassName: string
+}) {
+    return (
+        <div
+            className="flex max-w-max flex-col rounded-md bg-secondary px-3 py-3"
+            data-theme={theme ?? 'dark'}
+            data-transport-palette={palette.value}
+        >
+            <div className="grid grid-cols-8 gap-1.5">
+                {busAndTrainModes.map((mode) => {
+                    const colorDescription = getTransportColorDescription(
+                        palette.value,
+                        mode,
+                    )
+                    return (
+                        <div
+                            className="max-w-min"
+                            key={mode}
+                            aria-label={`${transportModeNames(mode)}${colorDescription ? `, ${colorDescription}` : ''}`}
+                            role="img"
+                        >
+                            <TransportIcon
+                                transportMode={mode}
+                                background
+                                className={iconClassName}
+                            />
+                        </div>
+                    )
+                })}
+                {transportModes.map((mode) => {
+                    const colorDescription = getTransportColorDescription(
+                        palette.value,
+                        mode.mode,
+                    )
+                    return (
+                        <div
+                            key={mode.submode ?? mode.mode}
+                            role="img"
+                            aria-label={`${transportModeNames(mode.mode)}${colorDescription ? `, ${colorDescription}` : ''}`}
+                        >
+                            <TransportIcon
+                                transportMode={mode.mode}
+                                transportSubmode={mode.submode}
+                                background
+                                className={iconClassName}
+                            />
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+//Dette følger samme designpattern som de andre nye komponentene, men må legge på litt ekstra
+
+function EditTransportPalette({ board }: { board: BoardDB }) {
+    const { capture } = usePosthogTracking()
+
+    const allowedPalettes = useAllowedPalettes(board)
+    const availablePalettes = useMemo(
+        () => generateTransportPalettes(allowedPalettes),
+        [allowedPalettes],
+    )
+
+    const [selectedValue, setSelectedValue] = useState<TransportPaletteValue>(
+        board.transportPalette ?? 'default',
+    )
+
+    useEffect(() => {
+        const availableValues = availablePalettes.map((p) => p.value)
+        if (!availableValues.includes(selectedValue)) {
+            setSelectedValue('default')
+        }
+    }, [availablePalettes, selectedValue])
+
+    async function handleSave(
+        _prevState: TransportPaletteState,
+        value: TransportPaletteValue,
+    ) {
+        const result = await saveTransportPalette(board.id, value)
+
+        if (result?.status === 'success') {
+            capture('board_settings_changed', {
+                location: 'edit_board_page',
+                setting: 'transport_palette',
+                value: value,
+            })
+        }
+
+        return result
+    }
+
+    const [state, action] = useActionState(handleSave, null)
+
+    const error = state?.status === 'error' ? state.message : undefined
+
+    function handleChange(value: TransportPaletteValue) {
+        setSelectedValue(value)
+        startTransition(() => {
+            action(value)
+        })
+    }
+
+    const theme = board.theme ?? 'dark'
+    const iconClassName = theme === 'dark' ? 'text-black' : 'text-white'
+
+    return (
+        <div>
+            <Paragraph className="mb-2" id="transport-palette-heading">
+                Farger på transportmidler
+            </Paragraph>
+            <div className="flex flex-col gap-4">
+                <RadioGroup
+                    name="transportPalette"
+                    value={selectedValue}
+                    aria-labelledby="transport-palette-heading"
+                    onChange={(e) =>
+                        handleChange(e.target.value as TransportPaletteValue)
+                    }
+                >
+                    {availablePalettes.map((palette) => (
+                        <div
+                            key={palette.value}
+                            className="flex items-center justify-between"
+                        >
+                            <Radio value={palette.value}>{palette.label}</Radio>
+                            <TransportPalettePreview
+                                palette={palette}
+                                theme={theme}
+                                iconClassName={iconClassName}
+                            />
+                        </div>
+                    ))}
+                </RadioGroup>
+            </div>
+            {error && <FeedbackText variant="negative">{error}</FeedbackText>}
+        </div>
+    )
+}
+
+export { EditTransportPalette }
+
+//4. Lav prioritet / valgfritt: availablePalettes (linje 97) regnes ut på nytt ved hver rendering (ikke useMemo-et),
+// som gjør at useEffect-en på linje 103 kjører oftere enn strengt tatt nødvendig. Dette er arvet fra gamle TransportPaletteSelect.tsx
+// og ikke noe du har innført — grei å la stå, men nevner den i tilfelle du vil stramme den til.

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
@@ -106,16 +106,6 @@ function EditTransportPalette({ board }: { board: BoardDB }) {
         board.transportPalette ?? 'default',
     )
 
-    useEffect(() => {
-        const availableValues = availablePalettes.map((p) => p.value)
-        if (!availableValues.includes(selectedValue)) {
-            setSelectedValue('default')
-            startTransition(() => {
-                action('default')
-            })
-        }
-    }, [availablePalettes, selectedValue, action])
-
     async function handleSave(
         _prevState: TransportPaletteState,
         value: TransportPaletteValue,
@@ -136,6 +126,16 @@ function EditTransportPalette({ board }: { board: BoardDB }) {
     const [state, action] = useActionState(handleSave, null)
 
     const error = state?.status === 'error' ? state.message : undefined
+
+    useEffect(() => {
+        const availableValues = availablePalettes.map((p) => p.value)
+        if (!availableValues.includes(selectedValue)) {
+            setSelectedValue('default')
+            startTransition(() => {
+                action('default')
+            })
+        }
+    }, [availablePalettes, selectedValue, action])
 
     function handleChange(value: TransportPaletteValue) {
         setSelectedValue(value)

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/EditTransportPalette.tsx
@@ -110,8 +110,11 @@ function EditTransportPalette({ board }: { board: BoardDB }) {
         const availableValues = availablePalettes.map((p) => p.value)
         if (!availableValues.includes(selectedValue)) {
             setSelectedValue('default')
+            startTransition(() => {
+                action('default')
+            })
         }
-    }, [availablePalettes, selectedValue])
+    }, [availablePalettes, selectedValue, action])
 
     async function handleSave(
         _prevState: TransportPaletteState,

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/TransportPalettePreview.tsx
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/TransportPalettePreview.tsx
@@ -1,0 +1,80 @@
+import { transportModeNames } from 'app/_components/TileCard/utils'
+import TransportIcon from 'app/_components/TransportIcon/TransportIcon'
+import type { BoardDB } from 'types/db-types/boards'
+import type { TTransportMode, TTransportSubmode } from 'types/graphql-schema'
+import { getTransportColorDescription } from '../utils/colorPalette'
+import type { TransportPaletteValue } from './validation'
+
+const busAndTrainModes: TTransportMode[] = ['bus', 'coach', 'rail']
+
+const transportModes: { mode: TTransportMode; submode?: TTransportSubmode }[] =
+    [
+        { mode: 'air' },
+        { mode: 'metro' },
+        { mode: 'tram' },
+        { mode: 'water', submode: 'internationalCarFerry' },
+        { mode: 'water' },
+    ]
+
+function TransportPalettePreview({
+    palette,
+    theme,
+    iconClassName,
+}: {
+    palette: { value: TransportPaletteValue; label: string }
+    theme: BoardDB['theme']
+    iconClassName: string
+}) {
+    return (
+        <div
+            className="flex max-w-max flex-col rounded-md bg-secondary px-3 py-3"
+            data-theme={theme ?? 'dark'}
+            data-transport-palette={palette.value}
+        >
+            <div className="grid grid-cols-8 gap-1.5">
+                {busAndTrainModes.map((mode) => {
+                    const colorDescription = getTransportColorDescription(
+                        palette.value,
+                        mode,
+                    )
+                    return (
+                        <div
+                            className="max-w-min"
+                            key={mode}
+                            aria-label={`${transportModeNames(mode)}${colorDescription ? `, ${colorDescription}` : ''}`}
+                            role="img"
+                        >
+                            <TransportIcon
+                                transportMode={mode}
+                                background
+                                className={iconClassName}
+                            />
+                        </div>
+                    )
+                })}
+                {transportModes.map((mode) => {
+                    const colorDescription = getTransportColorDescription(
+                        palette.value,
+                        mode.mode,
+                    )
+                    return (
+                        <div
+                            key={mode.submode ?? mode.mode}
+                            role="img"
+                            aria-label={`${transportModeNames(mode.mode)}${colorDescription ? `, ${colorDescription}` : ''}`}
+                        >
+                            <TransportIcon
+                                transportMode={mode.mode}
+                                transportSubmode={mode.submode}
+                                background
+                                className={iconClassName}
+                            />
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+export { TransportPalettePreview }

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/actions.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/actions.ts
@@ -1,0 +1,54 @@
+'use server'
+import * as Sentry from '@sentry/nextjs'
+import {
+    initializeAdminApp,
+    userCanEditBoard,
+} from 'app/(innlogget)/utils/firebase'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { updateBoard } from 'src/firebase'
+import { logToGcp } from 'utils/logging'
+import {
+    type TransportPaletteValue,
+    transportPaletteSchema,
+} from './validation'
+
+initializeAdminApp()
+
+export type TransportPaletteState =
+    | { status: 'success' }
+    | { status: 'error'; message: string }
+    | null
+
+export async function saveTransportPalette(
+    bid: string,
+    value: TransportPaletteValue,
+): Promise<TransportPaletteState> {
+    if (!(await userCanEditBoard(bid))) redirect('/')
+    logToGcp('info', 'action:saveTransportPalette invoked', { bid })
+
+    const parsed = transportPaletteSchema.safeParse(value)
+    if (!parsed.success)
+        return {
+            status: 'error',
+            message:
+                parsed.error.issues[0]?.message ??
+                'Ugyldig farge på transportmiddel',
+        }
+
+    try {
+        await updateBoard(bid, { transportPalette: parsed.data })
+    } catch (error) {
+        logToGcp(
+            'error',
+            `Failed to save transport palette: ${error instanceof Error ? error.message : String(error)}`,
+            { bid },
+        )
+        Sentry.captureException(error, { extra: { boardID: bid } })
+        return { status: 'error', message: 'Noe gikk galt. Prøv igjen.' }
+    }
+
+    revalidatePath(`/tavler/${bid}/rediger-beta`)
+
+    return { status: 'success' }
+}

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/validation.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/EditTransportPalette/validation.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const transportPaletteSchema = z.enum([
+    'default',
+    'blue-bus',
+    'green-bus',
+    'atb',
+    'fram',
+    'reis',
+])
+
+export type TransportPaletteValue = z.infer<typeof transportPaletteSchema>

--- a/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/utils/colorPalette.ts
+++ b/tavla/app/(innlogget)/tavler/[id]/rediger-beta/components/utils/colorPalette.ts
@@ -1,0 +1,163 @@
+import { useMemo } from 'react'
+import type { BoardDB, TransportPalette } from 'src/types/db-types/boards'
+
+const baseTransportPalettes: { label: string; value: TransportPalette }[] = [
+    { label: 'Nasjonal', value: 'default' },
+    { label: 'Lokal', value: 'atb' },
+    { label: 'Lokal', value: 'fram' },
+    { label: 'Lokal', value: 'reis' },
+    { label: 'Blå buss', value: 'blue-bus' },
+    { label: 'Grønn buss', value: 'green-bus' },
+]
+
+export const COUNTY_THEME_MAP = {
+    Trøndelag: 'atb' as const,
+    'Møre og Romsdal': 'fram' as const,
+    Nordland: 'reis' as const,
+} as const
+
+export type CountyThemeKey = keyof typeof COUNTY_THEME_MAP
+export type CountyThemeValue = (typeof COUNTY_THEME_MAP)[CountyThemeKey]
+
+export const useAllowedPalettes = (board: BoardDB) =>
+    useMemo(() => {
+        const counties = new Set<string>()
+
+        board.tiles.forEach((tile) => {
+            if (tile.county) {
+                counties.add(tile.county)
+            }
+        })
+
+        const hasCountyThemes = Array.from(counties).some(
+            (county) =>
+                COUNTY_THEME_MAP[county as keyof typeof COUNTY_THEME_MAP],
+        )
+
+        const themes = new Set<TransportPalette>(['default'])
+        if (hasCountyThemes) {
+            counties.forEach((county) => {
+                const theme =
+                    COUNTY_THEME_MAP[county as keyof typeof COUNTY_THEME_MAP]
+                if (theme) {
+                    themes.add(theme as TransportPalette)
+                }
+            })
+        }
+        themes.add('blue-bus')
+        themes.add('green-bus')
+
+        return Array.from(themes)
+    }, [board.tiles])
+
+const PALETTE_TO_COUNTY = Object.fromEntries(
+    Object.entries(COUNTY_THEME_MAP).map(([county, palette]) => [
+        palette,
+        county,
+    ]),
+) as Record<string, string>
+
+export const generateTransportPalettes = (
+    allowedPalettes: TransportPalette[],
+): { label: string; value: TransportPalette }[] => {
+    const filteredPalettes = allowedPalettes
+        ? baseTransportPalettes.filter(
+              (palette) =>
+                  palette.value === 'default' ||
+                  allowedPalettes.includes(palette.value as TransportPalette),
+          )
+        : baseTransportPalettes
+
+    const localPalettes = filteredPalettes.filter(
+        (palette) => PALETTE_TO_COUNTY[palette.value] !== undefined,
+    )
+
+    if (localPalettes.length > 1) {
+        return filteredPalettes.map((palette) => {
+            const county = PALETTE_TO_COUNTY[palette.value]
+            return county ? { ...palette, label: `Lokal (${county})` } : palette
+        })
+    }
+
+    return filteredPalettes
+}
+
+export const PALETTE_COLOR_DESCRIPTIONS: Record<
+    string,
+    Record<string, string>
+> = {
+    default: {
+        bus: 'rød',
+        rail: 'blå',
+        water: 'lyseblå',
+        air: 'mørk lilla',
+        metro: 'oransje',
+        taxi: 'mørk grå',
+        tram: 'lys lilla',
+        coach: 'grønn',
+        cableway: 'grå',
+        funicular: 'grå',
+    },
+    'blue-bus': {
+        bus: 'blå',
+        rail: 'rød',
+    },
+    'green-bus': {
+        bus: 'grønn',
+    },
+    atb: {
+        bus: 'grønn',
+        tram: 'grønn',
+        rail: 'mørk rosa',
+        metro: 'lilla',
+        water: 'mørk sjøgrønn',
+        air: 'grå',
+        taxi: 'lilla',
+        coach: 'blå',
+    },
+    fram: {
+        bus: 'mørk blå',
+        coach: 'grønn',
+        rail: 'mørk rød',
+        water: 'lys blå',
+        air: 'grå',
+        metro: 'grå',
+        tram: 'grå',
+        taxi: 'lys rosa',
+    },
+    svipper: {
+        bus: 'blå',
+        coach: 'grønn',
+        rail: 'rosa',
+        water: 'turkis',
+        air: 'mørk grå',
+    },
+    reis: {
+        bus: 'mørk blå',
+        tram: 'mørk blå',
+        rail: 'lilla',
+        metro: 'lilla',
+        water: 'lys blå',
+        air: 'sjøgrønn',
+        taxi: 'grå',
+        coach: 'grønn',
+    },
+}
+
+export const getTransportColorDescription = (
+    palette: string,
+    mode: string,
+): string => {
+    const paletteColors = PALETTE_COLOR_DESCRIPTIONS[palette]
+    const defaultColors = PALETTE_COLOR_DESCRIPTIONS.default
+
+    if (paletteColors?.[mode]) {
+        return paletteColors[mode]
+    }
+
+    if (defaultColors?.[mode]) {
+        return defaultColors[mode]
+    }
+
+    return ''
+}


### PR DESCRIPTION
### 🥅 Bakgrunn

> Som en admin
> Ønsker jeg å kunne endre fargene på transportmidlene på tavla
> Slik at Tavla bedre matcher brandingen i det valgte fylket

### ✨ Løsning

- la til radiobuttons for å velge fargepalett. Omtrent samme kode som i TransportPaletteSelect, men har delt det opp i to funksjoner.
- la til utils/colorPalette i component-mappen til beta da den skal bruks av flere komponenter enn kun EditTransportPalette.
- EditTransportPalette importerer fortsatt filer fra prod-redigersiden (transportModeNames og TransportIcon), men lar det være for nå.

### 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="511" height="301" alt="image" src="https://github.com/user-attachments/assets/8e794827-e36d-4468-b3d2-1eadaa4f8fa1" /> | <img width="511" height="345" alt="image" src="https://github.com/user-attachments/assets/8fc56e27-9511-46dc-9fca-8380b29118b1" /> |


### ✅ Sjekkliste

- [x] Testet i Chrome, Firefox og Safari
- [x] Lagt på aktuell posthog-tracking
- [x] Husket og testet UU
- [x] Oppdatert dokumentasjon (hvis relevant)


### 🧩 Testing
<fyll inn dersom det forventes testing fra reviewer>
